### PR TITLE
added support for querydsl's like construct as a regexp

### DIFF
--- a/src/main/java/org/neo4j/cypherdsl/querydsl/CypherQueryDSL.java
+++ b/src/main/java/org/neo4j/cypherdsl/querydsl/CypherQueryDSL.java
@@ -155,6 +155,10 @@ public class CypherQueryDSL
                 {
                     return isNotNull( (Expression) arg( operation.getArg( 0 ) ) );
                 }
+                else if ( id.equals( Ops.LIKE.getId() ) )
+                {
+                    return arg( operation.getArg( 0 ) ).regexp( arg( operation.getArg( 1 ) ) );
+                }
                 else
                 {
                     throw new IllegalArgumentException( "Unknown operator:" + id + " in expression " + operation );

--- a/src/test/java/org/neo4j/cypherdsl/querydsl/QueryDSLTest.java
+++ b/src/test/java/org/neo4j/cypherdsl/querydsl/QueryDSLTest.java
@@ -135,6 +135,15 @@ public class QueryDSLTest
                             .returns( identifier( n ) )
                             .toString() );
         }
+
+        {
+            QPerson n = new QPerson( "n" );
+            Assert.assertEquals( CYPHER + "START n=node(1,2,3) WHERE n.firstName=~\"(?i).*rick.*\" RETURN n",
+                    start( nodesById( identifier( n ), 1, 2, 3 ) )
+                            .where( toBooleanExpression( n.firstName.like( "(?i).*rick.*" )))
+                            .returns( identifier( n ) )
+                            .toString() );
+        }
     }
 
     @Test


### PR DESCRIPTION
We want to use query dsl in building queries without fixing ourselves to the eventual backend. In our case the current backend is translating these into cypher dsl queries. For our generic queries we use 'like' a lot, but there was no support for that in cypher dsl, so I added it to be translated into a regexp.
