### PR TITLE
Labels with spaces or special characters should be escaped with backticks

### DIFF
--- a/src/main/java/org/neo4j/cypherdsl/CypherQuery.java
+++ b/src/main/java/org/neo4j/cypherdsl/CypherQuery.java
@@ -192,7 +192,17 @@ public class CypherQuery
      */
     public static LabelValue label( String label )
     {
-        checkNull( label, "Label" );
+        return new LabelValue( identifier( label ) );
+    }
+
+    /**
+     * Declare a label.
+     *
+     * @param label literal value
+     * @return Label instance
+     */
+    public static LabelValue label( Identifier label )
+    {
         return new LabelValue( label );
     }
 

--- a/src/main/java/org/neo4j/cypherdsl/Path.java
+++ b/src/main/java/org/neo4j/cypherdsl/Path.java
@@ -71,6 +71,11 @@ public class Path
 
     public Path label( String label )
     {
+        return new Path( node, relationship, nodePropertyValues, new LabelValue( identifier(label) ) );
+    }
+
+    public Path label( Identifier label )
+    {
         return new Path( node, relationship, nodePropertyValues, new LabelValue( label ) );
     }
 

--- a/src/main/java/org/neo4j/cypherdsl/query/LabelValue.java
+++ b/src/main/java/org/neo4j/cypherdsl/query/LabelValue.java
@@ -19,21 +19,23 @@
  */
 package org.neo4j.cypherdsl.query;
 
+import org.neo4j.cypherdsl.Identifier;
+
 /**
  * Represents matching a label to a value
  */
 public class LabelValue extends AbstractExpression {
 
-	private final String label;
+	private final Identifier label;
 
-	public LabelValue(String label) {
+	public LabelValue( Identifier label ) {
 		this.label = label;
 	}
 
 	@Override
-	public void asString(StringBuilder builder) {
-		builder.append(":");
-		builder.append(label);
+	public void asString( StringBuilder builder ) {
+        builder.append( ":" );
+		label.asString( builder );
 	}
 
 }

--- a/src/test/java/org/neo4j/cypherdsl/CypherQueryTest2.java
+++ b/src/test/java/org/neo4j/cypherdsl/CypherQueryTest2.java
@@ -21,6 +21,10 @@ package org.neo4j.cypherdsl;
 
 import org.junit.Test;
 
+import static org.neo4j.cypherdsl.CypherQuery.identifier;
+import static org.neo4j.cypherdsl.CypherQuery.match;
+import static org.neo4j.cypherdsl.CypherQuery.node;
+
 /**
  * Tests for all parts of the Cypher DSL.
  */
@@ -77,6 +81,24 @@ public class CypherQueryTest2 extends AbstractCypherTest
                 {{
                         creates( node("n").labels( label("Person"), label("Swedish") ) );
                     }}.toString() );
+    }
+
+    @Test
+    public void testLabelWithSpaces()
+    {
+        assertQueryEquals( CYPHER + "MATCH (movie:`Movie With Spaces`) RETURN movie",
+                match( node( "movie" ).label( "Movie With Spaces" ) ).
+                        returns( identifier( "movie" ) ).
+                        toString() );
+    }
+
+    @Test
+    public void testLabelWithSpecialCharacters()
+    {
+        assertQueryEquals( CYPHER + "MATCH (movie:`Movie\"#'?!`) RETURN movie",
+                match( node( "movie" ).label( "Movie\"#'?!" ) ).
+                        returns( identifier( "movie" ) ).
+                        toString() );
     }
 
 }


### PR DESCRIPTION
Adding for labels behavior that already exists for identifiers, and relationship types.
