### PR TITLE
fix bug for support for standard Ops.EXIST to translate to cypher has function

### DIFF
--- a/src/main/java/org/neo4j/cypherdsl/CypherQuery.java
+++ b/src/main/java/org/neo4j/cypherdsl/CypherQuery.java
@@ -435,6 +435,20 @@ public class CypherQuery
     /**
      * Corresponds to:
      * <pre>
+     * has(expression)
+     * </pre>
+     *
+     * @param expression
+     * @return
+     */
+    public static BooleanExpression has( Expression expression )
+    {
+        return new Value( new FunctionExpression( "has", expression ) );
+    }
+
+    /**
+     * Corresponds to:
+     * <pre>
      * expression is null
      * </pre>
      *

--- a/src/main/java/org/neo4j/cypherdsl/querydsl/CypherQueryDSL.java
+++ b/src/main/java/org/neo4j/cypherdsl/querydsl/CypherQueryDSL.java
@@ -145,7 +145,7 @@ public class CypherQueryDSL
                 }
                 else if ( id.equals( Ops.EXISTS.getId() ) )
                 {
-                    return has( (Property) arg( operation.getArg( 0 ) ) );
+                    return has( (Expression) arg( operation.getArg( 0 ) ) );
                 }
                 else if ( id.equals( Ops.IS_NULL.getId() ) )
                 {

--- a/src/test/java/org/neo4j/cypherdsl/querydsl/QueryDSLTest.java
+++ b/src/test/java/org/neo4j/cypherdsl/querydsl/QueryDSLTest.java
@@ -43,6 +43,7 @@ import com.mysema.query.BooleanBuilder;
 import com.mysema.query.support.Expressions;
 import com.mysema.query.types.Ops;
 import com.mysema.query.types.Path;
+import com.mysema.query.types.expr.BooleanOperation;
 import com.mysema.query.types.expr.Param;
 import org.junit.Assert;
 import org.junit.Test;
@@ -143,6 +144,15 @@ public class QueryDSLTest
                             .where( toBooleanExpression( n.firstName.like( "(?i).*rick.*" )))
                             .returns( identifier( n ) )
                             .toString() );
+        }
+
+        {
+            QPerson n = new QPerson( "n" );
+            Assert.assertEquals(CYPHER + "START n=node(1,2,3) WHERE has(n.firstName) RETURN n",
+                    start(nodesById(identifier(n), 1, 2, 3))
+                            .where(toBooleanExpression(BooleanOperation.create(Ops.EXISTS, n.firstName)))
+                                    .returns(identifier(n))
+                                    .toString());
         }
     }
 


### PR DESCRIPTION
We use more generic mysema querydsl function, but EXISTS was broken.

krullert had already created a pull request for this, but now we have a unit test. 
