### PR TITLE
fix bug when lucene start queries have spaces

### DIFF
--- a/src/main/java/org/neo4j/cypherdsl/expression/StartExpression.java
+++ b/src/main/java/org/neo4j/cypherdsl/expression/StartExpression.java
@@ -119,7 +119,11 @@ public abstract class StartExpression
             name.asString( builder );
             builder.append( "=node:" );
             index.asString( builder );
-            builder.append( "(\"" ).append( query ).append( "\")" );
+            if (query.contains("\"")) {
+                builder.append( "('" ).append( query ).append( "')" );
+            } else {
+                builder.append( "(\"" ).append( query ).append( "\")" );
+            }
         }
     }
 

--- a/src/test/java/org/neo4j/cypherdsl/CypherQueryTest.java
+++ b/src/test/java/org/neo4j/cypherdsl/CypherQueryTest.java
@@ -70,6 +70,10 @@ public class CypherQueryTest extends AbstractCypherTest
         assertQueryEquals( CYPHER + "START john=node:nodes(\"name:John\") RETURN john", start( query( "john",
                 "nodes", "name:John" ) ).returns( identifier( "john" ) ).toString() );
 
+        // Start with query with spaces
+        assertQueryEquals( CYPHER + "START john=node:nodes('name:\"John doe\"') RETURN john", start( query( "john",
+                "nodes", "name:\"John doe\"" ) ).returns( identifier( "john" ) ).toString() );
+
         // Start with query-param
         assertEquals( CYPHER + "START john=node:nodes({param}) RETURN john", start( queryByParameter( "john",
                 "nodes", "param" ) ).returns( identifier( "john" ) ).toString() );


### PR DESCRIPTION
When you do a lucene query in a start expression and the query value contains a space, lucene needs to have double quotes. Single quotes wont work. Cypher can handle single quotes, so simply use single quotes in case someone puts a double quote in a lucene query.
