### PR TITLE
Upgrade to querydsl 4.0.x.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.neo4j</groupId>
   <artifactId>neo4j-cypher-dsl</artifactId>
-  <version>2.1.5-SNAPSHOT</version>
+  <version>2.2.0.ISSUE-49-SNAPSHOT</version>
   <name>Neo4j Cypher DSL</name>
   <description>Neo4j Cypher DSL</description>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,8 @@
 
   <properties>
     <neo4j.version>2.1.4</neo4j.version>
-    <querydsl.version>3.4.2</querydsl.version>
+    <querydsl.version>4.0.6</querydsl.version>
+    <querydsl-apt.version>1.1.3</querydsl-apt.version>
     <bundle.namespace>org.neo4j.cypherdsl</bundle.namespace>
     <short-name>cypher-dsl</short-name>
     <license-text.header>GPL-3-header.txt</license-text.header>
@@ -46,7 +47,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.mysema.querydsl</groupId>
+      <groupId>com.querydsl</groupId>
       <artifactId>querydsl-core</artifactId>
       <version>${querydsl.version}</version>
       <optional>true</optional>
@@ -58,7 +59,7 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>com.mysema.querydsl</groupId>
+      <groupId>com.querydsl</groupId>
       <artifactId>querydsl-lucene3</artifactId>
       <version>${querydsl.version}</version>
       <optional>true</optional>
@@ -70,7 +71,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.mysema.querydsl</groupId>
+      <groupId>com.querydsl</groupId>
       <artifactId>querydsl-apt</artifactId>
       <version>${querydsl.version}</version>
       <scope>provided</scope>
@@ -154,10 +155,17 @@
       </plugin>
       <plugin>
         <groupId>com.mysema.maven</groupId>
-        <artifactId>maven-apt-plugin</artifactId>
-        <version>1.0.2</version>
+		<artifactId>apt-maven-plugin</artifactId>
+        <version>${querydsl-apt.version}</version>
+        <dependencies>
+            <dependency>
+				<groupId>com.querydsl</groupId>
+				<artifactId>querydsl-apt</artifactId>
+				<version>${querydsl.version}</version>
+			</dependency>
+		</dependencies>
         <configuration>
-          <processor>com.mysema.query.apt.QuerydslAnnotationProcessor</processor>
+          <processor>com.querydsl.apt.QuerydslAnnotationProcessor</processor>
         </configuration>
         <executions>
           <execution>

--- a/src/main/java/org/neo4j/cypherdsl/querydsl/CypherQueryDSL.java
+++ b/src/main/java/org/neo4j/cypherdsl/querydsl/CypherQueryDSL.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2002-2013 "Neo Technology,"
+ * Copyright (c) 2002-2015 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.
@@ -21,17 +21,17 @@ package org.neo4j.cypherdsl.querydsl;
 
 import javax.annotation.Nullable;
 
-import com.mysema.query.lucene.LuceneSerializer;
-import com.mysema.query.types.Constant;
-import com.mysema.query.types.FactoryExpression;
-import com.mysema.query.types.Operation;
-import com.mysema.query.types.Ops;
-import com.mysema.query.types.ParamExpression;
-import com.mysema.query.types.Path;
-import com.mysema.query.types.Predicate;
-import com.mysema.query.types.SubQueryExpression;
-import com.mysema.query.types.TemplateExpression;
-import com.mysema.query.types.Visitor;
+import com.querydsl.lucene3.LuceneSerializer;
+import com.querydsl.core.types.Constant;
+import com.querydsl.core.types.FactoryExpression;
+import com.querydsl.core.types.Operation;
+import com.querydsl.core.types.Ops;
+import com.querydsl.core.types.ParamExpression;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.SubQueryExpression;
+import com.querydsl.core.types.TemplateExpression;
+import com.querydsl.core.types.Visitor;
 import org.neo4j.cypherdsl.CypherQuery;
 import org.neo4j.cypherdsl.Identifier;
 import org.neo4j.cypherdsl.Property;
@@ -104,58 +104,58 @@ public class CypherQueryDSL
                                             @Nullable BooleanExpression booleanExpression
             )
             {
-                String id = operation.getOperator().getId();
-                if ( id.equals( Ops.AND.getId() ) )
+                String id = operation.getOperator().name();
+                if ( id.equals( Ops.AND.name() ) )
                 {
                     return and( operation.getArg( 0 ).accept( this, null ), operation.getArg( 1 )
                             .accept( this, null ) );
                 }
-                else if ( id.equals( Ops.OR.getId() ) )
+                else if ( id.equals( Ops.OR.name() ) )
                 {
                     return or( operation.getArg( 0 ).accept( this, null ), operation.getArg( 1 )
                             .accept( this, null ) );
                 }
-                else if ( id.equals( Ops.NOT.getId() ) )
+                else if ( id.equals( Ops.NOT.name() ) )
                 {
                     return not( operation.getArg( 0 ).accept( this, null ) );
                 }
-                else if ( id.equals( Ops.EQ.getId() ) )
+                else if ( id.equals( Ops.EQ.name() ) )
                 {
                     return arg( operation.getArg( 0 ) ).eq( (StringExpression) arg( operation.getArg( 1 ) ) );
                 }
-                else if ( id.equals( Ops.NE.getId() ) )
+                else if ( id.equals( Ops.NE.name() ) )
                 {
                     return arg( operation.getArg( 0 ) ).ne( (StringExpression) arg( operation.getArg( 1 ) ) );
                 }
-                else if ( id.equals( Ops.GT.getId() ) )
+                else if ( id.equals( Ops.GT.name() ) )
                 {
                     return arg( operation.getArg( 0 ) ).gt( (StringExpression) arg( operation.getArg( 1 ) ) );
                 }
-                else if ( id.equals( Ops.LT.getId() ) )
+                else if ( id.equals( Ops.LT.name() ) )
                 {
                     return arg( operation.getArg( 0 ) ).lt( (StringExpression) arg( operation.getArg( 1 ) ) );
                 }
-                else if ( id.equals( Ops.GOE.getId() ) )
+                else if ( id.equals( Ops.GOE.name() ) )
                 {
                     return arg( operation.getArg( 0 ) ).gte( (StringExpression) arg( operation.getArg( 1 ) ) );
                 }
-                else if ( id.equals( Ops.LOE.getId() ) )
+                else if ( id.equals( Ops.LOE.name() ) )
                 {
                     return arg( operation.getArg( 0 ) ).lte( (StringExpression) arg( operation.getArg( 1 ) ) );
                 }
-                else if ( id.equals( Ops.EXISTS.getId() ) )
+                else if ( id.equals( Ops.EXISTS.name() ) )
                 {
                     return has( (Expression) arg( operation.getArg( 0 ) ) );
                 }
-                else if ( id.equals( Ops.IS_NULL.getId() ) )
+                else if ( id.equals( Ops.IS_NULL.name() ) )
                 {
                     return isNull( (Expression) arg( operation.getArg( 0 ) ) );
                 }
-                else if ( id.equals( Ops.IS_NOT_NULL.getId() ) )
+                else if ( id.equals( Ops.IS_NOT_NULL.name() ) )
                 {
                     return isNotNull( (Expression) arg( operation.getArg( 0 ) ) );
                 }
-                else if ( id.equals( Ops.LIKE.getId() ) )
+                else if ( id.equals( Ops.LIKE.name() ) )
                 {
                     return arg( operation.getArg( 0 ) ).regexp( arg( operation.getArg( 1 ) ) );
                 }
@@ -197,7 +197,7 @@ public class CypherQueryDSL
                 return null;
             }
 
-            public Value arg( com.mysema.query.types.Expression expression )
+            public Value arg( com.querydsl.core.types.Expression expression )
             {
                 if ( expression instanceof Constant )
                 {

--- a/src/main/java/org/neo4j/cypherdsl/querydsl/Projection.java
+++ b/src/main/java/org/neo4j/cypherdsl/querydsl/Projection.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2002-2013 "Neo Technology,"
+ * Copyright (c) 2002-2015 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.
@@ -24,11 +24,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import com.mysema.query.types.Expression;
-import com.mysema.query.types.Path;
-import com.mysema.query.types.Projections;
-import com.mysema.query.types.QBean;
-import com.mysema.query.types.path.PathBuilder;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.QBean; 
+import com.querydsl.core.types.dsl.PathBuilder;
 
 /**
  * Projection is responsible for converting the results of a query into an iterable of instances

--- a/src/test/java/org/neo4j/cypherdsl/querydsl/Person.java
+++ b/src/test/java/org/neo4j/cypherdsl/querydsl/Person.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2002-2013 "Neo Technology,"
+ * Copyright (c) 2002-2015 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypherdsl.querydsl;
 
-import com.mysema.query.annotations.QueryEntity;
+import com.querydsl.core.annotations.QueryEntity;
 
 /**
  * Person entity

--- a/src/test/java/org/neo4j/cypherdsl/querydsl/Place.java
+++ b/src/test/java/org/neo4j/cypherdsl/querydsl/Place.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2002-2013 "Neo Technology,"
+ * Copyright (c) 2002-2015 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypherdsl.querydsl;
 
-import com.mysema.query.annotations.QueryEntity;
+import com.querydsl.core.annotations.QueryEntity;
 
 /**
  * Place entity

--- a/src/test/java/org/neo4j/cypherdsl/querydsl/QueryDSLTest.java
+++ b/src/test/java/org/neo4j/cypherdsl/querydsl/QueryDSLTest.java
@@ -19,10 +19,10 @@
  */
 package org.neo4j.cypherdsl.querydsl;
 
-import static com.mysema.query.alias.Alias.$;
-import static com.mysema.query.alias.Alias.alias;
-import static com.mysema.query.support.Expressions.constant;
-import static com.mysema.query.support.Expressions.predicate;
+import static com.querydsl.core.alias.Alias.$;
+import static com.querydsl.core.alias.Alias.alias;
+import static com.querydsl.core.types.dsl.Expressions.constant;
+import static com.querydsl.core.types.dsl.Expressions.predicate;
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.cypherdsl.CypherQuery.nodesById;
 import static org.neo4j.cypherdsl.CypherReferenceTest.CYPHER;
@@ -39,12 +39,14 @@ import static org.neo4j.cypherdsl.querydsl.CypherQueryDSL.string;
 import static org.neo4j.cypherdsl.querydsl.CypherQueryDSL.toBooleanExpression;
 import static org.neo4j.cypherdsl.querydsl.CypherQueryDSL.toQuery;
 
-import com.mysema.query.BooleanBuilder;
-import com.mysema.query.support.Expressions;
-import com.mysema.query.types.Ops;
-import com.mysema.query.types.Path;
-import com.mysema.query.types.expr.BooleanOperation;
-import com.mysema.query.types.expr.Param;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.Ops;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.PredicateOperation;
+import com.querydsl.core.types.dsl.BooleanOperation;
+import com.querydsl.core.types.dsl.Param;
 import org.junit.Assert;
 import org.junit.Test;
 import org.neo4j.cypherdsl.Order;
@@ -89,8 +91,8 @@ public class QueryDSLTest
                             .where( toBooleanExpression( person.firstName.eq( "P" ).and( person.age.gt( 25 ) ) ) )
                             .returns( identifier( person ) )
                             .toString() );
+            
         }
-
         {
             QPerson person = QPerson.person;
             Assert.assertEquals( CYPHER + "START person=node:node_auto_index(\"firstName:rickard\") RETURN person" +
@@ -150,7 +152,7 @@ public class QueryDSLTest
             QPerson n = new QPerson( "n" );
             Assert.assertEquals(CYPHER + "START n=node(1,2,3) WHERE has(n.firstName) RETURN n",
                     start(nodesById(identifier(n), 1, 2, 3))
-                            .where(toBooleanExpression(BooleanOperation.create(Ops.EXISTS, n.firstName)))
+                    		.where(toBooleanExpression((PredicateOperation)ExpressionUtils.operation(Boolean.class,Ops.EXISTS, n.firstName)))
                                     .returns(identifier(n))
                                     .toString());
         }

--- a/src/test/java/org/neo4j/cypherdsl/querydsl/Stuff.java
+++ b/src/test/java/org/neo4j/cypherdsl/querydsl/Stuff.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypherdsl.querydsl;
 
-import com.mysema.query.annotations.QueryEntity;
+import com.querydsl.core.annotations.QueryEntity;
 
 /**
  * Stuff entity


### PR DESCRIPTION
Upgrade to querydsl 4.0.x.

Minor dependency upgrades to the querydsl infrastructure.
Upgraded querydsl.version to 4.0.6 to move away from the now 
unsupported mysema querydsl version.

Corrected imports and adapted internals to new com.querydsl API.

Fixes #49.
