### PR TITLE
Clean up a couple of Generic crime scenes.

### DIFF
--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Arguments.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Arguments.java
@@ -27,13 +27,12 @@ import org.neo4j.cypherdsl.core.support.Visitable;
 /**
  * Specialized list of expressions that represents the arguments of a procedure call.
  *
- * @param <S> The concrete type of this class.
  * @author Michael J. Simons
  * @soundtrack Apocalyptica - Cell-0
- * @since 2020.1.0
+ * @since 2020.0.1
  */
-@API(status = INTERNAL, since = "2020.1.0")
-public final class Arguments<S extends Arguments<S>> extends TypedSubtree<Expression, S> {
+@API(status = INTERNAL, since = "2020.0.1")
+public final class Arguments extends TypedSubtree<Expression, Arguments> {
 
 	Arguments(Expression... children) {
 		super(children);

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
@@ -318,7 +318,15 @@ public final class Cypher {
 			return new NumberLiteral((Number) object);
 		}
 		if (object instanceof Iterable) {
-			return new ListLiteral((Iterable<Literal<?>>) object);
+			for (Object element : ((Iterable<?>) object)) {
+				if (!(element instanceof Literal)) {
+					throw new IllegalArgumentException("Unsupported literal type in iterable: " + element.getClass());
+				}
+			}
+
+			@SuppressWarnings("unchecked") // See above
+			ListLiteral listLiteral = new ListLiteral((Iterable<Literal<?>>) object);
+			return listLiteral;
 		}
 		if (object instanceof Boolean) {
 			return BooleanLiteral.of((Boolean) object);

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
@@ -329,14 +329,14 @@ public final class Cypher {
 	/**
 	 * @return The {@literal true} literal.
 	 */
-	public static Literal literalTrue() {
+	public static Literal<Boolean> literalTrue() {
 		return BooleanLiteral.TRUE;
 	}
 
 	/**
 	 * @return The {@literal false} literal.
 	 */
-	public static Literal literalFalse() {
+	public static Literal<Boolean> literalFalse() {
 		return BooleanLiteral.FALSE;
 	}
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DefaultStatementBuilder.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DefaultStatementBuilder.java
@@ -30,6 +30,10 @@ import java.util.stream.Collectors;
 import org.neo4j.cypherdsl.core.ProcedureCall.OngoingInQueryCallWithArguments;
 import org.neo4j.cypherdsl.core.ProcedureCall.OngoingInQueryCallWithReturnFields;
 import org.neo4j.cypherdsl.core.ProcedureCall.OngoingInQueryCallWithoutArguments;
+import org.neo4j.cypherdsl.core.StatementBuilder.OngoingMatchAndUpdate;
+import org.neo4j.cypherdsl.core.StatementBuilder.OngoingReadingWithWhere;
+import org.neo4j.cypherdsl.core.StatementBuilder.OngoingReadingWithoutWhere;
+import org.neo4j.cypherdsl.core.StatementBuilder.OngoingUpdate;
 import org.neo4j.cypherdsl.core.support.Visitable;
 
 /**
@@ -38,12 +42,8 @@ import org.neo4j.cypherdsl.core.support.Visitable;
  * @author Romain Rossi
  * @since 1.0
  */
-class DefaultStatementBuilder
-	implements StatementBuilder,
-	StatementBuilder.OngoingReading,
-	StatementBuilder.OngoingUpdate,
-	StatementBuilder.OngoingReadingWithWhere,
-	StatementBuilder.OngoingReadingWithoutWhere, StatementBuilder.OngoingMatchAndUpdate {
+class DefaultStatementBuilder implements StatementBuilder,
+	OngoingUpdate, OngoingReadingWithWhere, OngoingReadingWithoutWhere, OngoingMatchAndUpdate {
 
 	/**
 	 * Current list of reading or update clauses to be generated.
@@ -109,12 +109,14 @@ class DefaultStatementBuilder
 	}
 
 	@Override
+	@SuppressWarnings("unchecked") // This method returns `this`, implementing `OngoingUpdate`
 	public OngoingUpdate create(PatternElement... pattern) {
 
 		return update(CREATE, pattern);
 	}
 
 	@Override
+	@SuppressWarnings("unchecked") // This method returns `this`, implementing `OngoingUpdate`
 	public OngoingUpdate merge(PatternElement... pattern) {
 
 		return update(MERGE, pattern);
@@ -131,7 +133,7 @@ class DefaultStatementBuilder
 		return new DefaultOngoingUnwind(expression);
 	}
 
-	private <T extends OngoingUpdate & OngoingMatchAndUpdate> T update(UpdateType updateType, Object[] pattern) {
+	private DefaultStatementBuilder update(UpdateType updateType, Object[] pattern) {
 
 		Assert.notNull(pattern, "Patterns to create are required.");
 		Assert.notEmpty(pattern, "At least one pattern to create is required.");
@@ -156,7 +158,7 @@ class DefaultStatementBuilder
 			this.currentOngoingUpdate = new DefaultStatementWithUpdateBuilder(updateType, (Expression[]) pattern);
 		}
 
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -202,18 +204,21 @@ class DefaultStatementBuilder
 	}
 
 	@Override
+	@SuppressWarnings("unchecked") // This method returns `this`, implementing `OngoingUpdate`
 	public OngoingUpdate delete(Expression... expressions) {
 
 		return update(DELETE, expressions);
 	}
 
 	@Override
+	@SuppressWarnings("unchecked") // This method returns `this`, implementing `OngoingUpdate`
 	public OngoingUpdate detachDelete(Expression... expressions) {
 
 		return update(DETACH_DELETE, expressions);
 	}
 
 	@Override
+	@SuppressWarnings("unchecked") // This method returns a `DefaultStatementWithUpdateBuilder`, implementing the necessary interfaces
 	public OngoingMatchAndUpdate set(Expression... expressions) {
 		if (this.currentOngoingUpdate != null) {
 			this.currentSinglePartElements.add(this.currentOngoingUpdate.buildUpdatingClause());
@@ -223,18 +228,21 @@ class DefaultStatementBuilder
 	}
 
 	@Override
+	@SuppressWarnings("unchecked") // This method returns a `DefaultStatementWithUpdateBuilder`, implementing the necessary interfaces
 	public OngoingMatchAndUpdate set(Node named, String... label) {
 
 		return new DefaultStatementWithUpdateBuilder(SET, Operations.set(named, label));
 	}
 
 	@Override
+	@SuppressWarnings("unchecked") // This method returns a `DefaultStatementWithUpdateBuilder`, implementing the necessary interfaces
 	public OngoingMatchAndUpdate remove(Property... properties) {
 
 		return new DefaultStatementWithUpdateBuilder(REMOVE, properties);
 	}
 
 	@Override
+	@SuppressWarnings("unchecked") // This method returns a `DefaultStatementWithUpdateBuilder`, implementing the necessary interfaces
 	public OngoingMatchAndUpdate remove(Node named, String... label) {
 
 		return new DefaultStatementWithUpdateBuilder(REMOVE, Operations.remove(named, label));
@@ -279,7 +287,7 @@ class DefaultStatementBuilder
 
 	protected final List<Visitable> buildListOfVisitables() {
 
-		List<Visitable> visitables = new ArrayList(this.currentSinglePartElements);
+		List<Visitable> visitables = new ArrayList<>(this.currentSinglePartElements);
 
 		if (this.currentOngoingMatch != null) {
 			visitables.add(this.currentOngoingMatch.buildMatch());
@@ -348,18 +356,21 @@ class DefaultStatementBuilder
 		}
 
 		@Override
-		public final OngoingReadingAndReturn descending() {
+		@SuppressWarnings("unchecked")
+		public final DefaultStatementWithReturnBuilder descending() {
 			orderBuilder.descending();
 			return this;
 		}
 
 		@Override
-		public final OngoingReadingAndReturn ascending() {
+		@SuppressWarnings("unchecked")
+		public final DefaultStatementWithReturnBuilder ascending() {
 			orderBuilder.ascending();
 			return this;
 		}
 
 		@Override
+		@SuppressWarnings("unchecked")
 		public final OngoingReadingAndReturn skip(Number number) {
 			orderBuilder.skip(number);
 			return this;
@@ -406,7 +417,7 @@ class DefaultStatementBuilder
 	 * Ongoing with extends from {@link WithBuilderSupport} and therefore from {@link DefaultStatementWithReturnBuilder}.
 	 */
 	protected final class DefaultStatementWithWithBuilder extends WithBuilderSupport
-		implements OngoingReadingAndWith, OngoingOrderDefinition, OrderableOngoingReadingAndWithWithoutWhere,
+		implements OngoingOrderDefinition, OrderableOngoingReadingAndWithWithoutWhere,
 		OrderableOngoingReadingAndWithWithWhere, OngoingReadingAndWithWithWhereAndOrder {
 
 		protected final ConditionBuilder conditionBuilder = new ConditionBuilder();
@@ -461,6 +472,7 @@ class DefaultStatementBuilder
 		}
 
 		@Override
+		@SuppressWarnings("unchecked")
 		public OngoingUpdate delete(Expression... expressions) {
 
 			return DefaultStatementBuilder.this
@@ -469,6 +481,7 @@ class DefaultStatementBuilder
 		}
 
 		@Override
+		@SuppressWarnings("unchecked")
 		public OngoingUpdate detachDelete(Expression... expressions) {
 
 			return DefaultStatementBuilder.this
@@ -477,6 +490,7 @@ class DefaultStatementBuilder
 		}
 
 		@Override
+		@SuppressWarnings("unchecked")
 		public OngoingMatchAndUpdate set(Expression... expressions) {
 
 			return DefaultStatementBuilder.this
@@ -485,6 +499,7 @@ class DefaultStatementBuilder
 		}
 
 		@Override
+		@SuppressWarnings("unchecked")
 		public OngoingMatchAndUpdate set(Node node, String... label) {
 
 			return DefaultStatementBuilder.this
@@ -493,6 +508,7 @@ class DefaultStatementBuilder
 		}
 
 		@Override
+		@SuppressWarnings("unchecked")
 		public OngoingMatchAndUpdate remove(Node node, String... label) {
 
 			return DefaultStatementBuilder.this
@@ -501,6 +517,7 @@ class DefaultStatementBuilder
 		}
 
 		@Override
+		@SuppressWarnings("unchecked")
 		public OngoingMatchAndUpdate remove(Property... properties) {
 
 			return DefaultStatementBuilder.this
@@ -562,6 +579,7 @@ class DefaultStatementBuilder
 		}
 
 		@Override
+		@SuppressWarnings("unchecked")
 		public OngoingUpdate create(PatternElement... pattern) {
 
 			return DefaultStatementBuilder.this
@@ -570,6 +588,7 @@ class DefaultStatementBuilder
 		}
 
 		@Override
+		@SuppressWarnings("unchecked")
 		public OngoingUpdate merge(PatternElement... pattern) {
 
 			return DefaultStatementBuilder.this
@@ -612,18 +631,21 @@ class DefaultStatementBuilder
 		}
 
 		@Override
+		@SuppressWarnings("unchecked")
 		public OrderableOngoingReadingAndWithWithWhere descending() {
 			orderBuilder.descending();
 			return this;
 		}
 
 		@Override
+		@SuppressWarnings("unchecked")
 		public OrderableOngoingReadingAndWithWithWhere ascending() {
 			orderBuilder.ascending();
 			return this;
 		}
 
 		@Override
+		@SuppressWarnings("unchecked")
 		public OrderableOngoingReadingAndWithWithWhere skip(Number number) {
 			orderBuilder.skip(number);
 			return this;
@@ -647,7 +669,7 @@ class DefaultStatementBuilder
 	private static final EnumSet<UpdateType> MERGE_OR_CREATE = EnumSet.of(CREATE, MERGE);
 
 	protected final class DefaultStatementWithUpdateBuilder extends DefaultStatementWithReturnBuilder
-		implements OngoingMatchAndUpdate, OngoingReadingAndReturn {
+		implements OngoingMatchAndUpdate {
 
 		private final List<? extends Visitable> expressions;
 		private final UpdateType updateType;
@@ -729,11 +751,13 @@ class DefaultStatementBuilder
 		}
 
 		@Override
+		@SuppressWarnings("unchecked")
 		public OngoingUpdate delete(Expression... deletedExpressions) {
 			return delete(false, deletedExpressions);
 		}
 
 		@Override
+		@SuppressWarnings("unchecked")
 		public OngoingUpdate detachDelete(Expression... deletedExpressions) {
 			return delete(true, deletedExpressions);
 		}
@@ -749,6 +773,7 @@ class DefaultStatementBuilder
 		}
 
 		@Override
+		@SuppressWarnings("unchecked")
 		public OngoingMatchAndUpdate set(Expression... keyValuePairs) {
 
 			DefaultStatementBuilder.this.addUpdatingClause(buildUpdatingClause());
@@ -756,6 +781,7 @@ class DefaultStatementBuilder
 		}
 
 		@Override
+		@SuppressWarnings("unchecked")
 		public OngoingMatchAndUpdate set(Node node, String... label) {
 
 			DefaultStatementBuilder.this.addUpdatingClause(buildUpdatingClause());
@@ -763,6 +789,7 @@ class DefaultStatementBuilder
 		}
 
 		@Override
+		@SuppressWarnings("unchecked")
 		public OngoingMatchAndUpdate remove(Node node, String... label) {
 
 			DefaultStatementBuilder.this.addUpdatingClause(buildUpdatingClause());
@@ -771,6 +798,7 @@ class DefaultStatementBuilder
 		}
 
 		@Override
+		@SuppressWarnings("unchecked")
 		public OngoingMatchAndUpdate remove(Property... properties) {
 
 			DefaultStatementBuilder.this.addUpdatingClause(buildUpdatingClause());
@@ -800,10 +828,12 @@ class DefaultStatementBuilder
 			return super.build();
 		}
 
+		@SuppressWarnings("incomplete-switch") // Both switch togehter with the IllegalArgumentException contains all values plus default.
 		private UpdatingClause buildUpdatingClause() {
 
 			if (MERGE_OR_CREATE.contains(updateType)) {
-				final Pattern pattern = new Pattern(this.expressions.stream().map(PatternElement.class::cast).collect(Collectors.toList()));
+				final Pattern pattern = new Pattern(
+					this.expressions.stream().map(PatternElement.class::cast).collect(Collectors.toList()));
 				switch (updateType) {
 					case CREATE:
 						return new Create(pattern);
@@ -811,7 +841,8 @@ class DefaultStatementBuilder
 						return new Merge(pattern);
 				}
 			} else {
-				final ExpressionList expressionsList = new ExpressionList(this.expressions.stream().map(Expression.class::cast).collect(Collectors.toList()));
+				final ExpressionList expressionsList = new ExpressionList(
+					this.expressions.stream().map(Expression.class::cast).collect(Collectors.toList()));
 				switch (updateType) {
 					case DETACH_DELETE:
 						return new Delete(expressionsList, true);

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DefaultStatementBuilder.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DefaultStatementBuilder.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.neo4j.cypherdsl.core.ProcedureCall.OngoingInQueryCallWithArguments;
 import org.neo4j.cypherdsl.core.ProcedureCall.OngoingInQueryCallWithReturnFields;
@@ -802,7 +803,7 @@ class DefaultStatementBuilder
 		private UpdatingClause buildUpdatingClause() {
 
 			if (MERGE_OR_CREATE.contains(updateType)) {
-				final Pattern pattern = new Pattern(this.expressions);
+				final Pattern pattern = new Pattern(this.expressions.stream().map(PatternElement.class::cast).collect(Collectors.toList()));
 				switch (updateType) {
 					case CREATE:
 						return new Create(pattern);
@@ -810,7 +811,7 @@ class DefaultStatementBuilder
 						return new Merge(pattern);
 				}
 			} else {
-				final ExpressionList expressionsList = new ExpressionList(this.expressions);
+				final ExpressionList expressionsList = new ExpressionList(this.expressions.stream().map(Expression.class::cast).collect(Collectors.toList()));
 				switch (updateType) {
 					case DETACH_DELETE:
 						return new Delete(expressionsList, true);

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesCall.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesCall.java
@@ -54,18 +54,25 @@ public interface ExposesCall<T> {
 		 * Adds the given arguments to the ongoing call and procedes.
 		 *
 		 * @param arguments The list of new arguments, might be null or empty.
-		 * @return An oingoing standalone call on which yielded arguments might be configured.
+		 * @return An ongoing standalone call on which yielded arguments might be configured.
 		 */
 		T withArgs(Expression... arguments);
 	}
 
 	/**
-	 * Used to yield procedure result fields.
+	 * Used to yield procedure result fields. There are no checks involved whether the procedure being called
+	 * actually returns items with the given names.
 	 *
 	 * @param <T> The type of the next step
 	 */
 	interface ExposesYield<T> {
 
+		/**
+		 * Adds the given items to the {@literal YIELD} clause of the generated call.
+		 *
+		 * @param yieldedItems The list of items to be yielded.
+		 * @return The ongoing standalone call to be configured.
+		 */
 		default T yield(String... yieldedItems) {
 
 			SymbolicName[] names = new SymbolicName[0];
@@ -76,8 +83,21 @@ public interface ExposesCall<T> {
 			return yield(names);
 		}
 
+		/**
+	     * Adds the given items to the {@literal YIELD} clause of the generated call.
+		 *
+		 * @param resultFields The list of result fields to be returned.
+		 * @return The ongoing standalone call to be configured.
+		 */
 		T yield(SymbolicName... resultFields);
 
+		/**
+		 * Adds the given items to the {@literal YIELD} clause of the generated call and uses new
+		 * aliases in the generated call.
+		 *
+		 * @param aliasedResultFields The list of result fields to be returned with new aliases given.
+		 * @return The ongoing standalone call to be configured.
+		 */
 		T yield(AliasedExpression... aliasedResultFields);
 	}
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesProperties.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesProperties.java
@@ -35,7 +35,7 @@ public interface ExposesProperties<T extends ExposesProperties<?> & PropertyCont
 	 * @param newProperties the new properties (can be {@literal null} to remove exiting properties).
 	 * @return The new property container.
 	 */
-	T withProperties(MapExpression<?> newProperties);
+	T withProperties(MapExpression newProperties);
 
 	/**
 	 * Creates a a copy of this property container with additional properties.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExpressionList.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExpressionList.java
@@ -32,7 +32,7 @@ import org.neo4j.cypherdsl.core.support.Visitable;
  * @author Michael J. Simons
  * @since 1.0
  */
-class ExpressionList<S extends ExpressionList<S>> extends TypedSubtree<Expression, S> {
+class ExpressionList extends TypedSubtree<Expression, ExpressionList> {
 
 	ExpressionList(List<Expression> returnItems) {
 		super(returnItems);

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Expressions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Expressions.java
@@ -38,10 +38,10 @@ final class Expressions {
 	 * @param <T> The type being returned
 	 * @return The name of the expression if the expression is named or the expression itself.
 	 */
-	static <T> T nameOrExpression(T expression) {
+	static <T extends Expression> Expression nameOrExpression(T expression) {
 
 		if (expression instanceof Named) {
-			return ((Named) expression).getSymbolicName().map(v -> (T) v).orElse(expression);
+			return ((Named) expression).getSymbolicName().map(Expression.class::cast).orElse(expression);
 		} else {
 			return expression;
 		}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListExpression.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListExpression.java
@@ -47,12 +47,12 @@ public final class ListExpression implements Expression {
 
 	static ListExpression create(Expression... expressions) {
 
-		return new ListExpression(new ExpressionList<>(expressions));
+		return new ListExpression(new ExpressionList(expressions));
 	}
 
-	private final ExpressionList<?> content;
+	private final ExpressionList content;
 
-	private ListExpression(ExpressionList<?> content) {
+	private ListExpression(ExpressionList content) {
 		this.content = content;
 	}
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MapExpression.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MapExpression.java
@@ -37,14 +37,13 @@ import org.neo4j.cypherdsl.core.support.Visitable;
  * or {@link Relationship relationships}.
  *
  * @author Michael J. Simons
- * @param <S> type of properties or parameter
  * @soundtrack Rammstein - RAMMSTEIN
  * @since 1.0
  */
 @API(status = INTERNAL, since = "1.0")
-public final class MapExpression<S extends MapExpression<S>> extends TypedSubtree<Expression, S> implements Expression {
+public final class MapExpression extends TypedSubtree<Expression, MapExpression> implements Expression {
 
-	static MapExpression<?> create(Object... input) {
+	static MapExpression create(Object... input) {
 
 		Assert.isTrue(input.length % 2 == 0, "Need an even number of input parameters");
 		List<Expression> newContent = new ArrayList<>(input.length / 2);
@@ -60,22 +59,22 @@ public final class MapExpression<S extends MapExpression<S>> extends TypedSubtre
 			knownKeys.add(entry.getKey());
 		}
 
-		return new MapExpression<>(newContent);
+		return new MapExpression(newContent);
 	}
 
-	static MapExpression<?> withEntries(List<Expression> entries) {
-		return new MapExpression<>(entries);
+	static MapExpression withEntries(List<Expression> entries) {
+		return new MapExpression(entries);
 	}
 
 	private MapExpression(List<Expression> children) {
 		super(children);
 	}
 
-	MapExpression<?> addEntries(List<Expression> entries) {
+	MapExpression addEntries(List<Expression> entries) {
 		List<Expression> newContent = new ArrayList<>(super.children.size() + entries.size());
 		newContent.addAll(super.children);
 		newContent.addAll(entries);
-		return new MapExpression<>(newContent);
+		return new MapExpression(newContent);
 	}
 
 	@Override

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MapProjection.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MapProjection.java
@@ -39,14 +39,14 @@ public final class MapProjection implements Expression {
 
 	private SymbolicName name;
 
-	private MapExpression<?> map;
+	private MapExpression map;
 
 	static MapProjection create(SymbolicName name, Object... content) {
 
 		return new MapProjection(name, MapExpression.withEntries(createNewContent(content)));
 	}
 
-	MapProjection(SymbolicName name, MapExpression<?> map) {
+	MapProjection(SymbolicName name, MapExpression map) {
 		this.name = name;
 		this.map = map;
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MapProjection.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MapProjection.java
@@ -69,6 +69,14 @@ public final class MapProjection implements Expression {
 		visitor.leave(this);
 	}
 
+	private static Object contentAt(Object[] content, int i) {
+
+		if (content[i] instanceof Expression) {
+			return nameOrExpression((Expression) content[i]);
+		}
+		return content[i];
+	}
+
 	private static List<Expression> createNewContent(Object... content) {
 		final List<Expression> newContent = new ArrayList<>(content.length);
 		final Set<String> knownKeys = new HashSet<>();
@@ -82,9 +90,9 @@ public final class MapProjection implements Expression {
 			if (i + 1 >= content.length) {
 				next = null;
 			} else {
-				next = nameOrExpression(content[i + 1]);
+				next = contentAt(content, i + 1);
 			}
-			Object current = nameOrExpression(content[i]);
+			Object current = contentAt(content, i);
 
 			if (current instanceof String) {
 				if (next instanceof Expression) {

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Node.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Node.java
@@ -114,7 +114,7 @@ public final class Node implements PatternElement, PropertyContainer, ExposesRel
 	}
 
 	@Override
-	public Node withProperties(MapExpression<?> newProperties) {
+	public Node withProperties(MapExpression newProperties) {
 
 		return new Node(this.symbolicName, newProperties == null ? null : new Properties(newProperties), labels);
 	}
@@ -122,7 +122,7 @@ public final class Node implements PatternElement, PropertyContainer, ExposesRel
 	@Override
 	public Node withProperties(Object... keysAndValues) {
 
-		MapExpression<?> newProperties = null;
+		MapExpression newProperties = null;
 		if (keysAndValues != null && keysAndValues.length != 0) {
 			newProperties = MapExpression.create(keysAndValues);
 		}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Order.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Order.java
@@ -30,11 +30,10 @@ import org.neo4j.cypherdsl.core.support.TypedSubtree;
  *
  * @author Gerrit Meier
  * @author Michael J. Simons
- * @param <S> The order's entry type
  * @since 1.0
  */
 @API(status = EXPERIMENTAL, since = "1.0")
-public final class Order<S extends Order<S>> extends TypedSubtree<SortItem, S> {
+public final class Order extends TypedSubtree<SortItem, Order> {
 
 	Order(List<SortItem> sortItems) {
 		super(sortItems);

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Pattern.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Pattern.java
@@ -32,11 +32,10 @@ import org.neo4j.cypherdsl.core.support.TypedSubtree;
  * See <a href="https://s3.amazonaws.com/artifacts.opencypher.org/railroad/Pattern.html">Pattern</a>.
  *
  * @author Michael J. Simons
- * @param <S> The pattern's entry type
  * @since 1.0
  */
 @API(status = INTERNAL, since = "1.0")
-public final class Pattern<S extends Pattern<S>> extends TypedSubtree<PatternElement, S> {
+public final class Pattern extends TypedSubtree<PatternElement, Pattern> {
 
 	Pattern(List<PatternElement> patternElements) {
 		super(patternElements);

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ProcedureCall.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ProcedureCall.java
@@ -28,7 +28,7 @@ import org.neo4j.cypherdsl.core.support.Visitor;
  * @soundtrack Apocalyptica - Cell-0
  * @since 2020.0.1
  */
-public final class ProcedureCall implements Visitable, Statement {
+public final class ProcedureCall implements Statement {
 
 	private final ProcedureName name;
 
@@ -95,7 +95,7 @@ public final class ProcedureCall implements Visitable, Statement {
 
 		protected Expression[] arguments;
 
-		protected YieldItems<?, ?> yieldItems;
+		protected YieldItems yieldItems;
 
 		protected final DefaultStatementBuilder.ConditionBuilder conditionBuilder = new DefaultStatementBuilder.ConditionBuilder();
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Properties.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Properties.java
@@ -33,9 +33,9 @@ import org.neo4j.cypherdsl.core.support.Visitor;
 @API(status = EXPERIMENTAL, since = "1.0")
 public final class Properties implements Visitable {
 
-	private final MapExpression<?> properties;
+	private final MapExpression properties;
 
-	Properties(MapExpression<?> properties) {
+	Properties(MapExpression properties) {
 		this.properties = properties;
 	}
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Relationship.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Relationship.java
@@ -185,7 +185,7 @@ public final class Relationship implements RelationshipPattern, PropertyContaine
 	}
 
 	@Override
-	public Relationship withProperties(MapExpression<?> newProperties) {
+	public Relationship withProperties(MapExpression newProperties) {
 
 		if (newProperties == null && this.details.getProperties() == null) {
 			return this;
@@ -197,7 +197,7 @@ public final class Relationship implements RelationshipPattern, PropertyContaine
 	@Override
 	public Relationship withProperties(Object... keysAndValues) {
 
-		MapExpression<?> newProperties = null;
+		MapExpression newProperties = null;
 		if (keysAndValues != null && keysAndValues.length != 0) {
 			newProperties = MapExpression.create(keysAndValues);
 		}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipChain.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipChain.java
@@ -34,7 +34,7 @@ import org.neo4j.cypherdsl.core.support.Visitor;
  * @since 1.0
  */
 @API(status = EXPERIMENTAL, since = "1.0")
-public final class RelationshipChain implements RelationshipPattern, ExposesRelationships<RelationshipChain> {
+public final class RelationshipChain implements RelationshipPattern {
 
 	private final LinkedList<Relationship> relationships = new LinkedList<>();
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipChain.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipChain.java
@@ -133,7 +133,7 @@ public final class RelationshipChain implements RelationshipPattern, ExposesRela
 	 * @param newProperties the new properties (can be {@literal null} to remove exiting properties).
 	 * @return This chain
 	 */
-	public RelationshipChain properties(MapExpression<?> newProperties) {
+	public RelationshipChain properties(MapExpression newProperties) {
 
 		Relationship lastElement = this.relationships.removeLast();
 		return this.add(lastElement.withProperties(newProperties));

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/SinglePartQuery.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/SinglePartQuery.java
@@ -52,7 +52,7 @@ public final class SinglePartQuery implements SingleQuery {
 
 	private SinglePartQuery(List<Visitable> precedingClauses, Return aReturn) {
 
-		this.precedingClauses = new ArrayList(precedingClauses);
+		this.precedingClauses = new ArrayList<>(precedingClauses);
 		this.aReturn = aReturn;
 	}
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementBuilder.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementBuilder.java
@@ -57,8 +57,7 @@ public interface StatementBuilder
 	 *
 	 * @since 1.0
 	 */
-	interface OngoingReadingWithoutWhere
-		extends OngoingReading, ExposesWhere, ExposesMatch, ExposesCreate, ExposesMerge {
+	interface OngoingReadingWithoutWhere extends OngoingReading, ExposesWhere, ExposesMatch {
 	}
 
 	/**
@@ -147,8 +146,7 @@ public interface StatementBuilder
 	 *
 	 * @since 1.0
 	 */
-	interface OngoingReadingAndWith
-		extends OngoingReading, ExposesMatch, ExposesReturning, ExposesCreate, ExposesMerge {
+	interface OngoingReadingAndWith extends OngoingReading, ExposesMatch {
 	}
 
 	/**
@@ -386,10 +384,9 @@ public interface StatementBuilder
 		 * all expression with {@link Cypher#sort(Expression)} or directly from properties.
 		 *
 		 * @param sortItem One or more sort items
-		 * @param <T>      The type of the step being returned
 		 * @return A build step that still offers methods for defining skip and limit
 		 */
-		<T extends ExposesSkip & ExposesLimit & OngoingReadingAndWith> T orderBy(SortItem... sortItem);
+		OrderableOngoingReadingAndWithWithWhere orderBy(SortItem... sortItem);
 
 		/**
 		 * Order the result set by an expression.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/YieldItems.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/YieldItems.java
@@ -26,25 +26,23 @@ import org.neo4j.cypherdsl.core.support.TypedSubtree;
 /**
  * Items yielded by a stand alone or in query call.
  *
- * @param <T>    The children's type
- * @param <SELF> The concrete type of this class.
  * @author Michael J. Simons
  * @soundtrack Brian May &amp; Kerry Ellis - Golden Days
  * @since 2020.0.1
  */
 @API(status = INTERNAL, since = "2020.0.1")
-public final class YieldItems<T extends Expression, SELF extends YieldItems<T, SELF>> extends TypedSubtree<T, SELF> {
+public final class YieldItems extends TypedSubtree<Expression, YieldItems> {
 
-	static <C extends Expression, SELF extends YieldItems<C, SELF>> YieldItems<C, SELF> yieldAllOf(C... c) {
+	static YieldItems yieldAllOf(Expression... c) {
 
 		if (c == null || c.length == 0) {
 			throw new IllegalArgumentException("Cannot yield an empty list of items.");
 		}
 
-		return new YieldItems<C, SELF>(c);
+		return new YieldItems(c);
 	}
 
-	private YieldItems(T... children) {
+	private YieldItems(Expression... children) {
 		super(children);
 	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/CypherRenderer.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/CypherRenderer.java
@@ -74,6 +74,9 @@ enum CypherRenderer implements Renderer {
 	}
 
 	private static class LRUCache<K, V> extends LinkedHashMap<K, V> {
+
+		private static final long serialVersionUID = -6819899594092598277L;
+
 		private int cacheSize;
 
 		LRUCache(int cacheSize) {

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/support/TypedSubtree.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/support/TypedSubtree.java
@@ -35,6 +35,8 @@ public abstract class TypedSubtree<T extends Visitable, SELF extends TypedSubtre
 
 	protected final List<T> children;
 
+	@SafeVarargs
+	@SuppressWarnings("varargs")
 	protected TypedSubtree(T... children) {
 
 		this.children = Arrays.asList(children);

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
@@ -880,8 +880,8 @@ class CypherIT {
 		void chainingOnWhere() {
 			Statement statement;
 
-			Literal test = Cypher.literalOf("Test");
-			Literal foobar = Cypher.literalOf("foobar");
+			Literal<?> test = Cypher.literalOf("Test");
+			Literal<?> foobar = Cypher.literalOf("foobar");
 
 			statement = Cypher.match(userNode)
 				.where(userNode.property("name").isEqualTo(test))
@@ -982,9 +982,9 @@ class CypherIT {
 		void chainingOnConditions() {
 			Statement statement;
 
-			Literal test = Cypher.literalOf("Test");
-			Literal foobar = Cypher.literalOf("foobar");
-			Literal bazbar = Cypher.literalOf("bazbar");
+			Literal<?> test = Cypher.literalOf("Test");
+			Literal<?> foobar = Cypher.literalOf("foobar");
+			Literal<?> bazbar = Cypher.literalOf("bazbar");
 
 			statement = Cypher.match(userNode)
 				.where(
@@ -1060,9 +1060,9 @@ class CypherIT {
 		void chainingCombined() {
 			Statement statement;
 
-			Literal test = Cypher.literalOf("Test");
-			Literal foobar = Cypher.literalOf("foobar");
-			Literal bazbar = Cypher.literalOf("bazbar");
+			Literal<?> test = Cypher.literalOf("Test");
+			Literal<?> foobar = Cypher.literalOf("foobar");
+			Literal<?> bazbar = Cypher.literalOf("bazbar");
 
 			statement = Cypher.match(userNode)
 				.where(
@@ -1666,7 +1666,6 @@ class CypherIT {
 				.isEqualTo(
 					"MERGE (u:`User`) WITH u RETURN u");
 
-			Relationship r = userNode.relationshipTo(bikeNode, "OWNS").named("o");
 			statement = Cypher.merge(userNode)
 				.with(userNode)
 				.set(userNode.property("x").to(Cypher.literalOf("y")))
@@ -1831,7 +1830,6 @@ class CypherIT {
 				.isEqualTo(
 					"CREATE (u:`User`) WITH u RETURN u");
 
-			Relationship r = userNode.relationshipTo(bikeNode, "OWNS").named("o");
 			statement = Cypher.create(userNode)
 				.with(userNode)
 				.set(userNode.property("x").to(Cypher.literalOf("y")))

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherTest.java
@@ -43,7 +43,7 @@ class CypherTest {
 		params.add(Cypher.literalFalse());
 		params.add(Cypher.literalTrue());
 
-		Literal listLiteral = Cypher.literalOf(params);
+		Literal<?> listLiteral = Cypher.literalOf(params);
 
 		assertThat(listLiteral).isInstanceOf(ListLiteral.class)
 			.returns("[false, true]", v -> v.asString());


### PR DESCRIPTION
This fixes a couple of places in which generics have put to use that are actually not fulfillable by any implementation, i.e. on final classes. Those makes of course now sense and has been fixed.

Furthermore, some return types on the entry points have changed, which may need recompiling dependents.

On a couple of methods unchecked conversions have been suppressed by `@SuppressWarnings("unchecked")` (all those that are actually safe).