### PR TITLE
Clean up the Functions api.

### DIFF
--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/BuiltInFunctions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/BuiltInFunctions.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.core;
+
+import static org.apiguardian.api.API.Status.*;
+
+import org.apiguardian.api.API;
+import org.neo4j.cypherdsl.core.FunctionInvocation.FunctionDefinition;
+
+/**
+ * A (non exhaustive) list of builtin functions.
+ *
+ * @author Michael J. Simons
+ * @soundtrack Metallica - ReLoad
+ * @since 2020.1.0
+ */
+@API(status = INTERNAL, since = "2020.1.0")
+final class BuiltInFunctions {
+
+	enum Predicates implements FunctionDefinition {
+
+		ALL("all"),
+		ANY("any"),
+		EXISTS("exists"),
+		NONE("none"),
+		SINGLE("single");
+
+		private final String implementationName;
+
+		Predicates(String implementationName) {
+			this.implementationName = implementationName;
+		}
+
+		@Override
+		public String getImplementationName() {
+			return implementationName;
+		}
+	}
+
+	enum Scalars implements FunctionDefinition {
+
+		ID("id"),
+		LABELS("labels"),
+		TYPE("type"),
+
+		COALESCE("coalesce"),
+		TO_LOWER("toLower"),
+		SIZE("size"),
+		DISTANCE("distance"),
+		POINT("point"),
+		RANGE("range"),
+		HEAD("head"),
+		LAST("last"),
+		SHORTEST_PATH("shortestPath"),
+		NODES("nodes");
+
+		private final String implementationName;
+
+		Scalars(String implementationName) {
+			this.implementationName = implementationName;
+		}
+
+		@Override
+		public String getImplementationName() {
+			return implementationName;
+		}
+	}
+
+	enum Aggregates implements FunctionDefinition {
+
+		COUNT("count"),
+		AVG("avg"),
+		COLLECT("collect"),
+		MAX("max"),
+		MIN("min"),
+		PERCENTILE_CONT("percentileCont"),
+		PERCENTILE_DISC("percentileDisc"),
+		ST_DEV("stDev"),
+		ST_DEV_P("stDevP"),
+		SUM("sum");
+
+		private final String implementationName;
+
+		Aggregates(String implementationName) {
+			this.implementationName = implementationName;
+		}
+
+		@Override
+		public String getImplementationName() {
+			return implementationName;
+		}
+
+		@Override public boolean isAggregate() {
+			return true;
+		}
+
+	}
+
+	private BuiltInFunctions() {
+	}
+}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
@@ -145,7 +145,7 @@ public final class Cypher {
 	 * @since 1.1.1
 	 */
 	public static NamedPath.OngoingShortestPathDefinitionWithName shortestPath(String name) {
-		return NamedPath.named(name, "shortestPath");
+		return NamedPath.named(name, BuiltInFunctions.Scalars.SHORTEST_PATH);
 	}
 
 	/**
@@ -156,7 +156,7 @@ public final class Cypher {
 	 * @since 1.1.1
 	 */
 	public static NamedPath.OngoingShortestPathDefinitionWithName shortestPath(SymbolicName name) {
-		return NamedPath.named(name, "shortestPath");
+		return NamedPath.named(name, BuiltInFunctions.Scalars.SHORTEST_PATH);
 	}
 
 	/**

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DistinctExpression.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DistinctExpression.java
@@ -18,9 +18,6 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
-
-import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitor;
 
 /**
@@ -29,8 +26,7 @@ import org.neo4j.cypherdsl.core.support.Visitor;
  * @author Michael J. Simons
  * @since 1.0
  */
-@API(status = INTERNAL, since = "1.0")
-public final class DistinctExpression implements Expression {
+final class DistinctExpression implements Expression {
 
 	private final Expression delegate;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Functions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Functions.java
@@ -20,9 +20,10 @@ package org.neo4j.cypherdsl.core;
 
 import static org.apiguardian.api.API.Status.*;
 
-import java.util.Collections;
-
 import org.apiguardian.api.API;
+import org.neo4j.cypherdsl.core.BuiltInFunctions.Aggregates;
+import org.neo4j.cypherdsl.core.BuiltInFunctions.Predicates;
+import org.neo4j.cypherdsl.core.BuiltInFunctions.Scalars;
 
 /**
  * Factory methods for creating instances of {@link FunctionInvocation functions}.
@@ -35,8 +36,6 @@ import org.apiguardian.api.API;
 @API(status = EXPERIMENTAL, since = "1.0")
 public final class Functions {
 
-	private static final String F_ID = "id";
-
 	/**
 	 * Creates a function invocation for {@code id{}}.
 	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/scalar/#functions-id">id</a>.
@@ -46,9 +45,9 @@ public final class Functions {
 	 */
 	public static FunctionInvocation id(Node node) {
 
-		Assert.notNull(node, "The node parameter is required.");
+		Assert.notNull(node, "The node for id() is required.");
 
-		return new FunctionInvocation(F_ID, node.getRequiredSymbolicName());
+		return FunctionInvocation.create(Scalars.ID, node.getRequiredSymbolicName());
 	}
 
 	/**
@@ -60,9 +59,9 @@ public final class Functions {
 	 */
 	public static FunctionInvocation id(Relationship relationship) {
 
-		Assert.notNull(relationship, "The relationship parameter is required.");
+		Assert.notNull(relationship, "The relationship for id() is required.");
 
-		return new FunctionInvocation(F_ID, relationship.getRequiredSymbolicName());
+		return FunctionInvocation.create(Scalars.ID, relationship.getRequiredSymbolicName());
 	}
 
 	/**
@@ -76,7 +75,7 @@ public final class Functions {
 
 		Assert.notNull(node, "The node parameter is required.");
 
-		return new FunctionInvocation("labels", node.getRequiredSymbolicName());
+		return FunctionInvocation.create(Scalars.LABELS, node.getRequiredSymbolicName());
 	}
 
 	/**
@@ -90,7 +89,7 @@ public final class Functions {
 
 		Assert.notNull(relationship, "The relationship parameter is required.");
 
-		return new FunctionInvocation("type", relationship.getRequiredSymbolicName());
+		return FunctionInvocation.create(Scalars.TYPE, relationship.getRequiredSymbolicName());
 	}
 
 	/**
@@ -102,7 +101,7 @@ public final class Functions {
 
 		Assert.notNull(node, "The node parameter is required.");
 
-		return count(node.getRequiredSymbolicName());
+		return FunctionInvocation.create(Aggregates.COUNT, node.getRequiredSymbolicName());
 	}
 
 	/**
@@ -114,9 +113,7 @@ public final class Functions {
 	 */
 	public static FunctionInvocation count(Expression expression) {
 
-		Assert.notNull(expression, "The expression to count is required.");
-
-		return new FunctionInvocation("count", expression);
+		return FunctionInvocation.create(Aggregates.COUNT, expression);
 	}
 
 	/**
@@ -130,7 +127,7 @@ public final class Functions {
 
 		Assert.notNull(node, "The node parameter is required.");
 
-		return countDistinct(node.getRequiredSymbolicName());
+		return FunctionInvocation.createDistinct(Aggregates.COUNT, node.getRequiredSymbolicName());
 	}
 
 	/**
@@ -142,9 +139,7 @@ public final class Functions {
 	 */
 	public static FunctionInvocation countDistinct(Expression expression) {
 
-		Assert.notNull(expression, "The expression to count is required.");
-
-		return new FunctionInvocation("count", new DistinctExpression(expression));
+		return FunctionInvocation.createDistinct(Aggregates.COUNT, expression);
 	}
 
 	/**
@@ -156,10 +151,7 @@ public final class Functions {
 	 */
 	public static FunctionInvocation coalesce(Expression... expressions) {
 
-		Assert.notEmpty(expressions, "At least one expression is required.");
-		Assert.notNull(expressions[0], "At least one expression is required.");
-
-		return new FunctionInvocation("coalesce", expressions);
+		return FunctionInvocation.create(Scalars.COALESCE, expressions);
 	}
 
 	/**
@@ -171,9 +163,7 @@ public final class Functions {
 	 */
 	public static FunctionInvocation toLower(Expression expression) {
 
-		Assert.notNull(expression, "The expression for toLower() is required.");
-
-		return new FunctionInvocation("toLower", expression);
+		return FunctionInvocation.create(Scalars.TO_LOWER, expression);
 	}
 
 	/**
@@ -188,9 +178,7 @@ public final class Functions {
 	 */
 	public static FunctionInvocation size(Expression expression) {
 
-		Assert.notNull(expression, "The expression for size() is required.");
-
-		return new FunctionInvocation("size", expression);
+		return FunctionInvocation.create(Scalars.SIZE, expression);
 	}
 
 	/**
@@ -204,9 +192,7 @@ public final class Functions {
 	 */
 	public static FunctionInvocation size(RelationshipPattern pattern) {
 
-		Assert.notNull(pattern, "The pattern for size() is required.");
-
-		return new FunctionInvocation("size", new Pattern(Collections.singletonList(pattern)));
+		return FunctionInvocation.create(Scalars.SIZE, pattern);
 	}
 
 	/**
@@ -218,9 +204,7 @@ public final class Functions {
 	 */
 	public static FunctionInvocation exists(Expression expression) {
 
-		Assert.notNull(expression, "The expression for exists() is required.");
-
-		return new FunctionInvocation("exists", expression);
+		return FunctionInvocation.create(Predicates.EXISTS, expression);
 	}
 
 	/**
@@ -237,7 +221,7 @@ public final class Functions {
 		Assert.notNull(point1, "The distance function requires two points.");
 		Assert.notNull(point2, "The distance function requires two points.");
 
-		return new FunctionInvocation("distance", point1, point2);
+		return FunctionInvocation.create(Scalars.DISTANCE, point1, point2);
 	}
 
 	/**
@@ -249,9 +233,7 @@ public final class Functions {
 	 */
 	public static FunctionInvocation point(MapExpression parameterMap) {
 
-		Assert.notNull(parameterMap, "The parameter map is required.");
-
-		return new FunctionInvocation("point", parameterMap);
+		return FunctionInvocation.create(Scalars.POINT, parameterMap);
 	}
 
 	/**
@@ -263,9 +245,7 @@ public final class Functions {
 	 */
 	public static FunctionInvocation point(Parameter parameter) {
 
-		Assert.notNull(parameter, "The parameter is required.");
-
-		return new FunctionInvocation("point", parameter);
+		return FunctionInvocation.create(Scalars.POINT, parameter);
 	}
 
 	/**
@@ -277,12 +257,24 @@ public final class Functions {
 	 */
 	public static FunctionInvocation avg(Expression expression) {
 
-		Assert.notNull(expression, "The expression to average is required.");
-
-		return new FunctionInvocation("avg", expression);
+		return FunctionInvocation.create(Aggregates.AVG, expression);
 	}
 
 	/**
+	 * Creates a function invocation for the {@code avg()} function with {@code DISTINCT} added.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/aggregating/#functions-avg">avg</a>.
+	 *
+	 * @param expression The things to average
+	 * @return A function call for {@code avg()}
+	 */
+	public static FunctionInvocation avgDistinct(Expression expression) {
+
+		return FunctionInvocation.createDistinct(Aggregates.AVG, expression);
+	}
+
+	/**
+	 * Creates a function invocation for the {@code collect()} function.
+	 *
 	 * @param variable The named thing to collect
 	 * @return A function call for {@code collect()}
 	 * @see #collect(Expression)
@@ -291,7 +283,21 @@ public final class Functions {
 
 		Assert.notNull(variable, "The variable parameter is required.");
 
-		return Functions.collect(variable.getRequiredSymbolicName());
+		return FunctionInvocation.create(Aggregates.COLLECT, variable.getRequiredSymbolicName());
+	}
+
+	/**
+	 * Creates a function invocation for the {@code collect()} function with {@code DISTINCT} added.
+	 *
+	 * @param variable The named thing to collect
+	 * @return A function call for {@code collect()}
+	 * @see #collect(Expression)
+	 */
+	public static FunctionInvocation collectDistinct(Named variable) {
+
+		Assert.notNull(variable, "The variable parameter is required.");
+
+		return FunctionInvocation.createDistinct(Aggregates.COLLECT, variable.getRequiredSymbolicName());
 	}
 
 	/**
@@ -303,9 +309,19 @@ public final class Functions {
 	 */
 	public static FunctionInvocation collect(Expression expression) {
 
-		Assert.notNull(expression, "The expression to collect is required.");
+		return FunctionInvocation.create(Aggregates.COLLECT, expression);
+	}
 
-		return new FunctionInvocation("collect", expression);
+	/**
+	 * Creates a function invocation for the {@code collect()} function with {@code DISTINCT} added.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/aggregating/#functions-collect">collect</a>.
+	 *
+	 * @param expression The things to collect
+	 * @return A function call for {@code collect()}
+	 */
+	public static FunctionInvocation collectDistinct(Expression expression) {
+
+		return FunctionInvocation.createDistinct(Aggregates.COLLECT, expression);
 	}
 
 	/**
@@ -317,9 +333,19 @@ public final class Functions {
 	 */
 	public static FunctionInvocation max(Expression expression) {
 
-		Assert.notNull(expression, "The expression for max is required.");
+		return FunctionInvocation.create(Aggregates.MAX, expression);
+	}
 
-		return new FunctionInvocation("max", expression);
+	/**
+	 * Creates a function invocation for the {@code max()} function with {@code DISTINCT} added.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/aggregating/#functions-max">max</a>.
+	 *
+	 * @param expression A list from which the maximum element value is returned
+	 * @return A function call for {@code max()}
+	 */
+	public static FunctionInvocation maxDistinct(Expression expression) {
+
+		return FunctionInvocation.createDistinct(Aggregates.MAX, expression);
 	}
 
 	/**
@@ -331,9 +357,27 @@ public final class Functions {
 	 */
 	public static FunctionInvocation min(Expression expression) {
 
-		Assert.notNull(expression, "The expression for min is required.");
+		return FunctionInvocation.create(Aggregates.MIN, expression);
+	}
 
-		return new FunctionInvocation("min", expression);
+	/**
+	 * Creates a function invocation for the {@code min()} function with {@code DISTINCT} added.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/aggregating/#functions-min">min</a>.
+	 *
+	 * @param expression A list from which the minimum element value is returned
+	 * @return A function call for {@code min()}
+	 */
+	public static FunctionInvocation minDistinct(Expression expression) {
+
+		return FunctionInvocation.createDistinct(Aggregates.MIN, expression);
+	}
+
+	private static void assertPercentileArguments(Aggregates builtIn, Expression expression, Number percentile) {
+		Assert.notNull(expression, "The numeric expression for " + builtIn.getImplementationName() + " is required.");
+		Assert.notNull(percentile, "The percentile for " + builtIn.getImplementationName() + " is required.");
+		final double p = percentile.doubleValue();
+		Assert.isTrue(p >= 0D && p <= 1D,
+			"The percentile for " + builtIn.getImplementationName() + " must be between 0.0 and 1.0.");
 	}
 
 	/**
@@ -346,12 +390,24 @@ public final class Functions {
 	 */
 	public static FunctionInvocation percentileCont(Expression expression, Number percentile) {
 
-		Assert.notNull(expression, "The numeric expression for percentileCont is required.");
-		Assert.notNull(percentile, "The percentile for percentileCont is required.");
-		final double p = percentile.doubleValue();
-		Assert.isTrue(p >= 0D && p <= 1D, "The percentile for percentileCont must be between 0.0 and 1.0.");
+		assertPercentileArguments(Aggregates.PERCENTILE_CONT, expression, percentile);
 
-		return new FunctionInvocation("percentileCont", expression, new NumberLiteral(percentile));
+		return FunctionInvocation.create(Aggregates.PERCENTILE_CONT, expression, new NumberLiteral(percentile));
+	}
+
+	/**
+	 * Creates a function invocation for the {@code percentileCont()} function with {@code DISTINCT} added.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/aggregating/#functions-percentilecont">percentileCont</a>.
+	 *
+	 * @param expression A numeric expression
+	 * @param percentile A numeric value between 0.0 and 1.0
+	 * @return A function call for {@code percentileCont()}
+	 */
+	public static FunctionInvocation percentileContDistinct(Expression expression, Number percentile) {
+
+		assertPercentileArguments(Aggregates.PERCENTILE_CONT, expression, percentile);
+
+		return FunctionInvocation.createDistinct(Aggregates.PERCENTILE_CONT, expression, new NumberLiteral(percentile));
 	}
 
 	/**
@@ -364,12 +420,24 @@ public final class Functions {
 	 */
 	public static FunctionInvocation percentileDisc(Expression expression, Number percentile) {
 
-		Assert.notNull(expression, "The numeric expression for percentileDisc is required.");
-		Assert.notNull(percentile, "The percentile for percentileDisc is required.");
-		final double p = percentile.doubleValue();
-		Assert.isTrue(p >= 0D && p <= 1D, "The percentile for percentileDisc must be between 0.0 and 1.0.");
+		assertPercentileArguments(Aggregates.PERCENTILE_DISC, expression, percentile);
 
-		return new FunctionInvocation("percentileDisc", expression, new NumberLiteral(percentile));
+		return FunctionInvocation.create(Aggregates.PERCENTILE_DISC, expression, new NumberLiteral(percentile));
+	}
+
+	/**
+	 * Creates a function invocation for the {@code percentileDisc()} function with {@code DISTINCT} added.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/aggregating/#functions-percentiledisc">percentileDisc</a>.
+	 *
+	 * @param expression A numeric expression
+	 * @param percentile A numeric value between 0.0 and 1.0
+	 * @return A function call for {@code percentileDisc()}
+	 */
+	public static FunctionInvocation percentileDiscDistinct(Expression expression, Number percentile) {
+
+		assertPercentileArguments(Aggregates.PERCENTILE_DISC, expression, percentile);
+
+		return FunctionInvocation.createDistinct(Aggregates.PERCENTILE_DISC, expression, new NumberLiteral(percentile));
 	}
 
 	/**
@@ -381,9 +449,19 @@ public final class Functions {
 	 */
 	public static FunctionInvocation stDev(Expression expression) {
 
-		Assert.notNull(expression, "The numeric expression for stDev is required.");
+		return FunctionInvocation.create(Aggregates.ST_DEV, expression);
+	}
 
-		return new FunctionInvocation("stDev", expression);
+	/**
+	 * Creates a function invocation for the {@code stDev()} function with {@code DISTINCT} added.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/aggregating/#functions-stdev">stDev</a>.
+	 *
+	 * @param expression A numeric expression
+	 * @return A function call for {@code stDev()}
+	 */
+	public static FunctionInvocation stDevDistinct(Expression expression) {
+
+		return FunctionInvocation.createDistinct(Aggregates.ST_DEV, expression);
 	}
 
 	/**
@@ -395,9 +473,19 @@ public final class Functions {
 	 */
 	public static FunctionInvocation stDevP(Expression expression) {
 
-		Assert.notNull(expression, "The numeric expression for stDevP is required.");
+		return FunctionInvocation.create(Aggregates.ST_DEV_P, expression);
+	}
 
-		return new FunctionInvocation("stDevP", expression);
+	/**
+	 * Creates a function invocation for the {@code stDevP()} function with {@code DISTINCT} added.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/aggregating/#functions-stdevp">stDevP</a>.
+	 *
+	 * @param expression A numeric expression
+	 * @return A function call for {@code stDevP()}
+	 */
+	public static FunctionInvocation stDevPDistinct(Expression expression) {
+
+		return FunctionInvocation.createDistinct(Aggregates.ST_DEV_P, expression);
 	}
 
 	/**
@@ -409,9 +497,19 @@ public final class Functions {
 	 */
 	public static FunctionInvocation sum(Expression expression) {
 
-		Assert.notNull(expression, "The set of numeric expression for sum is required.");
+		return FunctionInvocation.create(Aggregates.SUM, expression);
+	}
 
-		return new FunctionInvocation("sum", expression);
+	/**
+	 * Creates a function invocation for the {@code sum()} function  with {@code DISTINCT} added.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/aggregating/#functions-sum">sum</a>.
+	 *
+	 * @param expression An expression returning a set of numeric values
+	 * @return A function call for {@code sum()}
+	 */
+	public static FunctionInvocation sumDistinct(Expression expression) {
+
+		return FunctionInvocation.createDistinct(Aggregates.SUM, expression);
 	}
 
 	/**
@@ -439,9 +537,9 @@ public final class Functions {
 		Assert.notNull(end, "The expression for range is required.");
 
 		if (step == null) {
-			return new FunctionInvocation("range", start, end);
+			return FunctionInvocation.create(Scalars.RANGE, start, end);
 		} else {
-			return new FunctionInvocation("range", start, end, step);
+			return FunctionInvocation.create(Scalars.RANGE, start, end, step);
 		}
 	}
 
@@ -454,9 +552,7 @@ public final class Functions {
 	 */
 	public static FunctionInvocation head(Expression expression) {
 
-		Assert.notNull(expression, "The expression for head is required.");
-
-		return new FunctionInvocation("head", expression);
+		return FunctionInvocation.create(Scalars.HEAD, expression);
 	}
 
 	/**
@@ -468,32 +564,26 @@ public final class Functions {
 	 */
 	public static FunctionInvocation last(Expression expression) {
 
-		Assert.notNull(expression, "The expression for last is required.");
-
-		return new FunctionInvocation("last", expression);
+		return FunctionInvocation.create(Scalars.LAST, expression);
 	}
 
 	/**
 	 * Creates a function invocation for {@code nodes{}}.
-	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/list/#functions-nodes">labels</a>.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/list/#functions-nodes">nodes</a>.
 	 *
 	 * @param path The path for which the number of nodes should be retrieved
-	 * @return A function call for {@code nodes()} on a node.
+	 * @return A function call for {@code nodes()} on a path.
 	 * @since 1.1
 	 */
 	public static FunctionInvocation nodes(NamedPath path) {
 
 		Assert.notNull(path, "The path for nodes is required.");
-		return path.getSymbolicName().map(n -> new FunctionInvocation("nodes", n))
-			.orElseThrow(() -> new IllegalArgumentException("The path needs to be named!"));
+		return FunctionInvocation.create(Scalars.NODES,
+			path.getSymbolicName().orElseThrow(() -> new IllegalArgumentException("The path needs to be named!")));
 	}
 
 	public static FunctionInvocation shortestPath(Relationship relationship) {
 
-		Assert.notNull(relationship, "The relationship for shortestPath is required.");
-		return new FunctionInvocation("shortestPath", new Pattern(Collections.singletonList(relationship)));
-	}
-
-	private Functions() {
+		return FunctionInvocation.create(Scalars.SHORTEST_PATH, relationship);
 	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NamedPath.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NamedPath.java
@@ -20,10 +20,10 @@ package org.neo4j.cypherdsl.core;
 
 import static org.apiguardian.api.API.Status.*;
 
-import java.util.Collections;
 import java.util.Optional;
 
 import org.apiguardian.api.API;
+import org.neo4j.cypherdsl.core.FunctionInvocation.FunctionDefinition;
 import org.neo4j.cypherdsl.core.support.Visitable;
 import org.neo4j.cypherdsl.core.support.Visitor;
 
@@ -58,12 +58,12 @@ public final class NamedPath implements PatternElement, Named {
 		return new Builder(name);
 	}
 
-	static OngoingShortestPathDefinitionWithName named(String name, String algorithm) {
+	static OngoingShortestPathDefinitionWithName named(String name, FunctionDefinition algorithm) {
 
 		return new ShortestPathBuilder(SymbolicName.create(name), algorithm);
 	}
 
-	static OngoingShortestPathDefinitionWithName named(SymbolicName name, String algorithm) {
+	static OngoingShortestPathDefinitionWithName named(SymbolicName name, FunctionDefinition algorithm) {
 
 		Assert.notNull(name, "A name is required");
 		return new ShortestPathBuilder(name, algorithm);
@@ -102,16 +102,16 @@ public final class NamedPath implements PatternElement, Named {
 	private static class ShortestPathBuilder implements OngoingShortestPathDefinitionWithName {
 
 		private final SymbolicName name;
-		private final String algorithm;
+		private final FunctionDefinition algorithm;
 
-		private ShortestPathBuilder(SymbolicName name, String algorithm) {
+		private ShortestPathBuilder(SymbolicName name, FunctionDefinition algorithm) {
 			this.name = name;
 			this.algorithm = algorithm;
 		}
 
 		@Override
 		public NamedPath definedBy(Relationship relationship) {
-			return new NamedPath(name, new FunctionInvocation(algorithm, new Pattern(Collections.singletonList(relationship))));
+			return new NamedPath(name, FunctionInvocation.create(algorithm, relationship));
 		}
 	}
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Predicates.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Predicates.java
@@ -19,8 +19,7 @@
 package org.neo4j.cypherdsl.core;
 
 import static org.apiguardian.api.API.Status.*;
-
-import java.util.Collections;
+import static org.neo4j.cypherdsl.core.BuiltInFunctions.Predicates.*;
 
 import org.apiguardian.api.API;
 
@@ -43,9 +42,7 @@ public final class Predicates {
 	 */
 	public static Condition exists(Property property) {
 
-		Assert.notNull(property, "The property for exists() is required.");
-
-		return new BooleanFunctionCondition(new FunctionInvocation("exists", property));
+		return new BooleanFunctionCondition(FunctionInvocation.create(EXISTS, property));
 	}
 
 	/**
@@ -57,10 +54,7 @@ public final class Predicates {
 	 */
 	public static Condition exists(RelationshipPattern pattern) {
 
-		Assert.notNull(pattern, "The pattern for exists() is required.");
-
-		return new BooleanFunctionCondition(
-			new FunctionInvocation("exists", new Pattern(Collections.singletonList(pattern))));
+		return new BooleanFunctionCondition(FunctionInvocation.create(EXISTS, pattern));
 	}
 
 	/**
@@ -84,7 +78,7 @@ public final class Predicates {
 	 */
 	public static OngoingListBasedPredicateFunction all(SymbolicName variable) {
 
-		return new Builder("all", variable);
+		return new Builder(ALL, variable);
 	}
 
 	/**
@@ -108,7 +102,7 @@ public final class Predicates {
 	 */
 	public static OngoingListBasedPredicateFunction any(SymbolicName variable) {
 
-		return new Builder("any", variable);
+		return new Builder(ANY, variable);
 	}
 
 	/**
@@ -132,7 +126,7 @@ public final class Predicates {
 	 */
 	public static OngoingListBasedPredicateFunction none(SymbolicName variable) {
 
-		return new Builder("none", variable);
+		return new Builder(NONE, variable);
 	}
 
 	/**
@@ -156,7 +150,7 @@ public final class Predicates {
 	 */
 	public static OngoingListBasedPredicateFunction single(SymbolicName variable) {
 
-		return new Builder("single", variable);
+		return new Builder(SINGLE, variable);
 	}
 
 	/**
@@ -186,11 +180,11 @@ public final class Predicates {
 	private static class Builder implements OngoingListBasedPredicateFunction,
 		OngoingListBasedPredicateFunctionWithList {
 
-		private final String predicate;
+		private final BuiltInFunctions.Predicates predicate;
 		private final SymbolicName name;
 		private Expression listExpression;
 
-		Builder(String predicate, SymbolicName name) {
+		Builder(BuiltInFunctions.Predicates predicate, SymbolicName name) {
 
 			Assert.notNull(predicate, "The predicate is required");
 			Assert.notNull(name, "The name is required");
@@ -211,7 +205,7 @@ public final class Predicates {
 
 			Assert.notNull(condition, "The condition is required");
 			return new BooleanFunctionCondition(
-				new FunctionInvocation(predicate, new ListPredicate(name, listExpression, new Where(condition))));
+				FunctionInvocation.create(predicate, new ListPredicate(name, listExpression, new Where(condition))));
 		}
 	}
 

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
@@ -255,7 +255,8 @@ class CypherIT {
 					.where(Cypher.property("a", "name").isEqualTo(Cypher.literalOf("Alice")))
 					.returning(
 						Functions.size(
-							Cypher.anyNode("a").relationshipTo(Cypher.anyNode()).relationshipTo(Cypher.anyNode())).as("fof"))
+							Cypher.anyNode("a").relationshipTo(Cypher.anyNode()).relationshipTo(Cypher.anyNode()))
+							.as("fof"))
 					.build();
 
 				assertThat(cypherRenderer.render(statement))
@@ -627,7 +628,8 @@ class CypherIT {
 					Cypher.property("n", "a").isEqualTo(Cypher.literalOf("A")))
 					.with("n");
 			Function<ExposesMatch, ExposesReturning> step2Supplier =
-				previous -> previous.match(Cypher.anyNode("n").relationshipTo(Cypher.node("S2").named("m"), "SOMEHOW_RELATED"))
+				previous -> previous
+					.match(Cypher.anyNode("n").relationshipTo(Cypher.node("S2").named("m"), "SOMEHOW_RELATED"))
 					.with("n", "m");
 
 			Statement statement = step1Supplier.andThen(step2Supplier).apply(Statement.builder()).returning("n", "m")
@@ -685,6 +687,15 @@ class CypherIT {
 		}
 
 		@Test
+		void inReturnClauseWithDistinct() {
+			Statement statement = Cypher.match(userNode).returning(Functions.countDistinct(userNode)).build();
+
+			assertThat(cypherRenderer.render(statement))
+				.isEqualTo(
+					"MATCH (u:`User`) RETURN count(DISTINCT u)");
+		}
+
+		@Test
 		void aliasedInReturnClause() {
 			Statement statement = Cypher.match(userNode).returning(Functions.count(userNode).as("cnt")).build();
 
@@ -696,7 +707,8 @@ class CypherIT {
 		@Test
 		void shouldSupportMoreThanOneArgument() {
 			Statement statement = Cypher.match(userNode)
-				.returning(Functions.coalesce(userNode.property("a"), userNode.property("b"), Cypher.literalOf("¯\\_(ツ)_/¯")))
+				.returning(
+					Functions.coalesce(userNode.property("a"), userNode.property("b"), Cypher.literalOf("¯\\_(ツ)_/¯")))
 				.build();
 
 			assertThat(cypherRenderer.render(statement))
@@ -717,8 +729,11 @@ class CypherIT {
 
 		@Test // GH-257
 		void functionsBasedOnRelationships() {
-			Relationship relationship = Cypher.node("Person").named("bacon").withProperties("name", Cypher.literalOf("Kevin Bacon"))
-				.relationshipBetween(Cypher.node("Person").named("meg").withProperties("name", Cypher.literalOf("Meg Ryan"))).unbounded();
+			Relationship relationship = Cypher.node("Person").named("bacon")
+				.withProperties("name", Cypher.literalOf("Kevin Bacon"))
+				.relationshipBetween(
+					Cypher.node("Person").named("meg").withProperties("name", Cypher.literalOf("Meg Ryan")))
+				.unbounded();
 			Statement statement = Cypher.match(Cypher.shortestPath("p").definedBy(relationship)).returning("p").build();
 
 			assertThat(cypherRenderer.render(statement))
@@ -790,8 +805,9 @@ class CypherIT {
 			Statement statement;
 
 			statement = Cypher.match(userNode)
-				.where(org.neo4j.cypherdsl.core.Conditions.isTrue().or(org.neo4j.cypherdsl.core.Conditions.isFalse()).and(
-					org.neo4j.cypherdsl.core.Conditions.isTrue()))
+				.where(
+					org.neo4j.cypherdsl.core.Conditions.isTrue().or(org.neo4j.cypherdsl.core.Conditions.isFalse()).and(
+						org.neo4j.cypherdsl.core.Conditions.isTrue()))
 				.returning(userNode)
 				.build();
 
@@ -799,8 +815,9 @@ class CypherIT {
 				.isEqualTo("MATCH (u:`User`) WHERE ((true OR false) AND true) RETURN u");
 
 			statement = Cypher.match(userNode)
-				.where(org.neo4j.cypherdsl.core.Conditions.isTrue().or(org.neo4j.cypherdsl.core.Conditions.isFalse()).and(
-					org.neo4j.cypherdsl.core.Conditions.isTrue()))
+				.where(
+					org.neo4j.cypherdsl.core.Conditions.isTrue().or(org.neo4j.cypherdsl.core.Conditions.isFalse()).and(
+						org.neo4j.cypherdsl.core.Conditions.isTrue()))
 				.or(org.neo4j.cypherdsl.core.Conditions.isFalse())
 				.returning(userNode)
 				.build();
@@ -810,8 +827,9 @@ class CypherIT {
 					"MATCH (u:`User`) WHERE (((true OR false) AND true) OR false) RETURN u");
 
 			statement = Cypher.match(userNode)
-				.where(org.neo4j.cypherdsl.core.Conditions.isTrue().or(org.neo4j.cypherdsl.core.Conditions.isFalse()).and(
-					org.neo4j.cypherdsl.core.Conditions.isTrue()))
+				.where(
+					org.neo4j.cypherdsl.core.Conditions.isTrue().or(org.neo4j.cypherdsl.core.Conditions.isFalse()).and(
+						org.neo4j.cypherdsl.core.Conditions.isTrue()))
 				.or(org.neo4j.cypherdsl.core.Conditions.isFalse())
 				.and(org.neo4j.cypherdsl.core.Conditions.isFalse())
 				.returning(userNode)
@@ -821,8 +839,9 @@ class CypherIT {
 				.isEqualTo("MATCH (u:`User`) WHERE ((((true OR false) AND true) OR false) AND false) RETURN u");
 
 			statement = Cypher.match(userNode)
-				.where(org.neo4j.cypherdsl.core.Conditions.isTrue().or(org.neo4j.cypherdsl.core.Conditions.isFalse()).and(
-					org.neo4j.cypherdsl.core.Conditions.isTrue()))
+				.where(
+					org.neo4j.cypherdsl.core.Conditions.isTrue().or(org.neo4j.cypherdsl.core.Conditions.isFalse()).and(
+						org.neo4j.cypherdsl.core.Conditions.isTrue()))
 				.or(org.neo4j.cypherdsl.core.Conditions.isFalse().and(org.neo4j.cypherdsl.core.Conditions.isTrue()))
 				.returning(userNode)
 				.build();
@@ -831,8 +850,9 @@ class CypherIT {
 				.isEqualTo("MATCH (u:`User`) WHERE ((true OR false) AND true OR (false AND true)) RETURN u");
 
 			statement = Cypher.match(userNode)
-				.where(org.neo4j.cypherdsl.core.Conditions.isTrue().or(org.neo4j.cypherdsl.core.Conditions.isFalse()).and(
-					org.neo4j.cypherdsl.core.Conditions.isTrue()))
+				.where(
+					org.neo4j.cypherdsl.core.Conditions.isTrue().or(org.neo4j.cypherdsl.core.Conditions.isFalse()).and(
+						org.neo4j.cypherdsl.core.Conditions.isTrue()))
 				.or(org.neo4j.cypherdsl.core.Conditions.isFalse().and(org.neo4j.cypherdsl.core.Conditions.isTrue()))
 				.and(org.neo4j.cypherdsl.core.Conditions.isTrue())
 				.returning(userNode)
@@ -842,8 +862,9 @@ class CypherIT {
 				.isEqualTo("MATCH (u:`User`) WHERE ((true OR false) AND true OR (false AND true) AND true) RETURN u");
 
 			statement = Cypher.match(userNode)
-				.where(org.neo4j.cypherdsl.core.Conditions.isTrue().or(org.neo4j.cypherdsl.core.Conditions.isFalse()).and(
-					org.neo4j.cypherdsl.core.Conditions.isTrue()))
+				.where(
+					org.neo4j.cypherdsl.core.Conditions.isTrue().or(org.neo4j.cypherdsl.core.Conditions.isFalse()).and(
+						org.neo4j.cypherdsl.core.Conditions.isTrue()))
 				.or(org.neo4j.cypherdsl.core.Conditions.isFalse().or(org.neo4j.cypherdsl.core.Conditions.isTrue()))
 				.returning(userNode)
 				.build();
@@ -852,9 +873,10 @@ class CypherIT {
 				.isEqualTo("MATCH (u:`User`) WHERE ((true OR false) AND true OR (false OR true)) RETURN u");
 
 			statement = Cypher.match(userNode)
-				.where(org.neo4j.cypherdsl.core.Conditions.isTrue().or(org.neo4j.cypherdsl.core.Conditions.isFalse()).and(
-					org.neo4j.cypherdsl.core.Conditions.isTrue()).or(
-					org.neo4j.cypherdsl.core.Conditions.isFalse().or(org.neo4j.cypherdsl.core.Conditions.isTrue())))
+				.where(
+					org.neo4j.cypherdsl.core.Conditions.isTrue().or(org.neo4j.cypherdsl.core.Conditions.isFalse()).and(
+						org.neo4j.cypherdsl.core.Conditions.isTrue()).or(
+						org.neo4j.cypherdsl.core.Conditions.isFalse().or(org.neo4j.cypherdsl.core.Conditions.isTrue())))
 				.returning(userNode)
 				.build();
 
@@ -1127,14 +1149,16 @@ class CypherIT {
 
 			@Test
 			void doc3651And() {
-				Node timothy = Cypher.node("Person").named("timothy").withProperties("name", Cypher.literalOf("Timothy"));
+				Node timothy = Cypher.node("Person").named("timothy")
+					.withProperties("name", Cypher.literalOf("Timothy"));
 				Node other = Cypher.node("Person").named("other");
 
 				Statement statement;
 
 				String expected = "MATCH (timothy:`Person` {name: 'Timothy'}), (other:`Person`) WHERE (other.name IN ['Andy', 'Peter'] AND (timothy)<--(other)) RETURN other.name, other.age";
 				statement = Cypher.match(timothy, other)
-					.where(other.property("name").in(Cypher.listOf(Cypher.literalOf("Andy"), Cypher.literalOf("Peter"))))
+					.where(
+						other.property("name").in(Cypher.listOf(Cypher.literalOf("Andy"), Cypher.literalOf("Peter"))))
 					.and(timothy.relationshipFrom(other))
 					.returning(other.property("name"), other.property("age"))
 					.build();
@@ -1151,14 +1175,16 @@ class CypherIT {
 
 			@Test
 			void doc3651Or() {
-				Node timothy = Cypher.node("Person").named("timothy").withProperties("name", Cypher.literalOf("Timothy"));
+				Node timothy = Cypher.node("Person").named("timothy")
+					.withProperties("name", Cypher.literalOf("Timothy"));
 				Node other = Cypher.node("Person").named("other");
 
 				Statement statement;
 
 				String expected = "MATCH (timothy:`Person` {name: 'Timothy'}), (other:`Person`) WHERE (other.name IN ['Andy', 'Peter'] OR (timothy)<--(other)) RETURN other.name, other.age";
 				statement = Cypher.match(timothy, other)
-					.where(other.property("name").in(Cypher.listOf(Cypher.literalOf("Andy"), Cypher.literalOf("Peter"))))
+					.where(
+						other.property("name").in(Cypher.listOf(Cypher.literalOf("Andy"), Cypher.literalOf("Peter"))))
 					.or(timothy.relationshipFrom(other))
 					.returning(other.property("name"), other.property("age"))
 					.build();
@@ -1175,7 +1201,8 @@ class CypherIT {
 
 			@Test
 			void doc3651XOr() {
-				Node timothy = Cypher.node("Person").named("timothy").withProperties("name", Cypher.literalOf("Timothy"));
+				Node timothy = Cypher.node("Person").named("timothy")
+					.withProperties("name", Cypher.literalOf("Timothy"));
 				Node other = Cypher.node("Person").named("other");
 
 				Statement statement;
@@ -1215,7 +1242,9 @@ class CypherIT {
 				Statement statement;
 
 				statement = Cypher.match(person)
-					.where(person.relationshipBetween(Cypher.anyNode().withProperties("name", Cypher.literalOf("Timothy")), "KNOWS"))
+					.where(person
+						.relationshipBetween(Cypher.anyNode().withProperties("name", Cypher.literalOf("Timothy")),
+							"KNOWS"))
 					.returning(person.property("name"), person.property("age"))
 					.build();
 
@@ -1244,7 +1273,8 @@ class CypherIT {
 			@Test
 			void afterWith() {
 
-				Node timothy = Cypher.node("Person").named("timothy").withProperties("name", Cypher.literalOf("Timothy"));
+				Node timothy = Cypher.node("Person").named("timothy")
+					.withProperties("name", Cypher.literalOf("Timothy"));
 				Node other = Cypher.node("Person").named("other");
 
 				Statement statement;
@@ -1252,7 +1282,8 @@ class CypherIT {
 				String expected = "MATCH (timothy:`Person` {name: 'Timothy'}), (other:`Person`) WITH timothy, other WHERE (other.name IN ['Andy', 'Peter'] AND (timothy)<--(other)) RETURN other.name, other.age";
 				statement = Cypher.match(timothy, other)
 					.with(timothy, other)
-					.where(other.property("name").in(Cypher.listOf(Cypher.literalOf("Andy"), Cypher.literalOf("Peter"))))
+					.where(
+						other.property("name").in(Cypher.listOf(Cypher.literalOf("Andy"), Cypher.literalOf("Peter"))))
 					.and(timothy.relationshipFrom(other))
 					.returning(other.property("name"), other.property("age"))
 					.build();
@@ -2063,13 +2094,13 @@ class CypherIT {
 			Statement statement;
 			Node n = Cypher.anyNode("n");
 			statement = Cypher.match(n)
-					.where(Functions.distance(n.property("location"), Functions.point(Cypher.parameter("point.point")))
-							.gt(Cypher.parameter("point.distance")))
-					.returning(n)
-					.build();
+				.where(Functions.distance(n.property("location"), Functions.point(Cypher.parameter("point.point")))
+					.gt(Cypher.parameter("point.distance")))
+				.returning(n)
+				.build();
 
 			assertThat(cypherRenderer.render(statement))
-					.isEqualTo("MATCH (n) WHERE distance(n.location, point($point.point)) > $point.distance RETURN n");
+				.isEqualTo("MATCH (n) WHERE distance(n.location, point($point.point)) > $point.distance RETURN n");
 		}
 	}
 
@@ -2106,7 +2137,8 @@ class CypherIT {
 		@Test
 		void nestedProperties() {
 
-			Node nodeWithProperties = Cypher.node("Test").withProperties("outer", Cypher.mapOf("a", Cypher.literalOf("b")));
+			Node nodeWithProperties = Cypher.node("Test")
+				.withProperties("outer", Cypher.mapOf("a", Cypher.literalOf("b")));
 
 			Statement statement;
 			statement = Cypher.match(nodeWithProperties)
@@ -2142,7 +2174,8 @@ class CypherIT {
 
 			final Node rootNode = Cypher.anyNode("n");
 			final SymbolicName label = Cypher.name("label");
-			final Statement statement = Cypher.match(rootNode).where(rootNode.internalId().isEqualTo(Cypher.literalOf(1)))
+			final Statement statement = Cypher.match(rootNode)
+				.where(rootNode.internalId().isEqualTo(Cypher.literalOf(1)))
 				.unwind(rootNode.labels()).as("label")
 				.with(label).where(label.in(Cypher.parameter("fixedLabels")).not())
 				.returning(Functions.collect(label).as("labels")).build();
@@ -2361,21 +2394,24 @@ class CypherIT {
 				Node movie = Cypher.node("Movie").named("movie");
 
 				statement = Cypher
-					.match(actor.withProperties("name", Cypher.literalOf("Tom Hanks")).relationshipTo(movie, "ACTED_IN"))
+					.match(
+						actor.withProperties("name", Cypher.literalOf("Tom Hanks")).relationshipTo(movie, "ACTED_IN"))
 					.returning(actor
 						.project("name", "realName", "movies", Functions.collect(movie.project("title", "released"))))
 					.build();
 				assertThat(cypherRenderer.render(statement)).isEqualTo(expected);
 
 				statement = Cypher
-					.match(actor.withProperties("name", Cypher.literalOf("Tom Hanks")).relationshipTo(movie, "ACTED_IN"))
+					.match(
+						actor.withProperties("name", Cypher.literalOf("Tom Hanks")).relationshipTo(movie, "ACTED_IN"))
 					.returning(actor.project("name", "realName", "movies",
 						Functions.collect(movie.project(movie.property("title"), movie.property("released")))))
 					.build();
 				assertThat(cypherRenderer.render(statement)).isEqualTo(expected);
 
 				statement = Cypher
-					.match(actor.withProperties("name", Cypher.literalOf("Tom Hanks")).relationshipTo(movie, "ACTED_IN"))
+					.match(
+						actor.withProperties("name", Cypher.literalOf("Tom Hanks")).relationshipTo(movie, "ACTED_IN"))
 					.returning(actor.project("name", "realName", "movies",
 						Functions.collect(movie.project("title", "year", movie.property("released")))))
 					.build();
@@ -2504,7 +2540,8 @@ class CypherIT {
 		void orderOnWithShouldWork() {
 			Statement statement = Cypher
 				.match(
-					Cypher.node("Movie").named("m").relationshipFrom(Cypher.node("Person").named("p"), "ACTED_IN").named("r")
+					Cypher.node("Movie").named("m").relationshipFrom(Cypher.node("Person").named("p"), "ACTED_IN")
+						.named("r")
 				)
 				.with(Cypher.name("m"), Cypher.name("p"))
 				.orderBy(
@@ -2521,7 +2558,8 @@ class CypherIT {
 		void concatenatedOrdering() {
 			Statement statement;
 			statement = Cypher.match(
-				Cypher.node("Movie").named("m").relationshipFrom(Cypher.node("Person").named("p"), "ACTED_IN").named("r"))
+				Cypher.node("Movie").named("m").relationshipFrom(Cypher.node("Person").named("p"), "ACTED_IN")
+					.named("r"))
 				.with(Cypher.name("m"), Cypher.name("p")).orderBy(Cypher.property("m", "title")).ascending()
 				.and(Cypher.property("p", "name")).ascending()
 				.returning(Cypher.property("m", "title").as("movie"),
@@ -2541,7 +2579,8 @@ class CypherIT {
 			SymbolicName name = Cypher.name("a");
 			Statement statement = Cypher.returning(
 				Cypher.listWith(name)
-					.in(Cypher.listOf(Cypher.literalOf(1), Cypher.literalOf(2), Cypher.literalOf(3), Cypher.literalOf(4)))
+					.in(Cypher
+						.listOf(Cypher.literalOf(1), Cypher.literalOf(2), Cypher.literalOf(3), Cypher.literalOf(4)))
 					.returning()).build();
 			assertThat(cypherRenderer.render(statement))
 				.isEqualTo("RETURN [a IN [1, 2, 3, 4]]");
@@ -2553,7 +2592,8 @@ class CypherIT {
 			SymbolicName name = Cypher.name("a");
 			Statement statement = Cypher.returning(
 				Cypher.listWith(name)
-					.in(Cypher.listOf(Cypher.literalOf(1), Cypher.literalOf(2), Cypher.literalOf(3), Cypher.literalOf(4)))
+					.in(Cypher
+						.listOf(Cypher.literalOf(1), Cypher.literalOf(2), Cypher.literalOf(3), Cypher.literalOf(4)))
 					.returning(name.remainder(Cypher.literalOf(2)))).build();
 			assertThat(cypherRenderer.render(statement))
 				.isEqualTo("RETURN [a IN [1, 2, 3, 4] | (a % 2)]");
@@ -2565,7 +2605,8 @@ class CypherIT {
 			SymbolicName name = Cypher.name("a");
 			Statement statement = Cypher.returning(
 				Cypher.listWith(name)
-					.in(Cypher.listOf(Cypher.literalOf(1), Cypher.literalOf(2), Cypher.literalOf(3), Cypher.literalOf(4)))
+					.in(Cypher
+						.listOf(Cypher.literalOf(1), Cypher.literalOf(2), Cypher.literalOf(3), Cypher.literalOf(4)))
 					.where(name.gt(Cypher.literalOf(2)))
 					.returning()).build();
 			assertThat(cypherRenderer.render(statement))
@@ -2578,7 +2619,8 @@ class CypherIT {
 			SymbolicName name = Cypher.name("a");
 			Statement statement = Cypher.returning(
 				Cypher.listWith(name)
-					.in(Cypher.listOf(Cypher.literalOf(1), Cypher.literalOf(2), Cypher.literalOf(3), Cypher.literalOf(4)))
+					.in(Cypher
+						.listOf(Cypher.literalOf(1), Cypher.literalOf(2), Cypher.literalOf(3), Cypher.literalOf(4)))
 					.where(name.gt(Cypher.literalOf(2)))
 					.returning(name.remainder(Cypher.literalOf(2)))).build();
 			assertThat(cypherRenderer.render(statement))
@@ -2643,7 +2685,8 @@ class CypherIT {
 
 			statement = Cypher.match(a)
 				.returning(
-					Cypher.listBasedOn(a.relationshipBetween(b)).where(b.hasLabels("Movie")).returning(b.property("released"))
+					Cypher.listBasedOn(a.relationshipBetween(b)).where(b.hasLabels("Movie"))
+						.returning(b.property("released"))
 						.as("years"))
 				.build();
 			assertThat(cypherRenderer.render(statement))
@@ -2890,10 +2933,11 @@ class CypherIT {
 
 			Statement s = Cypher.match(r.relationshipTo(o, "FOR"))
 				.where(r.hasLabels("LastResume").not())
-				.and(Functions.coalesce(o.property("valid_only"), Cypher.literalFalse()).isEqualTo(Cypher.literalFalse())
-					.and(r.hasLabels("InvalidStatus").not())
-					.or(o.property("valid_only").isTrue()
-						.and(r.hasLabels("InvalidStatus"))))
+				.and(
+					Functions.coalesce(o.property("valid_only"), Cypher.literalFalse()).isEqualTo(Cypher.literalFalse())
+						.and(r.hasLabels("InvalidStatus").not())
+						.or(o.property("valid_only").isTrue()
+							.and(r.hasLabels("InvalidStatus"))))
 				.returningDistinct(r, o)
 				.build();
 
@@ -2910,10 +2954,11 @@ class CypherIT {
 
 			Statement s = Cypher.match(r.relationshipFrom(u, "HAS"))
 				.where(r.hasLabels("LastResume").not())
-				.and(Functions.coalesce(o.property("valid_only"), Cypher.literalFalse()).isEqualTo(Cypher.literalFalse())
-					.and(r.hasLabels("InvalidStatus").not())
-					.or(o.property("valid_only").isTrue()
-						.and(r.hasLabels("ValidStatus")))
+				.and(
+					Functions.coalesce(o.property("valid_only"), Cypher.literalFalse()).isEqualTo(Cypher.literalFalse())
+						.and(r.hasLabels("InvalidStatus").not())
+						.or(o.property("valid_only").isTrue()
+							.and(r.hasLabels("ValidStatus")))
 				)
 				.and(r.property("is_internship").isTrue()
 					.and(Functions.size(r.relationshipTo(Cypher.anyNode(), "PART_OF")).isEmpty())
@@ -3094,6 +3139,17 @@ class CypherIT {
 				.build();
 			assertThat(cypherRenderer.render(statement)).isEqualTo(expected);
 		}
+
+		@Test
+		void gh44() {
+
+			Node n = Cypher.anyNode("n");
+			Statement statement = Cypher.match(n)
+				.returning(Functions.collectDistinct(n).as("distinctNodes"))
+				.build();
+			assertThat(cypherRenderer.render(statement))
+				.isEqualTo("MATCH (n) RETURN collect(DISTINCT n) AS distinctNodes");
+		}
 	}
 
 	@Nested
@@ -3104,8 +3160,8 @@ class CypherIT {
 
 			// See docs
 			NamedPath p = Cypher.path("p").definedBy(
-					Cypher.anyNode("michael").withProperties("name", Cypher.literalOf("Michael Douglas"))
-						.relationshipTo(Cypher.anyNode()));
+				Cypher.anyNode("michael").withProperties("name", Cypher.literalOf("Michael Douglas"))
+					.relationshipTo(Cypher.anyNode()));
 			Statement statement = Cypher.match(p).returning(p.getRequiredSymbolicName()).build();
 
 			assertThat(cypherRenderer.render(statement))
@@ -3119,15 +3175,18 @@ class CypherIT {
 		@Test
 		void allShouldWork() {
 
-			NamedPath p = Cypher.path("p").definedBy(Cypher.anyNode("a").relationshipTo(Cypher.anyNode("b")).min(1).max(3));
+			NamedPath p = Cypher.path("p")
+				.definedBy(Cypher.anyNode("a").relationshipTo(Cypher.anyNode("b")).min(1).max(3));
 			Statement statement = Cypher.match(p)
 				.where(Cypher.property("a", "name").isEqualTo(Cypher.literalOf("Alice")))
 				.and(Cypher.property("b", "name").isEqualTo(Cypher.literalOf("Daniel")))
-				.and(Predicates.all("x").in(Functions.nodes(p)).where(Cypher.property("x", "age").gt(Cypher.literalOf(30))))
+				.and(Predicates.all("x").in(Functions.nodes(p))
+					.where(Cypher.property("x", "age").gt(Cypher.literalOf(30))))
 				.returning(p).build();
 
 			assertThat(cypherRenderer.render(statement))
-				.isEqualTo("MATCH p = (a)-[*1..3]->(b) WHERE (a.name = 'Alice' AND b.name = 'Daniel' AND all(x IN nodes(p) WHERE x.age > 30)) RETURN p");
+				.isEqualTo(
+					"MATCH p = (a)-[*1..3]->(b) WHERE (a.name = 'Alice' AND b.name = 'Daniel' AND all(x IN nodes(p) WHERE x.age > 30)) RETURN p");
 		}
 
 		@Test
@@ -3136,25 +3195,30 @@ class CypherIT {
 			Node a = Cypher.anyNode("a");
 			Statement statement = Cypher.match(a)
 				.where(Cypher.property("a", "name").isEqualTo(Cypher.literalOf("Eskil")))
-				.and(Predicates.any("x").in(a.property("array")).where(Cypher.name("x").isEqualTo(Cypher.literalOf("one"))))
+				.and(Predicates.any("x").in(a.property("array"))
+					.where(Cypher.name("x").isEqualTo(Cypher.literalOf("one"))))
 				.returning(a.property("name"), a.property("array")).build();
 
 			assertThat(cypherRenderer.render(statement))
-				.isEqualTo("MATCH (a) WHERE (a.name = 'Eskil' AND any(x IN a.array WHERE x = 'one')) RETURN a.name, a.array");
+				.isEqualTo(
+					"MATCH (a) WHERE (a.name = 'Eskil' AND any(x IN a.array WHERE x = 'one')) RETURN a.name, a.array");
 		}
 
 		@Test
 		void noneShouldWork() {
 
-			NamedPath p = Cypher.path("p").definedBy(Cypher.anyNode("a").relationshipTo(Cypher.anyNode("b")).min(1).max(3));
+			NamedPath p = Cypher.path("p")
+				.definedBy(Cypher.anyNode("a").relationshipTo(Cypher.anyNode("b")).min(1).max(3));
 			Statement statement = Cypher.match(p)
 				.where(Cypher.property("a", "name").isEqualTo(Cypher.literalOf("Alice")))
 				.and(Predicates
-					.none("x").in(Functions.nodes(p)).where(Cypher.property("x", "age").isEqualTo(Cypher.literalOf(25))))
+					.none("x").in(Functions.nodes(p))
+					.where(Cypher.property("x", "age").isEqualTo(Cypher.literalOf(25))))
 				.returning(p).build();
 
 			assertThat(cypherRenderer.render(statement))
-				.isEqualTo("MATCH p = (a)-[*1..3]->(b) WHERE (a.name = 'Alice' AND none(x IN nodes(p) WHERE x.age = 25)) RETURN p");
+				.isEqualTo(
+					"MATCH p = (a)-[*1..3]->(b) WHERE (a.name = 'Alice' AND none(x IN nodes(p) WHERE x.age = 25)) RETURN p");
 		}
 
 		@Test
@@ -3168,7 +3232,8 @@ class CypherIT {
 				.returning(p).build();
 
 			assertThat(cypherRenderer.render(statement))
-				.isEqualTo("MATCH p = (n)-->(b) WHERE (n.name = 'Alice' AND single(var IN nodes(p) WHERE var.eyes = 'blue')) RETURN p");
+				.isEqualTo(
+					"MATCH p = (n)-->(b) WHERE (n.name = 'Alice' AND single(var IN nodes(p) WHERE var.eyes = 'blue')) RETURN p");
 		}
 	}
 }

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/FunctionsIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/FunctionsIT.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.core;
+
+import static org.neo4j.cypherdsl.core.Cypher.*;
+
+import java.util.stream.Stream;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.neo4j.cypherdsl.core.renderer.Renderer;
+
+/**
+ * @author Michael J. Simons
+ */
+class FunctionsIT {
+
+	private static final Renderer cypherRenderer = Renderer.getDefaultRenderer();
+
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("functionsToTest")
+	void functionShouldBeRenderedAsExpected(FunctionInvocation functionInvocation, String expected) {
+
+		Assertions.assertThat(cypherRenderer.render(Cypher.returning(functionInvocation).build())).isEqualTo(expected);
+	}
+
+	private static Stream<Arguments> functionsToTest() {
+		Node n = Cypher.node("Node").named("n");
+		Node m = Cypher.node("Node2").named("m");
+		Relationship r = n.relationshipTo(m).named("r");
+		Expression e1 = Cypher.name("e1");
+		Expression e2 = Cypher.name("e2");
+		FunctionInvocation p1 = Functions.point(Cypher.mapOf("latitude", literalOf(1), "longitude", literalOf(2)));
+		FunctionInvocation p2 = Functions.point(Cypher.mapOf("latitude", literalOf(3), "longitude", literalOf(4)));
+
+		// NOTE: Not all of those return valid Cypher statements. They are used only for integration testing the function calls so far.
+		return Stream.of(
+			Arguments.of(Functions.id(n), "RETURN id(n)"),
+			Arguments.of(Functions.id(r), "RETURN id(r)"),
+			Arguments.of(Functions.labels(n), "RETURN labels(n)"),
+			Arguments.of(Functions.type(r), "RETURN type(r)"),
+			Arguments.of(Functions.count(n), "RETURN count(n)"),
+			Arguments.of(Functions.countDistinct(n), "RETURN count(DISTINCT n)"),
+			Arguments.of(Functions.count(e1), "RETURN count(e1)"),
+			Arguments.of(Functions.countDistinct(e1), "RETURN count(DISTINCT e1)"),
+			Arguments.of(Functions.coalesce(e1, e2), "RETURN coalesce(e1, e2)"),
+			Arguments.of(Functions.toLower(e1), "RETURN toLower(e1)"),
+			Arguments.of(Functions.size(e1), "RETURN size(e1)"),
+			Arguments.of(Functions.size(r), "RETURN size((n:`Node`)-[r]->(m:`Node2`))"),
+			Arguments.of(Functions.exists(e1), "RETURN exists(e1)"),
+			Arguments.of(Functions.distance(p1, p2),
+				"RETURN distance(point({latitude: 1, longitude: 2}), point({latitude: 3, longitude: 4}))"),
+			Arguments.of(Functions.avg(e1), "RETURN avg(e1)"),
+			Arguments.of(Functions.avgDistinct(e1), "RETURN avg(DISTINCT e1)"),
+			Arguments.of(Functions.collect(e1), "RETURN collect(e1)"),
+			Arguments.of(Functions.collectDistinct(e1), "RETURN collect(DISTINCT e1)"),
+			Arguments.of(Functions.collect(n), "RETURN collect(n)"),
+			Arguments.of(Functions.collectDistinct(n), "RETURN collect(DISTINCT n)"),
+			Arguments.of(Functions.max(e1), "RETURN max(e1)"),
+			Arguments.of(Functions.maxDistinct(e1), "RETURN max(DISTINCT e1)"),
+			Arguments.of(Functions.min(e1), "RETURN min(e1)"),
+			Arguments.of(Functions.minDistinct(e1), "RETURN min(DISTINCT e1)"),
+			Arguments.of(Functions.percentileCont(e1, 0.4), "RETURN percentileCont(e1, 0.4)"),
+			Arguments.of(Functions.percentileContDistinct(e1, 0.4), "RETURN percentileCont(DISTINCT e1, 0.4)"),
+			Arguments.of(Functions.percentileDisc(e1, 0.4), "RETURN percentileDisc(e1, 0.4)"),
+			Arguments.of(Functions.percentileDiscDistinct(e1, 0.4), "RETURN percentileDisc(DISTINCT e1, 0.4)"),
+			Arguments.of(Functions.stDev(e1), "RETURN stDev(e1)"),
+			Arguments.of(Functions.stDevDistinct(e1), "RETURN stDev(DISTINCT e1)"),
+			Arguments.of(Functions.stDevP(e1), "RETURN stDevP(e1)"),
+			Arguments.of(Functions.stDevPDistinct(e1), "RETURN stDevP(DISTINCT e1)"),
+			Arguments.of(Functions.sum(e1), "RETURN sum(e1)"),
+			Arguments.of(Functions.sumDistinct(e1), "RETURN sum(DISTINCT e1)"),
+			Arguments.of(Functions.range(literalOf(1), literalOf(3)), "RETURN range(1, 3)"),
+			Arguments.of(Functions.range(literalOf(1), literalOf(3), literalOf(2)), "RETURN range(1, 3, 2)"),
+			Arguments.of(Functions.head(e1), "RETURN head(e1)"),
+			Arguments.of(Functions.last(e1), "RETURN last(e1)"),
+			Arguments.of(Functions.nodes(Cypher.path("p").definedBy(r)), "RETURN nodes(p)"),
+			Arguments.of(Functions.shortestPath(r), "RETURN shortestPath((n:`Node`)-[r]->(m:`Node2`))")
+		);
+	}
+}

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/FunctionsTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/FunctionsTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Answers;
 
 /**
  * @author Michael J. Simons
@@ -44,14 +45,15 @@ class FunctionsTest {
 		@Test
 		void preconditionsShouldBeAsserted() {
 
+			String message = "The expression for coalesce() is required.";
 			assertThatIllegalArgumentException().isThrownBy(() -> Functions.coalesce((Expression[]) null))
-				.withMessage("At least one expression is required.");
+				.withMessage(message);
 
 			assertThatIllegalArgumentException().isThrownBy(() -> Functions.coalesce(new Expression[0]))
-				.withMessage("At least one expression is required.");
+				.withMessage(message);
 
 			assertThatIllegalArgumentException().isThrownBy(() -> Functions.coalesce(new Expression[] { null }))
-				.withMessage("At least one expression is required.");
+				.withMessage(message);
 		}
 
 		@Test
@@ -83,7 +85,7 @@ class FunctionsTest {
 		Method method = findMethod(Functions.class, functionName, argumentType);
 		assertThatIllegalArgumentException()
 			.isThrownBy(() -> invokeMethod(method, null, (Expression) null))
-			.withMessageEndingWith("is required.");
+			.withMessageMatching("The (node|relationship|expression|pattern) for " + functionName + "\\(\\) is required.");
 	}
 
 	@ParameterizedTest
@@ -91,7 +93,7 @@ class FunctionsTest {
 	void functionInvocationsShouldBeCreated(String functionName, Class<?> argumentType) {
 
 		Method method = findMethod(Functions.class, functionName, argumentType);
-		FunctionInvocation invocation = (FunctionInvocation) invokeMethod(method, null, mock(argumentType));
+		FunctionInvocation invocation = (FunctionInvocation) invokeMethod(method, null, mock(argumentType, Answers.RETURNS_DEEP_STUBS));
 		assertThat(invocation).hasFieldOrPropertyWithValue(FUNCTION_NAME_FIELD, functionName);
 	}
 }


### PR DESCRIPTION
This introduces a formal `FunctionDefinition` that contains the implementation name of the function and a flag whether its an aggregate or not.

This definition is used for the build in scalars, aggregates and predicates now. It can be used in the future for user defined functions (udfs) as well. Furthermore it could cater for better static definitions, like argument cardinality and type.

It also adds a test for and closes #44.