### PR TITLE
Avoid star and static imports.

### DIFF
--- a/etc/checkstyle/config.xml
+++ b/etc/checkstyle/config.xml
@@ -56,6 +56,11 @@
         <module name="com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck" />
 
         <!-- Imports -->
+        <module name="com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck" />
+        <module name="com.puppycrawl.tools.checkstyle.checks.imports.AvoidStaticImportCheck">
+            <property name="excludes"
+                      value="org.apiguardian.api.API.Status.*, org.assertj.core.api.Assertions.*, org.junit.Assert.*, org.junit.Assume.*, org.junit.internal.matchers.ThrowableMessageMatcher.*, org.hamcrest.CoreMatchers.*, org.hamcrest.Matchers.*, org.mockito.Mockito.*" />
+        </module>
         <module name="com.puppycrawl.tools.checkstyle.checks.imports.IllegalImportCheck">
             <property name="regexp" value="true" />
             <property name="illegalPkgs"

--- a/neo4j-cypher-dsl-examples/src/test/java/org/neo4j/cypherdsl/examples/core/CypherDSLExamplesTest.java
+++ b/neo4j-cypher-dsl-examples/src/test/java/org/neo4j/cypherdsl/examples/core/CypherDSLExamplesTest.java
@@ -19,7 +19,7 @@
 package org.neo4j.cypherdsl.examples.core;
 
 // tag::cypher-dsl-imports[]
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 // end::cypher-dsl-imports[]
 

--- a/neo4j-cypher-dsl-examples/src/test/java/org/neo4j/cypherdsl/examples/core/IssuesExamplesTest.java
+++ b/neo4j-cypher-dsl-examples/src/test/java/org/neo4j/cypherdsl/examples/core/IssuesExamplesTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.examples.core;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import org.neo4j.cypherdsl.core.Cypher;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Aliased.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Aliased.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AliasedExpression.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AliasedExpression.java
@@ -18,8 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
-import static org.neo4j.cypherdsl.core.Expressions.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitor;
@@ -68,7 +67,7 @@ public final class AliasedExpression implements Aliased, Expression {
 	public void accept(Visitor visitor) {
 
 		visitor.enter(this);
-		nameOrExpression(this.delegate).accept(visitor);
+		Expressions.nameOrExpression(this.delegate).accept(visitor);
 		visitor.leave(this);
 	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Arguments.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Arguments.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.INTERNAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.TypedSubtree;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Asterisk.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Asterisk.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/BooleanFunctionCondition.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/BooleanFunctionCondition.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.INTERNAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitor;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/BooleanLiteral.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/BooleanLiteral.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/BuiltInFunctions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/BuiltInFunctions.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.INTERNAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.FunctionInvocation.FunctionDefinition;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Case.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Case.java
@@ -18,7 +18,8 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Comparison.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Comparison.java
@@ -18,8 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
-import static org.neo4j.cypherdsl.core.Expressions.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitor;
@@ -78,11 +77,11 @@ public final class Comparison implements Condition {
 
 		visitor.enter(this);
 		if (left != null) {
-			nameOrExpression(left).accept(visitor);
+			Expressions.nameOrExpression(left).accept(visitor);
 		}
 		comparator.accept(visitor);
 		if (right != null) {
-			nameOrExpression(right).accept(visitor);
+			Expressions.nameOrExpression(right).accept(visitor);
 		}
 		visitor.leave(this);
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/CompoundCondition.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/CompoundCondition.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.util.ArrayList;
 import java.util.EnumSet;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Condition.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Condition.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Conditions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Conditions.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ConstantCondition.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ConstantCondition.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitor;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Create.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Create.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitor;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DefaultStatementBuilder.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DefaultStatementBuilder.java
@@ -18,8 +18,6 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.neo4j.cypherdsl.core.DefaultStatementBuilder.UpdateType.*;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -112,14 +110,14 @@ class DefaultStatementBuilder implements StatementBuilder,
 	@SuppressWarnings("unchecked") // This method returns `this`, implementing `OngoingUpdate`
 	public OngoingUpdate create(PatternElement... pattern) {
 
-		return update(CREATE, pattern);
+		return update(UpdateType.CREATE, pattern);
 	}
 
 	@Override
 	@SuppressWarnings("unchecked") // This method returns `this`, implementing `OngoingUpdate`
 	public OngoingUpdate merge(PatternElement... pattern) {
 
-		return update(MERGE, pattern);
+		return update(UpdateType.MERGE, pattern);
 	}
 
 	@Override
@@ -207,14 +205,14 @@ class DefaultStatementBuilder implements StatementBuilder,
 	@SuppressWarnings("unchecked") // This method returns `this`, implementing `OngoingUpdate`
 	public OngoingUpdate delete(Expression... expressions) {
 
-		return update(DELETE, expressions);
+		return update(UpdateType.DELETE, expressions);
 	}
 
 	@Override
 	@SuppressWarnings("unchecked") // This method returns `this`, implementing `OngoingUpdate`
 	public OngoingUpdate detachDelete(Expression... expressions) {
 
-		return update(DETACH_DELETE, expressions);
+		return update(UpdateType.DETACH_DELETE, expressions);
 	}
 
 	@Override
@@ -224,28 +222,28 @@ class DefaultStatementBuilder implements StatementBuilder,
 			this.currentSinglePartElements.add(this.currentOngoingUpdate.buildUpdatingClause());
 			this.currentOngoingUpdate = null;
 		}
-		return new DefaultStatementWithUpdateBuilder(SET, expressions);
+		return new DefaultStatementWithUpdateBuilder(UpdateType.SET, expressions);
 	}
 
 	@Override
 	@SuppressWarnings("unchecked") // This method returns a `DefaultStatementWithUpdateBuilder`, implementing the necessary interfaces
 	public OngoingMatchAndUpdate set(Node named, String... label) {
 
-		return new DefaultStatementWithUpdateBuilder(SET, Operations.set(named, label));
+		return new DefaultStatementWithUpdateBuilder(UpdateType.SET, Operations.set(named, label));
 	}
 
 	@Override
 	@SuppressWarnings("unchecked") // This method returns a `DefaultStatementWithUpdateBuilder`, implementing the necessary interfaces
 	public OngoingMatchAndUpdate remove(Property... properties) {
 
-		return new DefaultStatementWithUpdateBuilder(REMOVE, properties);
+		return new DefaultStatementWithUpdateBuilder(UpdateType.REMOVE, properties);
 	}
 
 	@Override
 	@SuppressWarnings("unchecked") // This method returns a `DefaultStatementWithUpdateBuilder`, implementing the necessary interfaces
 	public OngoingMatchAndUpdate remove(Node named, String... label) {
 
-		return new DefaultStatementWithUpdateBuilder(REMOVE, Operations.remove(named, label));
+		return new DefaultStatementWithUpdateBuilder(UpdateType.REMOVE, Operations.remove(named, label));
 	}
 
 	@Override
@@ -666,7 +664,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 		CREATE, MERGE;
 	}
 
-	private static final EnumSet<UpdateType> MERGE_OR_CREATE = EnumSet.of(CREATE, MERGE);
+	private static final EnumSet<UpdateType> MERGE_OR_CREATE = EnumSet.of(UpdateType.CREATE, UpdateType.MERGE);
 
 	protected final class DefaultStatementWithUpdateBuilder extends DefaultStatementWithReturnBuilder
 		implements OngoingMatchAndUpdate {
@@ -769,7 +767,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 
 		private OngoingUpdate delete(boolean nextDetach, Expression... deletedExpressions) {
 			DefaultStatementBuilder.this.addUpdatingClause(buildUpdatingClause());
-			return DefaultStatementBuilder.this.update(nextDetach ? DETACH_DELETE : DELETE, deletedExpressions);
+			return DefaultStatementBuilder.this.update(nextDetach ? UpdateType.DETACH_DELETE : UpdateType.DELETE, deletedExpressions);
 		}
 
 		@Override
@@ -777,7 +775,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 		public OngoingMatchAndUpdate set(Expression... keyValuePairs) {
 
 			DefaultStatementBuilder.this.addUpdatingClause(buildUpdatingClause());
-			return DefaultStatementBuilder.this.new DefaultStatementWithUpdateBuilder(SET, keyValuePairs);
+			return DefaultStatementBuilder.this.new DefaultStatementWithUpdateBuilder(UpdateType.SET, keyValuePairs);
 		}
 
 		@Override
@@ -785,7 +783,8 @@ class DefaultStatementBuilder implements StatementBuilder,
 		public OngoingMatchAndUpdate set(Node node, String... label) {
 
 			DefaultStatementBuilder.this.addUpdatingClause(buildUpdatingClause());
-			return DefaultStatementBuilder.this.new DefaultStatementWithUpdateBuilder(SET, Operations.set(node, label));
+			return DefaultStatementBuilder.this.new DefaultStatementWithUpdateBuilder(
+				UpdateType.SET, Operations.set(node, label));
 		}
 
 		@Override
@@ -793,7 +792,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 		public OngoingMatchAndUpdate remove(Node node, String... label) {
 
 			DefaultStatementBuilder.this.addUpdatingClause(buildUpdatingClause());
-			return DefaultStatementBuilder.this.new DefaultStatementWithUpdateBuilder(REMOVE,
+			return DefaultStatementBuilder.this.new DefaultStatementWithUpdateBuilder(UpdateType.REMOVE,
 				Operations.set(node, label));
 		}
 
@@ -802,7 +801,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 		public OngoingMatchAndUpdate remove(Property... properties) {
 
 			DefaultStatementBuilder.this.addUpdatingClause(buildUpdatingClause());
-			return DefaultStatementBuilder.this.new DefaultStatementWithUpdateBuilder(REMOVE, properties);
+			return DefaultStatementBuilder.this.new DefaultStatementWithUpdateBuilder(UpdateType.REMOVE, properties);
 		}
 
 		@Override

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Delete.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Delete.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitor;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Distinct.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Distinct.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.INTERNAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitable;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExcludedPattern.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExcludedPattern.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.INTERNAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitor;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesCall.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesCall.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.util.Arrays;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesCreate.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesCreate.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesMatch.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesMatch.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesMerge.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesMerge.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesRelationships.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesRelationships.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesReturning.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesReturning.java
@@ -18,8 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
-import static org.neo4j.cypherdsl.core.Expressions.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 
@@ -33,11 +32,11 @@ import org.apiguardian.api.API;
 public interface ExposesReturning {
 
 	default StatementBuilder.OngoingReadingAndReturn returning(String... variables) {
-		return returning(createSymbolicNames(variables));
+		return returning(Expressions.createSymbolicNames(variables));
 	}
 
 	default StatementBuilder.OngoingReadingAndReturn returning(Named... variables) {
-		return returning(createSymbolicNames(variables));
+		return returning(Expressions.createSymbolicNames(variables));
 	}
 
 	/**
@@ -49,11 +48,11 @@ public interface ExposesReturning {
 	StatementBuilder.OngoingReadingAndReturn returning(Expression... expressions);
 
 	default StatementBuilder.OngoingReadingAndReturn returningDistinct(String... variables) {
-		return returningDistinct(createSymbolicNames(variables));
+		return returningDistinct(Expressions.createSymbolicNames(variables));
 	}
 
 	default StatementBuilder.OngoingReadingAndReturn returningDistinct(Named... variables) {
-		return returningDistinct(createSymbolicNames(variables));
+		return returningDistinct(Expressions.createSymbolicNames(variables));
 	}
 
 	/**

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesUnwind.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesUnwind.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesWhere.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesWhere.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Expression.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Expression.java
@@ -18,8 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
-import static org.neo4j.cypherdsl.core.Cypher.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitable;
@@ -75,7 +74,7 @@ public interface Expression extends Visitable {
 	 * @return A new condition
 	 */
 	default Condition isTrue() {
-		return Conditions.isEqualTo(this, literalTrue());
+		return Conditions.isEqualTo(this, Cypher.literalTrue());
 	}
 
 	/**
@@ -84,7 +83,7 @@ public interface Expression extends Visitable {
 	 * @return A new condition
 	 */
 	default Condition isFalse() {
-		return Conditions.isEqualTo(this, literalFalse());
+		return Conditions.isEqualTo(this, Cypher.literalFalse());
 	}
 
 	/**

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Expressions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Expressions.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.util.Arrays;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/FunctionInvocation.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/FunctionInvocation.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.util.Collections;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Functions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Functions.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.BuiltInFunctions.Aggregates;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/HasLabelCondition.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/HasLabelCondition.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/KeyValueMapEntry.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/KeyValueMapEntry.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitor;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Limit.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Limit.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitable;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListComprehension.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListComprehension.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitable;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListExpression.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListExpression.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitor;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListLiteral.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListLiteral.java
@@ -18,9 +18,9 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static java.util.stream.Collectors.*;
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
+import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import org.apiguardian.api.API;
@@ -43,6 +43,6 @@ public final class ListLiteral extends Literal<Iterable<Literal<?>>> {
 	public String asString() {
 
 		return StreamSupport.stream(getContent().spliterator(), false).map(Literal::asString).collect(
-			joining(", ", "[", "]"));
+			Collectors.joining(", ", "[", "]"));
 	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListPredicate.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListPredicate.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.INTERNAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitor;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Literal.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Literal.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MapExpression.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MapExpression.java
@@ -18,8 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
-import static org.neo4j.cypherdsl.core.Expressions.*;
+import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -79,6 +78,6 @@ public final class MapExpression extends TypedSubtree<Expression, MapExpression>
 
 	@Override
 	protected Visitable prepareVisit(Expression child) {
-		return nameOrExpression(child);
+		return Expressions.nameOrExpression(child);
 	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MapProjection.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MapProjection.java
@@ -18,8 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
-import static org.neo4j.cypherdsl.core.Expressions.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -72,7 +71,7 @@ public final class MapProjection implements Expression {
 	private static Object contentAt(Object[] content, int i) {
 
 		if (content[i] instanceof Expression) {
-			return nameOrExpression((Expression) content[i]);
+			return Expressions.nameOrExpression((Expression) content[i]);
 		}
 		return content[i];
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Match.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Match.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitable;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Merge.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Merge.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitor;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MultiPartQuery.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MultiPartQuery.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Named.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Named.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.util.Optional;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NamedPath.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NamedPath.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.util.Optional;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Namespace.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Namespace.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NestedExpression.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NestedExpression.java
@@ -18,8 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
-import static org.neo4j.cypherdsl.core.Expressions.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitor;
@@ -41,7 +40,7 @@ public final class NestedExpression implements Expression {
 	public void accept(Visitor visitor) {
 
 		visitor.enter(this);
-		nameOrExpression(this.delegate).accept(visitor);
+		Expressions.nameOrExpression(this.delegate).accept(visitor);
 		visitor.leave(this);
 	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Node.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Node.java
@@ -18,13 +18,13 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static java.util.stream.Collectors.*;
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.Relationship.Direction;
@@ -77,7 +77,7 @@ public final class Node implements PatternElement, PropertyContainer, ExposesRel
 		if (!(primaryLabel == null || primaryLabel.isEmpty())) {
 			this.labels.add(new NodeLabel(primaryLabel));
 		}
-		this.labels.addAll(Arrays.stream(additionalLabels).map(NodeLabel::new).collect(toList()));
+		this.labels.addAll(Arrays.stream(additionalLabels).map(NodeLabel::new).collect(Collectors.toList()));
 		this.properties = properties;
 	}
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NodeLabel.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NodeLabel.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitable;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NodeLabels.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NodeLabels.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.util.List;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NotCondition.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NotCondition.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitor;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NullLiteral.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NullLiteral.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NumberLiteral.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NumberLiteral.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Operation.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Operation.java
@@ -18,12 +18,12 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static java.util.stream.Collectors.*;
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitable;
@@ -63,7 +63,7 @@ public final class Operation implements Expression {
 			String.format("Only operators %s can be used to modify labels", LABEL_OPERATORS));
 		Assert.notEmpty(nodeLabels, "The labels cannot be empty.");
 
-		List<NodeLabel> listOfNodeLabels = Arrays.stream(nodeLabels).map(NodeLabel::new).collect(toList());
+		List<NodeLabel> listOfNodeLabels = Arrays.stream(nodeLabels).map(NodeLabel::new).collect(Collectors.toList());
 		return new Operation(op1.getRequiredSymbolicName(), operator, new NodeLabels(listOfNodeLabels));
 	}
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Operations.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Operations.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Operator.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Operator.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitable;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Order.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Order.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.util.List;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Parameter.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Parameter.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Pattern.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Pattern.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.util.List;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PatternComprehension.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PatternComprehension.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitable;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PatternElement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PatternElement.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitable;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Predicates.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Predicates.java
@@ -18,8 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
-import static org.neo4j.cypherdsl.core.BuiltInFunctions.Predicates.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 
@@ -42,7 +41,7 @@ public final class Predicates {
 	 */
 	public static Condition exists(Property property) {
 
-		return new BooleanFunctionCondition(FunctionInvocation.create(EXISTS, property));
+		return new BooleanFunctionCondition(FunctionInvocation.create(BuiltInFunctions.Predicates.EXISTS, property));
 	}
 
 	/**
@@ -54,7 +53,7 @@ public final class Predicates {
 	 */
 	public static Condition exists(RelationshipPattern pattern) {
 
-		return new BooleanFunctionCondition(FunctionInvocation.create(EXISTS, pattern));
+		return new BooleanFunctionCondition(FunctionInvocation.create(BuiltInFunctions.Predicates.EXISTS, pattern));
 	}
 
 	/**
@@ -78,7 +77,7 @@ public final class Predicates {
 	 */
 	public static OngoingListBasedPredicateFunction all(SymbolicName variable) {
 
-		return new Builder(ALL, variable);
+		return new Builder(BuiltInFunctions.Predicates.ALL, variable);
 	}
 
 	/**
@@ -102,7 +101,7 @@ public final class Predicates {
 	 */
 	public static OngoingListBasedPredicateFunction any(SymbolicName variable) {
 
-		return new Builder(ANY, variable);
+		return new Builder(BuiltInFunctions.Predicates.ANY, variable);
 	}
 
 	/**
@@ -126,7 +125,7 @@ public final class Predicates {
 	 */
 	public static OngoingListBasedPredicateFunction none(SymbolicName variable) {
 
-		return new Builder(NONE, variable);
+		return new Builder(BuiltInFunctions.Predicates.NONE, variable);
 	}
 
 	/**
@@ -150,7 +149,7 @@ public final class Predicates {
 	 */
 	public static OngoingListBasedPredicateFunction single(SymbolicName variable) {
 
-		return new Builder(SINGLE, variable);
+		return new Builder(BuiltInFunctions.Predicates.SINGLE, variable);
 	}
 
 	/**

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ProcedureName.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ProcedureName.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.util.Arrays;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Properties.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Properties.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitable;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Property.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Property.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitor;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PropertyContainer.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PropertyContainer.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PropertyLookup.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PropertyLookup.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Relationship.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Relationship.java
@@ -18,12 +18,12 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static java.util.stream.Collectors.*;
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitor;
@@ -82,7 +82,7 @@ public final class Relationship implements RelationshipPattern, PropertyContaine
 
 		List<String> listOfTypes = Arrays.stream(types)
 			.filter(type -> !(type == null || type.isEmpty()))
-			.collect(toList());
+			.collect(Collectors.toList());
 
 		RelationshipDetail details = RelationshipDetail.create(
 			Optional.ofNullable(direction).orElse(Direction.UNI),

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipChain.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipChain.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.util.LinkedList;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipDetail.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipDetail.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.util.Optional;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipLength.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipLength.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.INTERNAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitable;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipPattern.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipPattern.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipPatternCondition.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipPatternCondition.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.INTERNAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitor;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipTypes.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipTypes.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.util.List;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Remove.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Remove.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitor;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Return.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Return.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitable;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ReturnBody.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ReturnBody.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitable;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Set.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Set.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitor;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/SinglePartQuery.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/SinglePartQuery.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Skip.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Skip.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitable;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/SortItem.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/SortItem.java
@@ -18,8 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
-import static org.neo4j.cypherdsl.core.Expressions.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.util.Optional;
 
@@ -60,7 +59,7 @@ public final class SortItem implements Visitable {
 	public void accept(Visitor visitor) {
 
 		visitor.enter(this);
-		nameOrExpression(this.expression).accept(visitor);
+		Expressions.nameOrExpression(this.expression).accept(visitor);
 
 		if (this.direction != Direction.UNDEFINED) {
 			this.direction.accept(visitor);

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Statement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Statement.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitable;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementBuilder.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementBuilder.java
@@ -18,8 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
-import static org.neo4j.cypherdsl.core.Expressions.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.ProcedureCall.OngoingInQueryCallWithoutArguments;
@@ -265,7 +264,7 @@ public interface StatementBuilder
 		 * @see #with(Expression...)
 		 */
 		default OrderableOngoingReadingAndWithWithoutWhere with(String... variables) {
-			return with(createSymbolicNames(variables));
+			return with(Expressions.createSymbolicNames(variables));
 		}
 
 		/**
@@ -274,7 +273,7 @@ public interface StatementBuilder
 		 * @see #with(Expression...)
 		 */
 		default OrderableOngoingReadingAndWithWithoutWhere with(Named... variables) {
-			return with(createSymbolicNames(variables));
+			return with(Expressions.createSymbolicNames(variables));
 		}
 
 		/**
@@ -291,7 +290,7 @@ public interface StatementBuilder
 		 * @see #withDistinct(Expression...)
 		 */
 		default OrderableOngoingReadingAndWithWithoutWhere withDistinct(String... variables) {
-			return withDistinct(createSymbolicNames(variables));
+			return withDistinct(Expressions.createSymbolicNames(variables));
 		}
 
 		/**
@@ -300,7 +299,7 @@ public interface StatementBuilder
 		 * @see #withDistinct(Expression...)
 		 */
 		default OrderableOngoingReadingAndWithWithoutWhere withDistinct(Named... variables) {
-			return withDistinct(createSymbolicNames(variables));
+			return withDistinct(Expressions.createSymbolicNames(variables));
 		}
 
 		/**
@@ -447,11 +446,11 @@ public interface StatementBuilder
 	interface ExposesDelete {
 
 		default <T extends OngoingUpdate & BuildableStatement> T delete(String... variables) {
-			return delete(createSymbolicNames(variables));
+			return delete(Expressions.createSymbolicNames(variables));
 		}
 
 		default <T extends OngoingUpdate & BuildableStatement> T delete(Named... variables) {
-			return delete(createSymbolicNames(variables));
+			return delete(Expressions.createSymbolicNames(variables));
 		}
 
 		/**
@@ -464,11 +463,11 @@ public interface StatementBuilder
 		<T extends OngoingUpdate & BuildableStatement> T delete(Expression... expressions);
 
 		default <T extends OngoingUpdate & BuildableStatement> T detachDelete(String... variables) {
-			return detachDelete(createSymbolicNames(variables));
+			return detachDelete(Expressions.createSymbolicNames(variables));
 		}
 
 		default <T extends OngoingUpdate & BuildableStatement> T detachDelete(Named... variables) {
-			return detachDelete(createSymbolicNames(variables));
+			return detachDelete(Expressions.createSymbolicNames(variables));
 		}
 
 		/**

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StringLiteral.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StringLiteral.java
@@ -18,8 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static java.util.regex.Pattern.*;
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.util.Locale;
 import java.util.Optional;
@@ -38,7 +37,7 @@ import org.apiguardian.api.API;
 @API(status = EXPERIMENTAL, since = "1.0")
 public final class StringLiteral extends Literal<CharSequence> {
 
-	private static final Pattern RESERVED_CHARS = Pattern.compile("([" + quote("\\'\"") + "])");
+	private static final Pattern RESERVED_CHARS = Pattern.compile("([" + Pattern.quote("\\'\"") + "])");
 	private static final String QUOTED_LITERAL_FORMAT = "'%s'";
 
 	StringLiteral(CharSequence content) {

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/SymbolicName.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/SymbolicName.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.util.Objects;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/UnionPart.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/UnionPart.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.Statement.SingleQuery;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/UnionQuery.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/UnionQuery.java
@@ -18,11 +18,11 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static java.util.stream.Collectors.*;
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitor;
@@ -38,7 +38,8 @@ public final class UnionQuery implements Statement.RegularQuery {
 
 		Assert.isTrue(queries != null && queries.size() >= 2, "At least two queries are needed.");
 
-		List<UnionPart> unionParts = queries.stream().skip(1).map(q -> new UnionPart(unionAll, q)).collect(toList());
+		List<UnionPart> unionParts = queries.stream().skip(1).map(q -> new UnionPart(unionAll, q)).collect(
+			Collectors.toList());
 		return new UnionQuery(unionAll, queries.get(0), unionParts);
 	}
 
@@ -64,7 +65,7 @@ public final class UnionQuery implements Statement.RegularQuery {
 
 		List<SingleQuery> queries = new ArrayList<>();
 		queries.add(firstQuery);
-		queries.addAll(additionalQueries.stream().map(UnionPart::getQuery).collect(toList()));
+		queries.addAll(additionalQueries.stream().map(UnionPart::getQuery).collect(Collectors.toList()));
 		queries.addAll(newAdditionalQueries);
 
 		return create(this.isAll(), queries);

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Unwind.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Unwind.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitor;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Where.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Where.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitable;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/With.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/With.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitable;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/YieldItems.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/YieldItems.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.INTERNAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.TypedSubtree;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Renderer.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Renderer.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core.renderer;
 
-import static org.apiguardian.api.API.Status.*;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.Statement;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/RenderingVisitor.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/RenderingVisitor.java
@@ -18,16 +18,58 @@
  */
 package org.neo4j.cypherdsl.core.renderer;
 
-import static java.util.stream.Collectors.*;
-import static org.neo4j.cypherdsl.core.renderer.Symbols.*;
-
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
-import org.neo4j.cypherdsl.core.*;
+import org.neo4j.cypherdsl.core.AliasedExpression;
+import org.neo4j.cypherdsl.core.Arguments;
+import org.neo4j.cypherdsl.core.Case;
+import org.neo4j.cypherdsl.core.CompoundCondition;
+import org.neo4j.cypherdsl.core.Create;
+import org.neo4j.cypherdsl.core.Delete;
+import org.neo4j.cypherdsl.core.Distinct;
+import org.neo4j.cypherdsl.core.FunctionInvocation;
+import org.neo4j.cypherdsl.core.KeyValueMapEntry;
+import org.neo4j.cypherdsl.core.Limit;
+import org.neo4j.cypherdsl.core.ListComprehension;
+import org.neo4j.cypherdsl.core.ListExpression;
+import org.neo4j.cypherdsl.core.Literal;
+import org.neo4j.cypherdsl.core.MapExpression;
+import org.neo4j.cypherdsl.core.Match;
+import org.neo4j.cypherdsl.core.Merge;
+import org.neo4j.cypherdsl.core.Named;
+import org.neo4j.cypherdsl.core.Namespace;
+import org.neo4j.cypherdsl.core.NestedExpression;
+import org.neo4j.cypherdsl.core.Node;
+import org.neo4j.cypherdsl.core.NodeLabel;
+import org.neo4j.cypherdsl.core.Operation;
+import org.neo4j.cypherdsl.core.Operator;
+import org.neo4j.cypherdsl.core.Order;
+import org.neo4j.cypherdsl.core.Parameter;
+import org.neo4j.cypherdsl.core.PatternComprehension;
+import org.neo4j.cypherdsl.core.ProcedureCall;
+import org.neo4j.cypherdsl.core.ProcedureName;
+import org.neo4j.cypherdsl.core.Properties;
+import org.neo4j.cypherdsl.core.PropertyLookup;
+import org.neo4j.cypherdsl.core.Relationship;
+import org.neo4j.cypherdsl.core.RelationshipDetail;
+import org.neo4j.cypherdsl.core.RelationshipLength;
+import org.neo4j.cypherdsl.core.RelationshipTypes;
+import org.neo4j.cypherdsl.core.Remove;
+import org.neo4j.cypherdsl.core.Return;
+import org.neo4j.cypherdsl.core.Set;
+import org.neo4j.cypherdsl.core.Skip;
+import org.neo4j.cypherdsl.core.SortItem;
+import org.neo4j.cypherdsl.core.SymbolicName;
+import org.neo4j.cypherdsl.core.UnionPart;
+import org.neo4j.cypherdsl.core.Unwind;
+import org.neo4j.cypherdsl.core.Where;
+import org.neo4j.cypherdsl.core.With;
+import org.neo4j.cypherdsl.core.YieldItems;
 import org.neo4j.cypherdsl.core.support.ReflectiveVisitor;
 import org.neo4j.cypherdsl.core.support.TypedSubtree;
 import org.neo4j.cypherdsl.core.support.Visitable;
@@ -300,7 +342,7 @@ class RenderingVisitor extends ReflectiveVisitor {
 
 	void enter(NodeLabel nodeLabel) {
 
-		escapeName(nodeLabel.getValue()).ifPresent(label -> builder.append(NODE_LABEL_START).append(label));
+		escapeName(nodeLabel.getValue()).ifPresent(label -> builder.append(Symbols.NODE_LABEL_START).append(label));
 	}
 
 	void enter(Properties properties) {
@@ -326,7 +368,7 @@ class RenderingVisitor extends ReflectiveVisitor {
 		builder
 			.append(types.getValues().stream()
 				.map(RenderingVisitor::escapeName)
-				.map(Optional::get).collect(joining(REL_TYP_SEPARATOR, REL_TYPE_START, "")));
+				.map(Optional::get).collect(Collectors.joining(Symbols.REL_TYP_SEPARATOR, Symbols.REL_TYPE_START, "")));
 	}
 
 	void enter(RelationshipLength length) {

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/ComparisonTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/ComparisonTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import org.junit.jupiter.api.Test;
 

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
@@ -18,7 +18,9 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 import java.util.function.Function;
 

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherTest.java
@@ -18,7 +18,9 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/DefaultStatementBuilderTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/DefaultStatementBuilderTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/ExpressionTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/ExpressionTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/FunctionsIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/FunctionsIT.java
@@ -18,8 +18,6 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.neo4j.cypherdsl.core.Cypher.*;
-
 import java.util.stream.Stream;
 
 import org.assertj.core.api.Assertions;
@@ -48,8 +46,10 @@ class FunctionsIT {
 		Relationship r = n.relationshipTo(m).named("r");
 		Expression e1 = Cypher.name("e1");
 		Expression e2 = Cypher.name("e2");
-		FunctionInvocation p1 = Functions.point(Cypher.mapOf("latitude", literalOf(1), "longitude", literalOf(2)));
-		FunctionInvocation p2 = Functions.point(Cypher.mapOf("latitude", literalOf(3), "longitude", literalOf(4)));
+		FunctionInvocation p1 = Functions.point(Cypher.mapOf("latitude", Cypher.literalOf(1), "longitude", Cypher
+			.literalOf(2)));
+		FunctionInvocation p2 = Functions.point(Cypher.mapOf("latitude", Cypher.literalOf(3), "longitude", Cypher
+			.literalOf(4)));
 
 		// NOTE: Not all of those return valid Cypher statements. They are used only for integration testing the function calls so far.
 		return Stream.of(
@@ -88,8 +88,8 @@ class FunctionsIT {
 			Arguments.of(Functions.stDevPDistinct(e1), "RETURN stDevP(DISTINCT e1)"),
 			Arguments.of(Functions.sum(e1), "RETURN sum(e1)"),
 			Arguments.of(Functions.sumDistinct(e1), "RETURN sum(DISTINCT e1)"),
-			Arguments.of(Functions.range(literalOf(1), literalOf(3)), "RETURN range(1, 3)"),
-			Arguments.of(Functions.range(literalOf(1), literalOf(3), literalOf(2)), "RETURN range(1, 3, 2)"),
+			Arguments.of(Functions.range(Cypher.literalOf(1), Cypher.literalOf(3)), "RETURN range(1, 3)"),
+			Arguments.of(Functions.range(Cypher.literalOf(1), Cypher.literalOf(3), Cypher.literalOf(2)), "RETURN range(1, 3, 2)"),
 			Arguments.of(Functions.head(e1), "RETURN head(e1)"),
 			Arguments.of(Functions.last(e1), "RETURN last(e1)"),
 			Arguments.of(Functions.nodes(Cypher.path("p").definedBy(r)), "RETURN nodes(p)"),

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/FunctionsTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/FunctionsTest.java
@@ -18,9 +18,9 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
-import static org.neo4j.cypherdsl.core.TestUtils.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.Mockito.mock;
 
 import java.lang.reflect.Method;
 import java.util.stream.Stream;
@@ -82,9 +82,9 @@ class FunctionsTest {
 	@MethodSource("functionsToTest")
 	void preconditionsShouldBeAsserted(String functionName, Class<?> argumentType) {
 
-		Method method = findMethod(Functions.class, functionName, argumentType);
+		Method method = TestUtils.findMethod(Functions.class, functionName, argumentType);
 		assertThatIllegalArgumentException()
-			.isThrownBy(() -> invokeMethod(method, null, (Expression) null))
+			.isThrownBy(() -> TestUtils.invokeMethod(method, null, (Expression) null))
 			.withMessageMatching("The (node|relationship|expression|pattern) for " + functionName + "\\(\\) is required.");
 	}
 
@@ -92,8 +92,9 @@ class FunctionsTest {
 	@MethodSource("functionsToTest")
 	void functionInvocationsShouldBeCreated(String functionName, Class<?> argumentType) {
 
-		Method method = findMethod(Functions.class, functionName, argumentType);
-		FunctionInvocation invocation = (FunctionInvocation) invokeMethod(method, null, mock(argumentType, Answers.RETURNS_DEEP_STUBS));
+		Method method = TestUtils.findMethod(Functions.class, functionName, argumentType);
+		FunctionInvocation invocation = (FunctionInvocation) TestUtils
+			.invokeMethod(method, null, mock(argumentType, Answers.RETURNS_DEEP_STUBS));
 		assertThat(invocation).hasFieldOrPropertyWithValue(FUNCTION_NAME_FIELD, functionName);
 	}
 }

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/NodeTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/NodeTest.java
@@ -18,8 +18,8 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.TestInstance.Lifecycle.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -30,6 +30,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -75,7 +76,7 @@ class NodeTest {
 	}
 
 	@Nested
-	@TestInstance(PER_CLASS)
+	@TestInstance(Lifecycle.PER_CLASS)
 	class PropertiesShouldBeHandled {
 
 		private Stream<Arguments> createNodesWithProperties() {

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/PredicatesTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/PredicatesTest.java
@@ -18,9 +18,9 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
-import static org.neo4j.cypherdsl.core.TestUtils.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.Mockito.mock;
 
 import java.lang.reflect.Method;
 import java.util.stream.Stream;
@@ -47,9 +47,9 @@ class PredicatesTest {
 	@MethodSource("predicatesToTest")
 	void preconditionsShouldBeAsserted(String predicateName, Class<?> argumentType) {
 
-		Method method = findMethod(Predicates.class, predicateName, argumentType);
+		Method method = TestUtils.findMethod(Predicates.class, predicateName, argumentType);
 		assertThatIllegalArgumentException()
-			.isThrownBy(() -> invokeMethod(method, null, (Expression) null))
+			.isThrownBy(() -> TestUtils.invokeMethod(method, null, (Expression) null))
 			.withMessageEndingWith("is required.");
 	}
 
@@ -57,8 +57,8 @@ class PredicatesTest {
 	@MethodSource("predicatesToTest")
 	void functionInvocationsShouldBeCreated(String functionName, Class<?> argumentType) {
 
-		Method method = findMethod(Predicates.class, functionName, argumentType);
-		BooleanFunctionCondition invocation = (BooleanFunctionCondition) invokeMethod(method, null, mock(argumentType));
+		Method method = TestUtils.findMethod(Predicates.class, functionName, argumentType);
+		BooleanFunctionCondition invocation = (BooleanFunctionCondition) TestUtils.invokeMethod(method, null, mock(argumentType));
 		assertThat(invocation).extracting("delegate")
 			.hasFieldOrPropertyWithValue(FUNCTION_NAME_FIELD, functionName);
 	}

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/ProcedureCallsIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/ProcedureCallsIT.java
@@ -18,8 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.neo4j.cypherdsl.core.Cypher.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -49,7 +48,7 @@ class ProcedureCallsIT {
 
 		Statement call = Cypher
 			.call("dbms.security.createUser")
-			.withArgs(literalOf("johnsmith"), literalOf("h6u4%kr"), BooleanLiteral.FALSE)
+			.withArgs(Cypher.literalOf("johnsmith"), Cypher.literalOf("h6u4%kr"), BooleanLiteral.FALSE)
 			.build();
 		assertThat(cypherRenderer.render(call))
 			.isEqualTo("CALL dbms.security.createUser('johnsmith', 'h6u4%kr', false)");
@@ -83,7 +82,7 @@ class ProcedureCallsIT {
 
 		Statement call = Cypher
 			.call("dbms.listConfig")
-			.withArgs(literalOf("browser"))
+			.withArgs(Cypher.literalOf("browser"))
 			.yield("name")
 			.build();
 		assertThat(cypherRenderer.render(call)).isEqualTo("CALL dbms.listConfig('browser') YIELD name");
@@ -95,10 +94,10 @@ class ProcedureCallsIT {
 		SymbolicName name = Cypher.name("name");
 		Statement call = Cypher
 			.call("dbms.listConfig")
-			.withArgs(literalOf("browser"))
+			.withArgs(Cypher.literalOf("browser"))
 			.yield(name)
 			.where(name.matches("browser\\.allow.*"))
-			.returning(asterisk())
+			.returning(Cypher.asterisk())
 			.build();
 		assertThat(cypherRenderer.render(call))
 			.isEqualTo("CALL dbms.listConfig('browser') YIELD name WHERE name =~ 'browser\\\\.allow.*' RETURN *");
@@ -126,12 +125,12 @@ class ProcedureCallsIT {
 			SymbolicName name = Cypher.name("name");
 			Statement call = Cypher
 				.call("dbms.listConfig")
-				.withArgs(literalOf("browser"))
+				.withArgs(Cypher.literalOf("browser"))
 				.yield(name)
 				.where(name.matches("browser\\.allow.*"))
 				.match(Cypher.anyNode("n"))
 				.with(name)
-				.returning(asterisk())
+				.returning(Cypher.asterisk())
 				.build();
 			assertThat(cypherRenderer.render(call))
 				.isEqualTo(
@@ -145,12 +144,12 @@ class ProcedureCallsIT {
 			SymbolicName description = Cypher.name("description");
 			Statement call = Cypher
 				.call("dbms.listConfig")
-				.withArgs(literalOf("browser"))
+				.withArgs(Cypher.literalOf("browser"))
 				.yield(name, description)
 				.where(name.matches("browser\\.allow.*"))
 				.with(Cypher.asterisk())
-				.create(node("Config").withProperties("name", name, "description", description).named("n"))
-				.returning(name("n"))
+				.create(Cypher.node("Config").withProperties("name", name, "description", description).named("n"))
+				.returning(Cypher.name("n"))
 				.build();
 			assertThat(cypherRenderer.render(call))
 				.isEqualTo(
@@ -161,11 +160,11 @@ class ProcedureCallsIT {
 		void relatedInner() {
 
 			SymbolicName name = Cypher.name("name");
-			AliasedExpression parameters = listOf(literalOf("browser"), literalOf("causal_clustering"))
+			AliasedExpression parameters = Cypher.listOf(Cypher.literalOf("browser"), Cypher.literalOf("causal_clustering"))
 				.as("parameters");
 			Statement call = Cypher.with(parameters)
 				.unwind(parameters).as("p")
-				.call("dbms.listConfig").withArgs(name("p"))
+				.call("dbms.listConfig").withArgs(Cypher.name("p"))
 				.yield(name)
 				.where(name.matches(".*allow.*"))
 				.returning(name)

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/PropertyTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/PropertyTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import org.junit.jupiter.api.Test;
 

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/RelationshipTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/RelationshipTest.java
@@ -18,8 +18,8 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.TestInstance.Lifecycle.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import java.util.HashSet;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -28,6 +28,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -51,7 +52,7 @@ class RelationshipTest {
 	}
 
 	@Nested
-	@TestInstance(PER_CLASS)
+	@TestInstance(Lifecycle.PER_CLASS)
 	class PropertiesShouldBeHandled {
 
 		private Stream<Arguments> createNodesWithProperties() {

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/StringLiteralTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/StringLiteralTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/renderer/RenderingVisitorTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/renderer/RenderingVisitorTest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.cypherdsl.core.renderer;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;


### PR DESCRIPTION
This changes enables checkstyle rules for avoid static but especially star imports.

While I do think that star imports doesn’t do much harm in applications, it has the potential to do big harm in a library such as this. For a backround read this: http://www.javadude.com/posts/20040522-import-on-demand-is-evil/.

Also, my sense of beautity to prefer `update(CREATE, pattern);` in contrast to `update(UpdateType.CREATE, pattern);` for example is much worth compared to actual hassle.