### PR TITLE
Automate release preparation and cleanup.

### DIFF
--- a/neo4j-cypher-dsl-examples/pom.xml
+++ b/neo4j-cypher-dsl-examples/pom.xml
@@ -33,17 +33,12 @@
 	<description>Examples used in the documentation.</description>
 
 	<properties>
+		<java-module-name>org.neo4j.cypherdsl.examples</java-module-name>
 		<java.version>11</java.version>
 		<neo4j-cypher-dsl.version>${revision}${sha1}${changelist}</neo4j-cypher-dsl.version>
-		<java-module-name>org.neo4j.cypherdsl.examples</java-module-name>
 	</properties>
 
 	<dependencies>
-		<dependency>
-			<groupId>org.neo4j</groupId>
-			<artifactId>neo4j-cypher-dsl</artifactId>
-			<version>${neo4j-cypher-dsl.version}</version>
-		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
@@ -53,6 +48,11 @@
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.neo4j</groupId>
+			<artifactId>neo4j-cypher-dsl</artifactId>
+			<version>${neo4j-cypher-dsl.version}</version>
 		</dependency>
 	</dependencies>
 
@@ -104,7 +104,7 @@
 				</property>
 			</activation>
 			<properties>
-				<revision>202x.0.0</revision>
+				<revision>9999</revision>
 			</properties>
 		</profile>
 		<profile>
@@ -115,7 +115,7 @@
 				</property>
 			</activation>
 			<properties>
-				<sha1/>
+				<sha1></sha1>
 			</properties>
 		</profile>
 		<profile>

--- a/neo4j-cypher-dsl/pom.xml
+++ b/neo4j-cypher-dsl/pom.xml
@@ -17,8 +17,7 @@
  | See the License for the specific language governing permissions and
  | limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/pom.xml
+++ b/pom.xml
@@ -92,22 +92,26 @@
 
 	<properties>
 		<apiguardian.version>1.1.0</apiguardian.version>
-		<asciidoctorj-diagram.version>2.0.1</asciidoctorj-diagram.version>
 		<asciidoctor-maven-plugin.version>1.6.0</asciidoctor-maven-plugin.version>
+		<asciidoctorj-diagram.version>2.0.1</asciidoctorj-diagram.version>
 		<assertj.version>3.15.0</assertj.version>
 		<changelist>-SNAPSHOT</changelist>
 		<checkstyle.version>8.29</checkstyle.version>
+		<exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
 		<flatten-maven-plugin.version>1.2.1</flatten-maven-plugin.version>
 		<jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
-		<java-module-name />
+		<java-module-name></java-module-name>
 		<java.version>1.8</java.version>
 		<junit-jupiter.version>5.6.1</junit-jupiter.version>
 		<maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
 		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+		<maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
 		<maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
 		<maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
+		<maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
 		<maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
 		<maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
+		<maven-scm-plugin.version>1.11.2</maven-scm-plugin.version>
 		<maven-source-plugin.version>3.2.1</maven-source-plugin.version>
 		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
@@ -116,11 +120,9 @@
 		<mockito.version>3.2.4</mockito.version>
 		<project.build.docs>${project.build.directory}/docs</project.build.docs>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<revision>202x.0.0</revision> <!-- Have a look here https://spring.io/blog/2020/04/30/updates-to-spring-versions -->
-		<sha1 />
+		<revision>9999</revision>
+		<sha1></sha1>
 		<sortpom-maven-plugin.version>2.11.0</sortpom-maven-plugin.version>
-		<maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
-		<maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
 	</properties>
 
 	<dependencyManagement>
@@ -230,10 +232,68 @@
 
 		<plugins>
 			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>${exec-maven-plugin.version}</version>
+				<executions>
+					<execution>
+						<id>update_readme</id>
+						<goals>
+							<goal>exec</goal>
+						</goals>
+						<configuration>
+							<executable>sed</executable>
+							<arguments>
+								<argument>-i</argument>
+								<argument>.bak</argument>
+								<argument>s/\(:neo4j-cypher-dsl-version:\) \(.*\)/\1 ${revision}${sha1}${changelist}/g</argument>
+								<argument>README.adoc</argument>
+							</arguments>
+						</configuration>
+					</execution>
+					<execution>
+						<id>delete_readme_backup</id>
+						<goals>
+							<goal>exec</goal>
+						</goals>
+						<configuration>
+							<executable>rm</executable>
+							<arguments>
+								<argument>README.adoc.bak</argument>
+							</arguments>
+						</configuration>
+					</execution>
+				</executions>
+				<inherited>false</inherited>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-scm-plugin</artifactId>
+				<version>${maven-scm-plugin.version}</version>
+				<executions>
+					<execution>
+						<id>prepare_release</id>
+						<configuration>
+							<message>[maven-scm-plugin] Prepare release.</message>
+							<includes>README.adoc</includes>
+						</configuration>
+					</execution>
+					<execution>
+						<id>after_release</id>
+						<configuration>
+							<message>[maven-scm-plugin] After release cleanup.</message>
+							<includes>README.adoc</includes>
+						</configuration>
+					</execution>
+				</executions>
+				<inherited>false</inherited>
+			</plugin>
+			<plugin>
 				<groupId>com.github.ekryd.sortpom</groupId>
 				<artifactId>sortpom-maven-plugin</artifactId>
 				<executions>
 					<execution>
+						<id>sort</id>
 						<phase>verify</phase>
 						<goals>
 							<goal>sort</goal>
@@ -349,10 +409,6 @@
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>flatten-maven-plugin</artifactId>
 				<version>${flatten-maven-plugin.version}</version>
-				<configuration>
-					<updatePomFile>true</updatePomFile>
-					<flattenMode>resolveCiFriendliesOnly</flattenMode>
-				</configuration>
 				<executions>
 					<execution>
 						<id>flatten</id>
@@ -369,12 +425,24 @@
 						</goals>
 					</execution>
 				</executions>
+				<configuration>
+					<updatePomFile>true</updatePomFile>
+					<flattenMode>resolveCiFriendliesOnly</flattenMode>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.asciidoctor</groupId>
 				<artifactId>asciidoctor-maven-plugin</artifactId>
 				<version>${asciidoctor-maven-plugin.version}</version>
-				<inherited>false</inherited>
+				<executions>
+					<execution>
+						<id>generate-docs</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>process-asciidoc</goal>
+						</goals>
+					</execution>
+				</executions>
 				<dependencies>
 					<dependency>
 						<groupId>org.asciidoctor</groupId>
@@ -382,6 +450,7 @@
 						<version>${asciidoctorj-diagram.version}</version>
 					</dependency>
 				</dependencies>
+				<inherited>false</inherited>
 				<configuration>
 					<backend>html</backend>
 					<doctype>book</doctype>
@@ -401,15 +470,6 @@
 					</requires>
 					<outputDirectory>${project.build.docs}</outputDirectory>
 				</configuration>
-				<executions>
-					<execution>
-						<id>generate-docs</id>
-						<phase>prepare-package</phase>
-						<goals>
-							<goal>process-asciidoc</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
This includes

- Setting a specific version in `README.adoc` so that the GH-Action uses the correct version when the documentation is generated and "current" http://neo4j-contrib.github.io/cypher-dsl/current points to that

Can be done now through

```
./mvnw exec:exec@prepare_release -Drevision=2020.0.2 -Dchangelist= -pl org.neo4j:neo4j-cypher-dsl-parent
./mvnw exec:exec@delete_readme_backup -pl org.neo4j:neo4j-cypher-dsl-parent
./mvnw scm:checkin@prepare_release
```

- Change back to the snapshot version afterwards so that the README itself is correct when looking at the main branch and also at the snapshot documentation under http://neo4j-contrib.github.io/cypher-dsl/main/

Implemented with

```
./mvnw exec:exec@prepare_release -pl org.neo4j:neo4j-cypher-dsl-parent
./mvnw exec:exec@delete_readme_backup -pl org.neo4j:neo4j-cypher-dsl-parent
./mvnw scm:checkin@after_release
```

The snapshot version of the POM should be changed to something unrealistic which doesn't indicate a next release date or something.

The corresponding targets should than be called from Team City.

This closes #71.