### PR TITLE
GH-76 - Add ListOperator expression.

### DIFF
--- a/docs/functions/index.adoc
+++ b/docs/functions/index.adoc
@@ -1,0 +1,6 @@
+[[functions]]
+= Functions
+
+NOTE: There are many more functions implemented in `org.neo4j.cypherdsl.core.Functions`. Not all of them are already documented here.
+
+include::lists.adoc[leveloffset=+1]

--- a/docs/functions/lists.adoc
+++ b/docs/functions/lists.adoc
@@ -1,0 +1,43 @@
+== Lists
+
+[[functions-list-range]]
+=== range()
+
+Creates an invocation of https://neo4j.com/docs/cypher-manual/current/functions/list/#functions-range[`range()`].
+
+Given the following imports
+
+[source,java,indent=0]
+----
+include::../../neo4j-cypher-dsl-examples/src/test/java/org/neo4j/cypherdsl/examples/core/FunctionsListTest.java[tag=functions-list-range-imports]
+----
+
+[source,java,indent=0]
+----
+include::../../neo4j-cypher-dsl-examples/src/test/java/org/neo4j/cypherdsl/examples/core/FunctionsListTest.java[tag=functions-list-range]
+----
+
+Gives you `range(0,10)`.
+The step size can be specified as well:
+
+[source,java,indent=0]
+----
+include::../../neo4j-cypher-dsl-examples/src/test/java/org/neo4j/cypherdsl/examples/core/FunctionsListTest.java[tag=functions-list-range-step]
+----
+
+This gives you `range(0,10,1)`.
+
+Both variants of `range` also take a `NumberLiteral` for the start and end index and the step size.
+
+=== Inserting a list operator
+
+The _list operator_ `[]` selects a specific value of a list or a range of values from a list.
+A range can either be closed or open.
+
+Find examples to select a value at a given index, a sublist based on a closed range and sublist based on open ranges below.
+While the examples use <<functions-list-range>>, the list operator doesn't put any restrictions on the expression at the moment.
+
+[source,java,indent=0]
+----
+include::../../neo4j-cypher-dsl-examples/src/test/java/org/neo4j/cypherdsl/examples/core/FunctionsListTest.java[tag=functions-list-operator]
+----

--- a/docs/getting-started/getting-started.adoc
+++ b/docs/getting-started/getting-started.adoc
@@ -1,6 +1,3 @@
-[[getting-started]]
-= Getting started
-
 == Prepare dependencies
 
 Please use a dependency management system. We recommend either Maven or Gradle.

--- a/docs/getting-started/index.adoc
+++ b/docs/getting-started/index.adoc
@@ -1,1 +1,4 @@
+[[getting-started]]
+= Getting started
+
 include::getting-started.adoc[leveloffset=+1]

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -42,6 +42,8 @@ We will try to keep breaking changes to a minimum, but we reserve the right to m
 and behaviour in case we need those changes for the https://github.com/neo4j/sdn-rx[SDN/RX] project, the origin of the Cypher-DSL.
 All public classes inside `org.neo4j.cypherdsl` still subject to breaking changes are annotated with `@API(status = EXPERIMENTAL)`.
 
-include::introduction-and-preface/index.adoc[]
+include::introduction-and-preface/index.adoc[leveloffset=+1]
 
-include::getting-started/index.adoc[]
+include::getting-started/index.adoc[leveloffset=+1]
+
+include::functions/index.adoc[leveloffset=+1]

--- a/docs/introduction-and-preface/index.adoc
+++ b/docs/introduction-and-preface/index.adoc
@@ -1,1 +1,4 @@
+[[introduction]]
+= Introduction
+
 include::introduction.adoc[leveloffset=+1]

--- a/docs/introduction-and-preface/introduction.adoc
+++ b/docs/introduction-and-preface/introduction.adoc
@@ -1,6 +1,3 @@
-[[introduction]]
-= Introduction
-
 == Purpose
 
 The Cypher-DSL has been developed with the needs of https://github.com/neo4j/sdn-rx[SDN/RX] in mind:

--- a/neo4j-cypher-dsl-examples/src/test/java/org/neo4j/cypherdsl/examples/core/FunctionsListTest.java
+++ b/neo4j-cypher-dsl-examples/src/test/java/org/neo4j/cypherdsl/examples/core/FunctionsListTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.examples.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+// tag::functions-list-range-imports[]
+import org.neo4j.cypherdsl.core.Cypher;
+import org.neo4j.cypherdsl.core.Functions;
+// end::functions-list-range-imports[]
+import org.neo4j.cypherdsl.core.renderer.Renderer;
+
+/**
+ * @author Michael J. Simons
+ * @soundtrack Danger Dan - Dinkelbrot & Ölsardinen
+ */
+class FunctionsListTest {
+
+	private static final Renderer cypherRenderer = Renderer.getDefaultRenderer();
+
+	// tag::functions-list-operator[]
+	@Test
+	void valueAtExample() {
+
+		// tag::functions-list-range[]
+		var range = Functions.range(0, 10);
+		// end::functions-list-range[]
+
+		var statement = Cypher.returning(Cypher.valueAt(range, 3)).build();
+		assertThat(cypherRenderer.render(statement))
+			.isEqualTo("RETURN range(0, 10)[3]");
+	}
+
+	@Test
+	void subListUntilExample() {
+
+		var range = Functions.range(Cypher.literalOf(0), Cypher.literalOf(10));
+
+		var statement = Cypher.returning(Cypher.subListUntil(range, 3)).build();
+		assertThat(cypherRenderer.render(statement))
+			.isEqualTo("RETURN range(0, 10)[..3]");
+	}
+
+	@Test
+	void subListFromExample() {
+
+		// tag::functions-list-range-step[]
+		var range = Functions.range(0, 10, 1);
+		// end::functions-list-range-step[]
+
+		var statement = Cypher.returning(Cypher.subListFrom(range, -3)).build();
+		assertThat(cypherRenderer.render(statement))
+			.isEqualTo("RETURN range(0, 10, 1)[-3..]");
+	}
+
+	@Test
+	void subListExample() {
+
+		var range = Functions.range(Cypher.literalOf(0), Cypher.literalOf(10), Cypher.literalOf(1));
+
+		var statement = Cypher.returning(Cypher.subList(range, 2, 4)).build();
+		assertThat(cypherRenderer.render(statement))
+			.isEqualTo("RETURN range(0, 10, 1)[2..4]");
+	}
+	// end::functions-list-operator[]
+}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
@@ -458,7 +458,7 @@ public final class Cypher {
 	 * @return A range literal.
 	 * @since 2020.1.0
 	 */
-	public static Expression subList(Expression targetExpression, Literal<Number> start, Literal<Number> end) {
+	public static Expression subList(Expression targetExpression, Expression start, Expression end) {
 
 		return ListOperator.subList(targetExpression, start, end);
 	}
@@ -484,7 +484,7 @@ public final class Cypher {
 	 * @return A range literal.
 	 * @since 2020.1.0
 	 */
-	public static Expression subListFrom(Expression targetExpression, Literal<Number> start) {
+	public static Expression subListFrom(Expression targetExpression, Expression start) {
 
 		return ListOperator.subListFrom(targetExpression, start);
 	}
@@ -510,7 +510,7 @@ public final class Cypher {
 	 * @return A range literal.
 	 * @since 2020.1.0
 	 */
-	public static Expression subListUntil(Expression targetExpression, Literal<Number> end) {
+	public static Expression subListUntil(Expression targetExpression, Expression end) {
 
 		return ListOperator.subListUntil(targetExpression, end);
 	}
@@ -536,7 +536,7 @@ public final class Cypher {
 	 * @return A range literal.
 	 * @since 2020.1.0
 	 */
-	public static ListOperator valueAt(Expression targetExpression, Literal<Number> index) {
+	public static ListOperator valueAt(Expression targetExpression, Expression index) {
 
 		return ListOperator.valueAt(targetExpression, index);
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
@@ -307,16 +307,16 @@ public final class Cypher {
 	 * @return a new {@link NullLiteral}.
 	 * @throws IllegalArgumentException when the object cannot be represented as a literal
 	 */
-	public static Literal<?> literalOf(Object object) {
+	public static <T> Literal<T> literalOf(Object object) {
 
 		if (object == null) {
-			return NullLiteral.INSTANCE;
+			return (Literal<T>) NullLiteral.INSTANCE;
 		}
 		if (object instanceof CharSequence) {
-			return new StringLiteral((CharSequence) object);
+			return (Literal<T>) new StringLiteral((CharSequence) object);
 		}
 		if (object instanceof Number) {
-			return new NumberLiteral((Number) object);
+			return (Literal<T>) new NumberLiteral((Number) object);
 		}
 		if (object instanceof Iterable) {
 			for (Object element : ((Iterable<?>) object)) {
@@ -326,11 +326,11 @@ public final class Cypher {
 			}
 
 			@SuppressWarnings("unchecked") // See above
-			ListLiteral listLiteral = new ListLiteral((Iterable<Literal<?>>) object);
-			return listLiteral;
+				ListLiteral listLiteral = new ListLiteral((Iterable<Literal<?>>) object);
+			return (Literal<T>) listLiteral;
 		}
 		if (object instanceof Boolean) {
-			return BooleanLiteral.of((Boolean) object);
+			return (Literal<T>) BooleanLiteral.of((Boolean) object);
 		}
 		throw new IllegalArgumentException("Unsupported literal type: " + object.getClass());
 	}
@@ -433,6 +433,112 @@ public final class Cypher {
 	 */
 	public static OngoingStandaloneCallWithoutArguments call(String... namespaceAndProcedure) {
 		return Statement.call(namespaceAndProcedure);
+	}
+
+	/**
+	 * Creates a closed range with given boundaries.
+	 *
+	 * @param targetExpression The target expression for the range
+	 * @param start            The inclusive start
+	 * @param end              The exclusive end
+	 * @return A range literal.
+	 * @since 2020.1.0
+	 */
+	public static Expression subList(Expression targetExpression, Integer start, Integer end) {
+
+		return ListOperator.subList(targetExpression, Cypher.literalOf(start), Cypher.literalOf(end));
+	}
+
+	/**
+	 * Creates a closed range with given boundaries.
+	 *
+	 * @param targetExpression The target expression for the range
+	 * @param start            The inclusive start
+	 * @param end              The exclusive end
+	 * @return A range literal.
+	 * @since 2020.1.0
+	 */
+	public static Expression subList(Expression targetExpression, Literal<Number> start, Literal<Number> end) {
+
+		return ListOperator.subList(targetExpression, start, end);
+	}
+
+	/**
+	 * Creates an open range starting at {@code start}.
+	 *
+	 * @param targetExpression The target expression for the range
+	 * @param start            The inclusive start
+	 * @return A range literal.
+	 * @since 2020.1.0
+	 */
+	public static Expression subListFrom(Expression targetExpression, Integer start) {
+
+		return ListOperator.subListFrom(targetExpression, Cypher.literalOf(start));
+	}
+
+	/**
+	 * Creates an open range starting at {@code start}.
+	 *
+	 * @param targetExpression The target expression for the range
+	 * @param start            The inclusive start
+	 * @return A range literal.
+	 * @since 2020.1.0
+	 */
+	public static Expression subListFrom(Expression targetExpression, Literal<Number> start) {
+
+		return ListOperator.subListFrom(targetExpression, start);
+	}
+
+	/**
+	 * Creates an open range starting at {@code start}.
+	 *
+	 * @param targetExpression The target expression for the range
+	 * @param end              The exclusive end
+	 * @return A range literal.
+	 * @since 2020.1.0
+	 */
+	public static Expression subListUntil(Expression targetExpression, Integer end) {
+
+		return ListOperator.subListUntil(targetExpression, Cypher.literalOf(end));
+	}
+
+	/**
+	 * Creates an open range starting at {@code start}.
+	 *
+	 * @param targetExpression The target expression for the range
+	 * @param end              The exclusive end
+	 * @return A range literal.
+	 * @since 2020.1.0
+	 */
+	public static Expression subListUntil(Expression targetExpression, Literal<Number> end) {
+
+		return ListOperator.subListUntil(targetExpression, end);
+	}
+
+	/**
+	 * Creates a single valued range at {@code index}.
+	 *
+	 * @param targetExpression The target expression for the range
+	 * @param index            The index of the range
+	 * @return A range literal.
+	 * @since 2020.1.0
+	 */
+	public static ListOperator valueAt(Expression targetExpression, Integer index) {
+
+		return ListOperator.valueAt(targetExpression, Cypher.literalOf(index));
+	}
+
+	/**
+	 * Creates a single valued range at {@code index}.
+	 *
+	 * @param targetExpression The target expression for the range
+	 * @param index            The index of the range
+	 * @return A range literal.
+	 * @since 2020.1.0
+	 */
+	public static ListOperator valueAt(Expression targetExpression, Literal<Number> index) {
+
+		return ListOperator.valueAt(targetExpression, index);
 	}
 
 	private static Statement unionImpl(boolean unionAll, Statement... statements) {

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Functions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Functions.java
@@ -179,7 +179,6 @@ public final class Functions {
 		return FunctionInvocation.create(Scalars.PROPERTIES, map);
 	}
 
-
 	/**
 	 * Creates a function invocation for the {@code coalesce()} function.
 	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/scalar/#functions-coalesce">coalesce</a>.
@@ -555,10 +554,36 @@ public final class Functions {
 	 * @param start the range's start
 	 * @param end   the range's end
 	 * @return A function call for {@code range()}
+	 * @see #range(Expression, Expression)
+	 */
+	public static FunctionInvocation range(Integer start, Integer end) {
+
+		return range(Cypher.literalOf(start), Cypher.literalOf(end));
+	}
+
+	/**
+	 * @param start the range's start
+	 * @param end   the range's end
+	 * @return A function call for {@code range()}
 	 * @see #range(Expression, Expression, Expression)
 	 */
 	public static FunctionInvocation range(Expression start, Expression end) {
 		return range(start, end, null);
+	}
+
+	/**
+	 * Creates a function invocation for the {@code range()} function.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/list/#functions-range">range</a>.
+	 *
+	 * @param start the range's start
+	 * @param end   the range's end
+	 * @param step  the range's step
+	 * @return A function call for {@code range()}
+	 * @see #range(Expression, Expression, Expression)
+	 */
+	public static FunctionInvocation range(Integer start, Integer end, Integer step) {
+
+		return range(Cypher.literalOf(start), Cypher.literalOf(end), Cypher.literalOf(step));
 	}
 
 	/**
@@ -648,8 +673,8 @@ public final class Functions {
 
 		Assertions.notNull(relationship, "The relationship for endNode is required.");
 		return FunctionInvocation.create(Scalars.START_NODE,
-				relationship.getSymbolicName()
-						.orElseThrow(() -> new IllegalArgumentException("The relationship needs to be named!")));
+			relationship.getSymbolicName()
+				.orElseThrow(() -> new IllegalArgumentException("The relationship needs to be named!")));
 	}
 
 	/**
@@ -665,7 +690,7 @@ public final class Functions {
 		Assertions.notNull(relationship, "The relationship for endNode is required.");
 		return FunctionInvocation.create(Scalars.END_NODE,
 			relationship.getSymbolicName()
-					.orElseThrow(() -> new IllegalArgumentException("The relationship needs to be named!")));
+				.orElseThrow(() -> new IllegalArgumentException("The relationship needs to be named!")));
 	}
 
 	public static FunctionInvocation shortestPath(Relationship relationship) {

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListOperator.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListOperator.java
@@ -53,7 +53,7 @@ public final class ListOperator implements Expression {
 		/**
 		 * An optional start for the range (inclusive if given).
 		 */
-		private final Literal<Number> optionalStart;
+		private final Expression optionalStart;
 
 		/**
 		 * Optional dots between the start and end.
@@ -63,9 +63,9 @@ public final class ListOperator implements Expression {
 		/**
 		 * An optional end for the range (exclusive if given).
 		 */
-		private final Literal<Number> optionalEnd;
+		private final Expression optionalEnd;
 
-		Details(Literal<Number> optionalStart, Literal<String> dots, Literal<Number> optionalEnd) {
+		Details(Expression optionalStart, Literal<String> dots, Expression optionalEnd) {
 			this.optionalStart = optionalStart;
 			this.dots = dots;
 			this.optionalEnd = optionalEnd;
@@ -100,8 +100,7 @@ public final class ListOperator implements Expression {
 	 * @param end              The exclusive end
 	 * @return A range literal.
 	 */
-	static ListOperator subList(Expression targetExpression, Literal<Number> start,
-		Literal<Number> end) {
+	static ListOperator subList(Expression targetExpression, Expression start, Expression end) {
 
 		Assertions.notNull(targetExpression, "The range's target expression must not be null.");
 		Assertions.notNull(start, "The start of the range must not be null.");
@@ -117,7 +116,7 @@ public final class ListOperator implements Expression {
 	 * @param start            The inclusive start
 	 * @return A range literal.
 	 */
-	static ListOperator subListFrom(Expression targetExpression, Literal<Number> start) {
+	static ListOperator subListFrom(Expression targetExpression, Expression start) {
 
 		Assertions.notNull(targetExpression, "The range's target expression must not be null.");
 		Assertions.notNull(start, "The start of the range must not be null.");
@@ -132,7 +131,7 @@ public final class ListOperator implements Expression {
 	 * @param end              The exclusive end
 	 * @return A range literal.
 	 */
-	static ListOperator subListUntil(Expression targetExpression, Literal<Number> end) {
+	static ListOperator subListUntil(Expression targetExpression, Expression end) {
 
 		Assertions.notNull(targetExpression, "The range's target expression must not be null.");
 		Assertions.notNull(end, "The end of the range must not be null.");
@@ -147,7 +146,7 @@ public final class ListOperator implements Expression {
 	 * @param index            The index of the range
 	 * @return A range literal.
 	 */
-	static ListOperator valueAt(Expression targetExpression, Literal<Number> index) {
+	static ListOperator valueAt(Expression targetExpression, Expression index) {
 
 		Assertions.notNull(targetExpression, "The range's target expression must not be null.");
 		Assertions.notNull(index, "The index of the range must not be null.");
@@ -155,8 +154,8 @@ public final class ListOperator implements Expression {
 		return new ListOperator(targetExpression, index, null, null);
 	}
 
-	private ListOperator(Expression targetExpression, Literal<Number> optionalStart,
-		Literal<String> dots, Literal<Number> optionalEnd) {
+	private ListOperator(Expression targetExpression, Expression optionalStart,
+		Literal<String> dots, Expression optionalEnd) {
 
 		this.targetExpression = targetExpression;
 		this.details = new Details(optionalStart, dots, optionalEnd);

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListOperator.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListOperator.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.core;
+
+import static org.apiguardian.api.API.Status.INTERNAL;
+
+import org.apiguardian.api.API;
+import org.neo4j.cypherdsl.core.support.Visitable;
+import org.neo4j.cypherdsl.core.support.Visitor;
+import org.neo4j.cypherdsl.core.utils.Assertions;
+
+/**
+ * Represents a range literal applied to another expression.
+ *
+ * @author Michael J. Simons
+ * @soundtrack Danger Dan - Reflexionen aus dem beschönigten Leben
+ * @since 2020.1.0
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "2020.1.0")
+public final class ListOperator implements Expression {
+
+	/**
+	 * A literal for the dots.
+	 */
+	private static final Literal<String> DOTS = new Literal<String>("..") {
+		@Override public String asString() {
+			return super.getContent();
+		}
+	};
+
+	/**
+	 * This is not a public API and just used internally for structuring the tree.
+	 */
+	@API(status = INTERNAL, since = "1.0")
+	public static final class Details implements Visitable {
+
+		/**
+		 * An optional start for the range (inclusive if given).
+		 */
+		private final Literal<Number> optionalStart;
+
+		/**
+		 * Optional dots between the start and end.
+		 */
+		private final Literal<String> dots;
+
+		/**
+		 * An optional end for the range (exclusive if given).
+		 */
+		private final Literal<Number> optionalEnd;
+
+		Details(Literal<Number> optionalStart, Literal<String> dots, Literal<Number> optionalEnd) {
+			this.optionalStart = optionalStart;
+			this.dots = dots;
+			this.optionalEnd = optionalEnd;
+		}
+
+		@Override
+		public void accept(Visitor visitor) {
+
+			visitor.enter(this);
+			Visitable.visitIfNotNull(this.optionalStart, visitor);
+			Visitable.visitIfNotNull(this.dots, visitor);
+			Visitable.visitIfNotNull(this.optionalEnd, visitor);
+			visitor.leave(this);
+		}
+	}
+
+	/**
+	 * The target expression to which the literal should be applied.
+	 */
+	private final Expression targetExpression;
+
+	/**
+	 * The actual operator's details.
+	 */
+	private final Details details;
+
+	/**
+	 * Creates a closed range with given boundaries.
+	 *
+	 * @param targetExpression The target expression for the range
+	 * @param start            The inclusive start
+	 * @param end              The exclusive end
+	 * @return A range literal.
+	 */
+	static ListOperator subList(Expression targetExpression, Literal<Number> start,
+		Literal<Number> end) {
+
+		Assertions.notNull(targetExpression, "The range's target expression must not be null.");
+		Assertions.notNull(start, "The start of the range must not be null.");
+		Assertions.notNull(end, "The end of the range must not be null.");
+
+		return new ListOperator(targetExpression, start, DOTS, end);
+	}
+
+	/**
+	 * Creates an open range starting at {@code start}.
+	 *
+	 * @param targetExpression The target expression for the range
+	 * @param start            The inclusive start
+	 * @return A range literal.
+	 */
+	static ListOperator subListFrom(Expression targetExpression, Literal<Number> start) {
+
+		Assertions.notNull(targetExpression, "The range's target expression must not be null.");
+		Assertions.notNull(start, "The start of the range must not be null.");
+
+		return new ListOperator(targetExpression, start, DOTS, null);
+	}
+
+	/**
+	 * Creates an open range starting at {@code start}.
+	 *
+	 * @param targetExpression The target expression for the range
+	 * @param end              The exclusive end
+	 * @return A range literal.
+	 */
+	static ListOperator subListUntil(Expression targetExpression, Literal<Number> end) {
+
+		Assertions.notNull(targetExpression, "The range's target expression must not be null.");
+		Assertions.notNull(end, "The end of the range must not be null.");
+
+		return new ListOperator(targetExpression, null, DOTS, end);
+	}
+
+	/**
+	 * Creates a single valued range at {@code index}.
+	 *
+	 * @param targetExpression The target expression for the range
+	 * @param index            The index of the range
+	 * @return A range literal.
+	 */
+	static ListOperator valueAt(Expression targetExpression, Literal<Number> index) {
+
+		Assertions.notNull(targetExpression, "The range's target expression must not be null.");
+		Assertions.notNull(index, "The index of the range must not be null.");
+
+		return new ListOperator(targetExpression, index, null, null);
+	}
+
+	private ListOperator(Expression targetExpression, Literal<Number> optionalStart,
+		Literal<String> dots, Literal<Number> optionalEnd) {
+
+		this.targetExpression = targetExpression;
+		this.details = new Details(optionalStart, dots, optionalEnd);
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+
+		visitor.enter(this);
+		this.targetExpression.accept(visitor);
+		this.details.accept(visitor);
+		visitor.leave(this);
+	}
+}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/RenderingVisitor.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/RenderingVisitor.java
@@ -40,6 +40,7 @@ import org.neo4j.cypherdsl.core.KeyValueMapEntry;
 import org.neo4j.cypherdsl.core.Limit;
 import org.neo4j.cypherdsl.core.ListComprehension;
 import org.neo4j.cypherdsl.core.ListExpression;
+import org.neo4j.cypherdsl.core.ListOperator;
 import org.neo4j.cypherdsl.core.Literal;
 import org.neo4j.cypherdsl.core.MapExpression;
 import org.neo4j.cypherdsl.core.Match;
@@ -148,6 +149,8 @@ class RenderingVisitor extends ReflectiveVisitor {
 			return String.format("%s%03d", Strings.randomIdentifier(8), resolvedSymbolicNames.size());
 		});
 	}
+
+	boolean inc;
 
 	@Override
 	protected boolean preEnter(Visitable visitable) {
@@ -554,6 +557,16 @@ class RenderingVisitor extends ReflectiveVisitor {
 	void leave(ProcedureCall procedureCall) {
 
 		builder.append(" ");
+	}
+
+	void enter(ListOperator.Details details) {
+
+		builder.append("[");
+	}
+
+	void leave(ListOperator.Details details) {
+
+		builder.append("]");
 	}
 
 	public String getRenderedContent() {

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
@@ -3338,7 +3338,7 @@ class CypherIT {
 						"livesIn",
 						Cypher.subList(
 							Cypher.listBasedOn(person.relationshipTo(location, "LIVES_IN")).returning(location.project("name")),
-							Cypher.parameter("$personLivedInOffset"), Cypher.parameter("personLivedInOffset").add(Cypher.parameter("personLivedInFirst"))
+							Cypher.parameter("personLivedInOffset"), Cypher.parameter("personLivedInOffset").add(Cypher.parameter("personLivedInFirst"))
 						)
 					)
 				).build();


### PR DESCRIPTION
Modelled after the openCypher ListOperator expression, `Cypher.rangeOf`, `Cypher.rangeStartingAt`, `Cypher.rangeUntil` and `Cypher.valueAt` can be used to create a list operation upon an expression. No sanity check if the expression resolved to a list is done at the moment. This closes #76.

@Andy2003 Would you please have a look if that suites your use case?