### PR TITLE
GH-89 - Add support for Neo4j’s temporal functions.

### DIFF
--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/BuiltInFunctions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/BuiltInFunctions.java
@@ -161,6 +161,27 @@ final class BuiltInFunctions {
 
 	}
 
+	enum Temporals implements FunctionDefinition {
+
+		DATE("date"),
+		DATETIME("datetime"),
+		LOCALDATETIME("localdatetime"),
+		LOCALTIME("localtime"),
+		TIME("time"),
+		DURATION("duration");
+
+		private final String implementationName;
+
+		Temporals(String implementationName) {
+			this.implementationName = implementationName;
+		}
+
+		@Override
+		public String getImplementationName() {
+			return implementationName;
+		}
+	}
+
 	private BuiltInFunctions() {
 	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
@@ -22,6 +22,7 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.TimeZone;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.ListComprehension.OngoingDefinitionWithVariable;
@@ -331,6 +332,9 @@ public final class Cypher {
 		}
 		if (object instanceof Boolean) {
 			return (Literal<T>) BooleanLiteral.of((Boolean) object);
+		}
+		if (object instanceof TimeZone) {
+			return new StringLiteral(((TimeZone) object).getID());
 		}
 		throw new IllegalArgumentException("Unsupported literal type: " + object.getClass());
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
@@ -22,7 +22,6 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.TimeZone;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.ListComprehension.OngoingDefinitionWithVariable;
@@ -302,10 +301,10 @@ public final class Cypher {
 	}
 
 	/**
-	 * Creates a new {@link NullLiteral} from the given {@code object}.
+	 * Creates a new {@link Literal Literal&lt;?&gt;} from the given {@code object}.
 	 *
 	 * @param object the object to represent.
-	 * @return a new {@link NullLiteral}.
+	 * @return a new {@link Literal Literal&lt;?&gt;}.
 	 * @throws IllegalArgumentException when the object cannot be represented as a literal
 	 */
 	public static <T> Literal<T> literalOf(Object object) {
@@ -332,9 +331,6 @@ public final class Cypher {
 		}
 		if (object instanceof Boolean) {
 			return (Literal<T>) BooleanLiteral.of((Boolean) object);
-		}
-		if (object instanceof TimeZone) {
-			return new StringLiteral(((TimeZone) object).getID());
 		}
 		throw new IllegalArgumentException("Unsupported literal type: " + object.getClass());
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Functions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Functions.java
@@ -20,6 +20,8 @@ package org.neo4j.cypherdsl.core;
 
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
+import java.util.TimeZone;
+
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.BuiltInFunctions.Aggregates;
 import org.neo4j.cypherdsl.core.BuiltInFunctions.Lists;
@@ -691,6 +693,497 @@ public final class Functions {
 		return FunctionInvocation.create(Scalars.END_NODE,
 			relationship.getSymbolicName()
 				.orElseThrow(() -> new IllegalArgumentException("The relationship needs to be named!")));
+	}
+
+	/**
+	 * Creates a function invocation for {@code date()}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/date/">date</a>.
+	 * This is the most simple form.
+	 *
+	 * @return A function call for {@code date()}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation date() {
+
+		return FunctionInvocation.create(BuiltInFunctions.Temporals.DATE);
+	}
+
+	/**
+	 * Creates a function invocation for {@code date({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/date/">date</a>.
+	 *
+	 * @param year  The year
+	 * @param month The month
+	 * @param day   The day
+	 * @return A function call for {@code date({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation calendarDate(Integer year, Integer month, Integer day) {
+
+		Assertions.notNull(year, "The year is required.");
+		Assertions.notNull(month, "The month is required.");
+		Assertions.notNull(day, "The year is required.");
+		return FunctionInvocation.create(BuiltInFunctions.Temporals.DATE, Cypher
+			.mapOf("year", Cypher.literalOf(year), "month", Cypher.literalOf(month), "day", Cypher.literalOf(day)));
+	}
+
+	/**
+	 * Creates a function invocation for {@code date({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/date/">date</a>.
+	 *
+	 * @param year      The year
+	 * @param week      The optional week
+	 * @param dayOfWeek The optional day of the week
+	 * @return A function call for {@code date({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation weekDate(Integer year, Integer week, Integer dayOfWeek) {
+
+		Assertions.notNull(year, "The year is required.");
+		Object[] parameters = new Object[2 + (week == null ? 0 : 2) + (dayOfWeek == null ? 0 : 2)];
+		int i = 0;
+		parameters[i++] = "year";
+		parameters[i++] = Cypher.literalOf(year);
+		if (week != null) {
+			parameters[i++] = "week";
+			parameters[i++] = Cypher.literalOf(week);
+		}
+		if (dayOfWeek != null) {
+			if (week == null) {
+				throw new IllegalArgumentException("week is required when using dayOfWeek.");
+			}
+			parameters[i++] = "dayOfWeek";
+			parameters[i++] = Cypher.literalOf(dayOfWeek);
+		}
+		return FunctionInvocation.create(BuiltInFunctions.Temporals.DATE, Cypher.mapOf(parameters));
+	}
+
+	/**
+	 * Creates a function invocation for {@code date({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/date/">date</a>.
+	 *
+	 * @param year         The year
+	 * @param quarter      The optional week
+	 * @param dayOfQuarter The optional day of the week
+	 * @return A function call for {@code date({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation quarterDate(Integer year, Integer quarter, Integer dayOfQuarter) {
+
+		Assertions.notNull(year, "The year is required.");
+		Object[] parameters = new Object[2 + (quarter == null ? 0 : 2) + (dayOfQuarter == null ? 0 : 2)];
+		int i = 0;
+		parameters[i++] = "year";
+		parameters[i++] = Cypher.literalOf(year);
+		if (quarter != null) {
+			parameters[i++] = "quarter";
+			parameters[i++] = Cypher.literalOf(quarter);
+		}
+		if (dayOfQuarter != null) {
+			if (dayOfQuarter == null) {
+				throw new IllegalArgumentException("quarter is required when using dayOfQuarter.");
+			}
+			parameters[i++] = "dayOfQuarter";
+			parameters[i++] = Cypher.literalOf(dayOfQuarter);
+		}
+		return FunctionInvocation.create(BuiltInFunctions.Temporals.DATE, Cypher.mapOf(parameters));
+	}
+
+	/**
+	 * Creates a function invocation for {@code date({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/date/">date</a>.
+	 *
+	 * @param year       The year
+	 * @param ordinalDay The ordinal day of the year.
+	 * @return A function call for {@code date({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation ordinalDate(Integer year, Integer ordinalDay) {
+
+		Assertions.notNull(year, "The year is required.");
+		Object[] parameters = new Object[2 + (ordinalDay == null ? 0 : 2)];
+		int i = 0;
+		parameters[i++] = "year";
+		parameters[i++] = Cypher.literalOf(year);
+		if (ordinalDay != null) {
+			parameters[i++] = "ordinalDay";
+			parameters[i++] = Cypher.literalOf(ordinalDay);
+		}
+		return FunctionInvocation.create(BuiltInFunctions.Temporals.DATE, Cypher.mapOf(parameters));
+	}
+
+	/**
+	 * Creates a function invocation for {@code date({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/date/">date</a>.
+	 * This is the most generic form.
+	 *
+	 * @param components The map to pass to {@code date({})}
+	 * @return A function call for {@code date({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation date(MapExpression components) {
+
+		Assertions.notNull(components, "The components is required.");
+		return FunctionInvocation.create(BuiltInFunctions.Temporals.DATE, components);
+	}
+
+	/**
+	 * Creates a function invocation for {@code date({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/date/">date</a>.
+	 * This creates a date from a string.
+	 *
+	 * @param temporalValue A string representing a temporal value.
+	 * @return A function call for {@code date({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation date(String temporalValue) {
+
+		Assertions.hasText(temporalValue, "The temporalValue is required.");
+		return FunctionInvocation.create(BuiltInFunctions.Temporals.DATE, Cypher.literalOf(temporalValue));
+	}
+
+	/**
+	 * Creates a function invocation for {@code date({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/date/">date</a>.
+	 * This creates a date from a string.
+	 *
+	 * @param temporalValue An expression representing a temporal value.
+	 * @return A function call for {@code date({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation date(Expression temporalValue) {
+
+		Assertions.notNull(temporalValue, "The temporalValue is required.");
+		return FunctionInvocation.create(BuiltInFunctions.Temporals.DATE, temporalValue);
+	}
+
+	/**
+	 * Creates a function invocation for {@code datetime({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/datetime/">datetime</a>.
+	 *
+	 * @return A function call for {@code datetime({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation datetime() {
+
+		return FunctionInvocation.create(BuiltInFunctions.Temporals.DATETIME);
+	}
+
+	/**
+	 * Creates a function invocation for {@code datetime({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/datetime/">datetime</a>.
+	 *
+	 * @return A function call for {@code datetime({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation datetime(TimeZone timeZone) {
+
+		Assertions.notNull(timeZone, "The timezone is required.");
+		return FunctionInvocation
+			.create(BuiltInFunctions.Temporals.DATETIME, Cypher.mapOf("timezone", Cypher.literalOf(timeZone)));
+	}
+
+	/**
+	 * Creates a function invocation for {@code datetime({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/datetime/">datetime</a>.
+	 * This is the most generic form.
+	 *
+	 * @param components The map to pass to {@code datetime({})}
+	 * @return A function call for {@code datetime({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation datetime(MapExpression components) {
+
+		Assertions.notNull(components, "The components is required.");
+		return FunctionInvocation.create(BuiltInFunctions.Temporals.DATETIME, components);
+	}
+
+	/**
+	 * Creates a function invocation for {@code datetime({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/date/">datetime</a>.
+	 * This creates a datetime from a string.
+	 *
+	 * @param temporalValue A string representing a temporal value.
+	 * @return A function call for {@code datetime({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation datetime(String temporalValue) {
+
+		Assertions.hasText(temporalValue, "The temporalValue is required.");
+		return FunctionInvocation.create(BuiltInFunctions.Temporals.DATETIME, Cypher.literalOf(temporalValue));
+	}
+
+	/**
+	 * Creates a function invocation for {@code datetime({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/date/">datetime</a>.
+	 * This creates a datetime from a string.
+	 *
+	 * @param temporalValue An expression representing a temporal value.
+	 * @return A function call for {@code date({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation datetime(Expression temporalValue) {
+
+		Assertions.notNull(temporalValue, "The temporalValue is required.");
+		return FunctionInvocation.create(BuiltInFunctions.Temporals.DATETIME, temporalValue);
+	}
+
+	/**
+	 * Creates a function invocation for {@code localdatetime({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/localdatetime/">localdatetime</a>.
+	 *
+	 * @return A function call for {@code localdatetime({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation localdatetime() {
+
+		return FunctionInvocation.create(BuiltInFunctions.Temporals.LOCALDATETIME);
+	}
+
+	/**
+	 * Creates a function invocation for {@code localdatetime({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/localdatetime/">localdatetime</a>.
+	 *
+	 * @return A function call for {@code localdatetime({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation localdatetime(TimeZone timeZone) {
+
+		Assertions.notNull(timeZone, "The timezone is required.");
+		return FunctionInvocation
+			.create(BuiltInFunctions.Temporals.LOCALDATETIME, Cypher.mapOf("timezone", Cypher.literalOf(timeZone)));
+	}
+
+	/**
+	 * Creates a function invocation for {@code localdatetime({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/localdatetime/">localdatetime</a>.
+	 * This is the most generic form.
+	 *
+	 * @param components The map to pass to {@code localdatetime({})}
+	 * @return A function call for {@code localdatetime({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation localdatetime(MapExpression components) {
+
+		Assertions.notNull(components, "The components is required.");
+		return FunctionInvocation.create(BuiltInFunctions.Temporals.LOCALDATETIME, components);
+	}
+
+	/**
+	 * Creates a function invocation for {@code localdatetime({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/localdatetime/">localdatetime</a>.
+	 * This creates a localdatetime from a string.
+	 *
+	 * @param temporalValue A string representing a temporal value.
+	 * @return A function call for {@code localdatetime({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation localdatetime(String temporalValue) {
+
+		Assertions.hasText(temporalValue, "The temporalValue is required.");
+		return FunctionInvocation.create(BuiltInFunctions.Temporals.LOCALDATETIME, Cypher.literalOf(temporalValue));
+	}
+
+	/**
+	 * Creates a function invocation for {@code localdatetime({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/localdatetime/">localdatetime</a>.
+	 * This creates a localdatetime from a string.
+	 *
+	 * @param temporalValue An expression representing a temporal value.
+	 * @return A function call for {@code localdatetime({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation localdatetime(Expression temporalValue) {
+
+		Assertions.notNull(temporalValue, "The temporalValue is required.");
+		return FunctionInvocation.create(BuiltInFunctions.Temporals.LOCALDATETIME, temporalValue);
+	}
+
+	/**
+	 * Creates a function invocation for {@code localtime({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/localdatetime/">localtime</a>.
+	 *
+	 * @return A function call for {@code localtime({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation localtime() {
+
+		return FunctionInvocation.create(BuiltInFunctions.Temporals.LOCALTIME);
+	}
+
+	/**
+	 * Creates a function invocation for {@code localtime({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/localtime/">localtime</a>.
+	 *
+	 * @return A function call for {@code localtime({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation localtime(TimeZone timeZone) {
+
+		Assertions.notNull(timeZone, "The timezone is required.");
+		return FunctionInvocation
+			.create(BuiltInFunctions.Temporals.LOCALTIME, Cypher.mapOf("timezone", Cypher.literalOf(timeZone)));
+	}
+
+	/**
+	 * Creates a function invocation for {@code localtime({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/localdatetime/">localtime</a>.
+	 * This is the most generic form.
+	 *
+	 * @param components The map to pass to {@code localtime({})}
+	 * @return A function call for {@code localtime({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation localtime(MapExpression components) {
+
+		Assertions.notNull(components, "The components is required.");
+		return FunctionInvocation.create(BuiltInFunctions.Temporals.LOCALTIME, components);
+	}
+
+	/**
+	 * Creates a function invocation for {@code localtime({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/localtime/">localtime</a>.
+	 * This creates a localtime from a string.
+	 *
+	 * @param temporalValue A string representing a temporal value.
+	 * @return A function call for {@code localtime({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation localtime(String temporalValue) {
+
+		Assertions.hasText(temporalValue, "The temporalValue is required.");
+		return FunctionInvocation.create(BuiltInFunctions.Temporals.LOCALTIME, Cypher.literalOf(temporalValue));
+	}
+
+	/**
+	 * Creates a function invocation for {@code localtime({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/localtime/">localtime</a>.
+	 * This creates a localtime from a string.
+	 *
+	 * @param temporalValue An expression representing a temporal value.
+	 * @return A function call for {@code localtime({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation localtime(Expression temporalValue) {
+
+		Assertions.notNull(temporalValue, "The temporalValue is required.");
+		return FunctionInvocation.create(BuiltInFunctions.Temporals.LOCALTIME, temporalValue);
+	}
+
+	/**
+	 * Creates a function invocation for {@code time({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/time/">time</a>.
+	 *
+	 * @return A function call for {@code time({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation time() {
+
+		return FunctionInvocation.create(BuiltInFunctions.Temporals.TIME);
+	}
+
+	/**
+	 * Creates a function invocation for {@code time({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/time/">time</a>.
+	 *
+	 * @return A function call for {@code time({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation time(TimeZone timeZone) {
+
+		Assertions.notNull(timeZone, "The timezone is required.");
+		return FunctionInvocation
+			.create(BuiltInFunctions.Temporals.TIME, Cypher.mapOf("timezone", Cypher.literalOf(timeZone)));
+	}
+
+	/**
+	 * Creates a function invocation for {@code time({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/time/">time</a>.
+	 * This is the most generic form.
+	 *
+	 * @param components The map to pass to {@code time({})}
+	 * @return A function call for {@code time({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation time(MapExpression components) {
+
+		Assertions.notNull(components, "The components is required.");
+		return FunctionInvocation.create(BuiltInFunctions.Temporals.TIME, components);
+	}
+
+	/**
+	 * Creates a function invocation for {@code time({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/time/">time</a>.
+	 * This creates a time from a string.
+	 *
+	 * @param temporalValue A string representing a temporal value.
+	 * @return A function call for {@code time({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation time(String temporalValue) {
+
+		Assertions.hasText(temporalValue, "The temporalValue is required.");
+		return FunctionInvocation.create(BuiltInFunctions.Temporals.TIME, Cypher.literalOf(temporalValue));
+	}
+
+	/**
+	 * Creates a function invocation for {@code time({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/time/">time</a>.
+	 * This creates a time from a string.
+	 *
+	 * @param temporalValue An expression representing a temporal value.
+	 * @return A function call for {@code time({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation time(Expression temporalValue) {
+
+		Assertions.notNull(temporalValue, "The temporalValue is required.");
+		return FunctionInvocation.create(BuiltInFunctions.Temporals.TIME, temporalValue);
+	}
+
+	/**
+	 * Creates a function invocation for {@code duration({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/duration/">duration</a>.
+	 * This is the most generic form.
+	 *
+	 * @param components The map to pass to {@code duration({})}
+	 * @return A function call for {@code duration({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation duration(MapExpression components) {
+
+		Assertions.notNull(components, "The components is required.");
+		return FunctionInvocation.create(BuiltInFunctions.Temporals.DURATION, components);
+	}
+
+	/**
+	 * Creates a function invocation for {@code duration({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/duration/">duration</a>.
+	 * This creates a duration from a string.
+	 *
+	 * @param temporalAmount A string representing a temporal amount.
+	 * @return A function call for {@code duration({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation duration(String temporalAmount) {
+
+		Assertions.hasText(temporalAmount, "The temporalAmount is required.");
+		return FunctionInvocation.create(BuiltInFunctions.Temporals.DURATION, Cypher.literalOf(temporalAmount));
+	}
+
+	/**
+	 * Creates a function invocation for {@code duration({})}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/temporal/duration/">duration</a>.
+	 * This creates a duration from a string.
+	 *
+	 * @param temporalAmount An expression representing a temporal amount.
+	 * @return A function call for {@code duration({})}.
+	 * @since 2020.1.0
+	 */
+	public static FunctionInvocation duration(Expression temporalAmount) {
+
+		Assertions.notNull(temporalAmount, "The temporalAmount is required.");
+		return FunctionInvocation.create(BuiltInFunctions.Temporals.DURATION, temporalAmount);
 	}
 
 	public static FunctionInvocation shortestPath(Relationship relationship) {

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Functions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Functions.java
@@ -880,7 +880,7 @@ public final class Functions {
 
 		Assertions.notNull(timeZone, "The timezone is required.");
 		return FunctionInvocation
-			.create(BuiltInFunctions.Temporals.DATETIME, Cypher.mapOf("timezone", Cypher.literalOf(timeZone)));
+			.create(BuiltInFunctions.Temporals.DATETIME, timezoneMapLiteralOf(timeZone));
 	}
 
 	/**
@@ -951,7 +951,7 @@ public final class Functions {
 
 		Assertions.notNull(timeZone, "The timezone is required.");
 		return FunctionInvocation
-			.create(BuiltInFunctions.Temporals.LOCALDATETIME, Cypher.mapOf("timezone", Cypher.literalOf(timeZone)));
+			.create(BuiltInFunctions.Temporals.LOCALDATETIME, timezoneMapLiteralOf(timeZone));
 	}
 
 	/**
@@ -1022,7 +1022,7 @@ public final class Functions {
 
 		Assertions.notNull(timeZone, "The timezone is required.");
 		return FunctionInvocation
-			.create(BuiltInFunctions.Temporals.LOCALTIME, Cypher.mapOf("timezone", Cypher.literalOf(timeZone)));
+			.create(BuiltInFunctions.Temporals.LOCALTIME, timezoneMapLiteralOf(timeZone));
 	}
 
 	/**
@@ -1093,7 +1093,11 @@ public final class Functions {
 
 		Assertions.notNull(timeZone, "The timezone is required.");
 		return FunctionInvocation
-			.create(BuiltInFunctions.Temporals.TIME, Cypher.mapOf("timezone", Cypher.literalOf(timeZone)));
+			.create(BuiltInFunctions.Temporals.TIME, timezoneMapLiteralOf(timeZone));
+	}
+
+	private static MapExpression timezoneMapLiteralOf(TimeZone timeZone) {
+		return Cypher.mapOf("timezone", Cypher.literalOf(timeZone.getID()));
 	}
 
 	/**

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/FunctionsIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/FunctionsIT.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
+import java.util.TimeZone;
 import java.util.stream.Stream;
 
 import org.assertj.core.api.Assertions;
@@ -51,7 +52,6 @@ class FunctionsIT {
 	@ParameterizedTest(name = "{0}")
 	@MethodSource("functionsToTest")
 	void functionShouldBeRenderedAsExpected(FunctionInvocation functionInvocation, String expected) {
-
 		Assertions.assertThat(cypherRenderer.render(Cypher.returning(functionInvocation).build())).isEqualTo(expected);
 	}
 
@@ -104,7 +104,8 @@ class FunctionsIT {
 			Arguments.of(Functions.sum(e1), "RETURN sum(e1)"),
 			Arguments.of(Functions.sumDistinct(e1), "RETURN sum(DISTINCT e1)"),
 			Arguments.of(Functions.range(Cypher.literalOf(1), Cypher.literalOf(3)), "RETURN range(1, 3)"),
-			Arguments.of(Functions.range(Cypher.literalOf(1), Cypher.literalOf(3), Cypher.literalOf(2)), "RETURN range(1, 3, 2)"),
+			Arguments.of(Functions.range(Cypher.literalOf(1), Cypher.literalOf(3), Cypher.literalOf(2)),
+				"RETURN range(1, 3, 2)"),
 			Arguments.of(Functions.head(e1), "RETURN head(e1)"),
 			Arguments.of(Functions.last(e1), "RETURN last(e1)"),
 			Arguments.of(Functions.nodes(Cypher.path("p").definedBy(r)), "RETURN nodes(p)"),
@@ -114,7 +115,83 @@ class FunctionsIT {
 			Arguments.of(Functions.properties(Cypher.mapOf("a", Cypher.literalOf("b"))), "RETURN properties({a: 'b'})"),
 			Arguments.of(Functions.relationships(Cypher.path("p").definedBy(r)), "RETURN relationships(p)"),
 			Arguments.of(Functions.startNode(r), "RETURN startNode(r)"),
-			Arguments.of(Functions.endNode(r), "RETURN endNode(r)")
+			Arguments.of(Functions.endNode(r), "RETURN endNode(r)"),
+			Arguments.of(Functions.date(), "RETURN date()"),
+			Arguments.of(Functions.calendarDate(2020, 9, 21), "RETURN date({year: 2020, month: 9, day: 21})"),
+			Arguments.of(Functions.weekDate(1984, 10, 3), "RETURN date({year: 1984, week: 10, dayOfWeek: 3})"),
+			Arguments.of(Functions.weekDate(1984, 10, null), "RETURN date({year: 1984, week: 10})"),
+			Arguments.of(Functions.weekDate(1984, null, null), "RETURN date({year: 1984})"),
+			Arguments
+				.of(Functions.quarterDate(1984, 10, 45), "RETURN date({year: 1984, quarter: 10, dayOfQuarter: 45})"),
+			Arguments.of(Functions.quarterDate(1984, 10, null), "RETURN date({year: 1984, quarter: 10})"),
+			Arguments.of(Functions.quarterDate(1984, null, null), "RETURN date({year: 1984})"),
+			Arguments.of(Functions.ordinalDate(1984, 202), "RETURN date({year: 1984, ordinalDay: 202})"),
+			Arguments.of(Functions.ordinalDate(1984, null), "RETURN date({year: 1984})"),
+			Arguments.of(Functions.date(Cypher.mapOf("year", Cypher.literalOf(2020))), "RETURN date({year: 2020})"),
+			Arguments.of(Functions.date("2020-09-15"), "RETURN date('2020-09-15')"),
+			Arguments.of(Functions.date(Cypher.parameter("$myDateParameter")), "RETURN date($myDateParameter)"),
+			Arguments.of(Functions.datetime(), "RETURN datetime()"),
+			Arguments.of(Functions.datetime(
+				Cypher.mapOf("year", Cypher.literalOf(1984), "month", Cypher.literalOf(10), "day",
+					Cypher.literalOf(11), "hour", Cypher.literalOf(12), "minute", Cypher.literalOf(31), "timezone",
+					Cypher.literalOf("Europe/Stockholm")
+				)
+			), "RETURN datetime({year: 1984, month: 10, day: 11, hour: 12, minute: 31, timezone: 'Europe/Stockholm'})"),
+			Arguments
+				.of(Functions.datetime("2015-07-21T21:40:32.142+0100"),
+					"RETURN datetime('2015-07-21T21:40:32.142+0100')"),
+			Arguments.of(Functions.datetime(Cypher.parameter("$myDateParameter")), "RETURN datetime($myDateParameter)"),
+			Arguments.of(Functions.datetime(TimeZone.getTimeZone("America/Los_Angeles")),
+				"RETURN datetime({timezone: 'America/Los_Angeles'})"),
+			Arguments.of(Functions.localdatetime(), "RETURN localdatetime()"),
+			Arguments.of(Functions.localdatetime(
+				Cypher.mapOf("year", Cypher.literalOf(1984), "month", Cypher.literalOf(10), "day",
+					Cypher.literalOf(11), "hour", Cypher.literalOf(12), "minute", Cypher.literalOf(31), "second",
+					Cypher.literalOf(14), "millisecond", Cypher.literalOf(123), "microsecond", Cypher.literalOf(456),
+					"nanosecond", Cypher.literalOf(789)
+				)
+				),
+				"RETURN localdatetime({year: 1984, month: 10, day: 11, hour: 12, minute: 31, second: 14, millisecond: 123, microsecond: 456, nanosecond: 789})"),
+			Arguments
+				.of(Functions.localdatetime("2015-07-21T21:40:32.142"),
+					"RETURN localdatetime('2015-07-21T21:40:32.142')"),
+			Arguments.of(Functions.localdatetime(Cypher.parameter("$myDateParameter")),
+				"RETURN localdatetime($myDateParameter)"),
+			Arguments.of(Functions.localdatetime(TimeZone.getTimeZone("America/Los_Angeles")),
+				"RETURN localdatetime({timezone: 'America/Los_Angeles'})"),
+			Arguments.of(Functions.localtime(), "RETURN localtime()"),
+			Arguments.of(Functions.localtime(
+				Cypher.mapOf("hour", Cypher.literalOf(12), "minute", Cypher.literalOf(31), "second",
+					Cypher.literalOf(14), "millisecond", Cypher.literalOf(123), "microsecond", Cypher.literalOf(456),
+					"nanosecond", Cypher.literalOf(789)
+				)
+				),
+				"RETURN localtime({hour: 12, minute: 31, second: 14, millisecond: 123, microsecond: 456, nanosecond: 789})"),
+			Arguments
+				.of(Functions.localtime("21:40:32.142"), "RETURN localtime('21:40:32.142')"),
+			Arguments
+				.of(Functions.localtime(Cypher.parameter("$myDateParameter")), "RETURN localtime($myDateParameter)"),
+			Arguments.of(Functions.localtime(TimeZone.getTimeZone("America/Los_Angeles")),
+				"RETURN localtime({timezone: 'America/Los_Angeles'})"),
+			Arguments.of(Functions.time(), "RETURN time()"),
+			Arguments.of(Functions.time(
+				Cypher.mapOf("hour", Cypher.literalOf(12), "minute", Cypher.literalOf(31), "second",
+					Cypher.literalOf(14), "millisecond", Cypher.literalOf(123), "microsecond", Cypher.literalOf(456),
+					"nanosecond", Cypher.literalOf(789)
+				)
+			), "RETURN time({hour: 12, minute: 31, second: 14, millisecond: 123, microsecond: 456, nanosecond: 789})"),
+			Arguments
+				.of(Functions.time("21:40:32.142"), "RETURN time('21:40:32.142')"),
+			Arguments.of(Functions.time(Cypher.parameter("$myDateParameter")), "RETURN time($myDateParameter)"),
+			Arguments.of(Functions.time(TimeZone.getTimeZone("America/Los_Angeles")),
+				"RETURN time({timezone: 'America/Los_Angeles'})"),
+			Arguments.of(Functions.duration(
+				Cypher
+					.mapOf("days", Cypher.literalOf(14), "hours", Cypher.literalOf(16), "minutes", Cypher.literalOf(12))
+			), "RETURN duration({days: 14, hours: 16, minutes: 12})"),
+			Arguments
+				.of(Functions.duration("P14DT16H12M"), "RETURN duration('P14DT16H12M')"),
+			Arguments.of(Functions.duration(Cypher.parameter("$myDateParameter")), "RETURN duration($myDateParameter)")
 		);
 	}
 }


### PR DESCRIPTION
This add supports for most of the temporal functions. For date, it adds a couple of convinience methods. Otherwise the temporals can be called with map expressions, parameter expressions or string literals.

This fixes #89.

Please, @meistermeier have a quick look if I forgot something important or if you would generify the creation a bit (I wouldn't, I think the effort is not worth it).