### PR TITLE
Make sure aliased expressions are not rendered multiple times.

### DIFF
--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AliasedExpression.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AliasedExpression.java
@@ -19,6 +19,7 @@
 package org.neo4j.cypherdsl.core;
 
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.INTERNAL;
 
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.support.Visitor;
@@ -47,7 +48,8 @@ public final class AliasedExpression implements Aliased, Expression {
 		return alias;
 	}
 
-	Expression getDelegate() {
+	@API(status = INTERNAL)
+	public Expression getDelegate() {
 		return delegate;
 	}
 

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
@@ -3397,7 +3397,8 @@ class CypherIT {
 		}
 
 		@Test
-		void aliasedFunctionsShouldNotBeRenrederedTwiceInReturn() {
+		void aliasedFunctionsShouldNotBeRenderedTwiceInReturn() {
+
 			Node o = Cypher.node("Order").named("o");
 			Node li = Cypher.node("LineItem").named("li");
 			Relationship hasLineItems = o.relationshipTo(li).named("h");


### PR DESCRIPTION
This became appearent when trying to formulate

```
String query = ""
			+ "MATCH (n:Order) - [r:HAS] -> (l:LineItem) "
			+ "WHERE n.id = $id "
			+ "WITH n, sum(l.price * l.quantity) AS netAmount, collect(r) as hasRel, collect(l) as lineItems "
			+ "RETURN {"
			+ " netAmount: netAmount,"
			+ "	taxAmount: netAmount * $taxRate,"
			+ " totalAmount: netAmount * (1+$taxRate),"
			+ " hasRel: hasRel, lineItems: lineItems"
			+ "}";
```

for the spring data neo4j native project.