### PR TITLE
Fix missing labels for nodes after `WITH`.

### DIFF
--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/DefaultVisitor.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/DefaultVisitor.java
@@ -83,7 +83,6 @@ import org.neo4j.cypherdsl.core.YieldItems;
 import org.neo4j.cypherdsl.core.support.ReflectiveVisitor;
 import org.neo4j.cypherdsl.core.support.TypedSubtree;
 import org.neo4j.cypherdsl.core.support.Visitable;
-import org.neo4j.cypherdsl.core.support.Visitor;
 import org.neo4j.cypherdsl.core.utils.Strings;
 
 /**
@@ -297,7 +296,7 @@ class DefaultVisitor extends ReflectiveVisitor implements RenderingVisitor {
 		// TODO This must be probably nested for subqueries, too
 		java.util.Set<Named> retain = new HashSet<>();
 		with.accept(segment -> {
-			if(segment instanceof SymbolicName) {
+			if (segment instanceof SymbolicName) {
 				visitedNamed.stream()
 					.filter(named -> named.getRequiredSymbolicName().equals(segment))
 					.forEach(retain::add);

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
@@ -654,7 +654,7 @@ class CypherIT {
 
 			assertThat(cypherRenderer.render(statement))
 				.isEqualTo(
-					"MATCH (u:`User`)-[:`OWNS`]->(b:`Bike`) MATCH (t:`Trip`) DELETE t WITH b, t MATCH (u) WITH b, u RETURN b, u");
+					"MATCH (u:`User`)-[:`OWNS`]->(b:`Bike`) MATCH (t:`Trip`) DELETE t WITH b, t MATCH (u:`User`) WITH b, u RETURN b, u");
 		}
 	}
 


### PR DESCRIPTION
A node must be rendered completly after a `WITH` clause as long as it has not been carried forward in the body of that clause.