### PR TITLE
GH-154 - Make Node and Relationship extendable.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
       - name: Run Maven build
         run: >
           ./mvnw --no-transfer-progress clean deploy -Drevision=$REVISION -Dsha1=-$GITHUB_SHA -Dchangelist=
@@ -28,6 +28,27 @@ jobs:
         with:
           name: artifacts
           path: target/repository
+
+  test_on_jdk8:
+    name: Verify tests on JDK 8
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Determine revision
+        run: echo "REVISION=$(date +'%Y.0.0')" >> $GITHUB_ENV
+      - uses: actions/checkout@v1
+      - name: Download artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: artifacts
+          path: repository
+      - name: Install dependencies
+        run: "mkdir -p $HOME/.m2 && mv $GITHUB_WORKSPACE/repository $HOME/.m2/"
+      - name: Run tests
+        run: >
+          docker run -v `pwd`:/ws --workdir=/ws jbangdev/jbang-action --java 8 bin/runtests.java
+          -cp $GITHUB_WORKSPACE/repository/org/neo4j/neo4j-cypher-dsl/$REVISION-$GITHUB_SHA/neo4j-cypher-dsl-$REVISION-$GITHUB_SHA.jar
+          -cp neo4j-cypher-dsl/target/test-classes --select-package=org.neo4j.cypherdsl
 
   test_native:
     name: Verify compilation on GraalVM native

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,15 +37,21 @@ jobs:
       - name: Determine revision
         run: echo "REVISION=$(date +'%Y.0.0')" >> $GITHUB_ENV
       - uses: actions/checkout@v1
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
       - name: Download artifacts
         uses: actions/download-artifact@v1
         with:
           name: artifacts
-          path: repository
+          path: binaries
+      - name: Recreate test classes
+        run: ./mvnw test-compile -pl org.neo4j:neo4j-cypher-dsl
       - name: Run tests
         run: >
           docker run -v `pwd`:/ws --workdir=/ws jbangdev/jbang-action --java 8 bin/runtests.java
-          -cp repository/org/neo4j/neo4j-cypher-dsl/$REVISION-$GITHUB_SHA/neo4j-cypher-dsl-$REVISION-$GITHUB_SHA.jar
+          -cp binaries/org/neo4j/neo4j-cypher-dsl/$REVISION-$GITHUB_SHA/neo4j-cypher-dsl-$REVISION-$GITHUB_SHA.jar
           -cp neo4j-cypher-dsl/target/test-classes --select-package=org.neo4j.cypherdsl
 
   test_native:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,8 +42,6 @@ jobs:
         with:
           name: artifacts
           path: repository
-      - name: Install dependencies
-        run: "mkdir -p $HOME/.m2 && mv $GITHUB_WORKSPACE/repository $HOME/.m2/"
       - name: Run tests
         run: >
           docker run -v `pwd`:/ws --workdir=/ws jbangdev/jbang-action --java 8 bin/runtests.java

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,7 @@ jobs:
           docker run -v `pwd`:/ws --workdir=/ws jbangdev/jbang-action --java 8 bin/runtests.java
           -cp binaries/org/neo4j/neo4j-cypher-dsl/$REVISION-$GITHUB_SHA/neo4j-cypher-dsl-$REVISION-$GITHUB_SHA.jar
           -cp neo4j-cypher-dsl/target/test-classes --select-package=org.neo4j.cypherdsl
+          --include-classname=\.\*Test --include-classname=\.\*IT
 
   test_native:
     name: Verify compilation on GraalVM native

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
           name: artifacts
           path: binaries
       - name: Recreate test classes
-        run: ./mvnw test-compile -pl org.neo4j:neo4j-cypher-dsl
+        run: ./mvnw --no-transfer-progress test-compile -pl org.neo4j:neo4j-cypher-dsl
       - name: Run tests
         run: >
           docker run -v `pwd`:/ws --workdir=/ws jbangdev/jbang-action --java 8 bin/runtests.java

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Run tests
         run: >
           docker run -v `pwd`:/ws --workdir=/ws jbangdev/jbang-action --java 8 bin/runtests.java
-          -cp $GITHUB_WORKSPACE/repository/org/neo4j/neo4j-cypher-dsl/$REVISION-$GITHUB_SHA/neo4j-cypher-dsl-$REVISION-$GITHUB_SHA.jar
+          -cp repository/org/neo4j/neo4j-cypher-dsl/$REVISION-$GITHUB_SHA/neo4j-cypher-dsl-$REVISION-$GITHUB_SHA.jar
           -cp neo4j-cypher-dsl/target/test-classes --select-package=org.neo4j.cypherdsl
 
   test_native:

--- a/README.adoc
+++ b/README.adoc
@@ -87,8 +87,10 @@ class SimpleExample {
 }
 ----
 
-=== Required JDK Version
+=== Required Java Version
 
-The minimal required version to use the Cypher-DSL core module is *JDK 8*.
+The minimal required Java version to use the Cypher-DSL core module is *Java 8*.
 The reason for staying on JDK 8 is the fact that the Cypher-DSL is widely used in https://github.com/spring-projects/spring-data-neo4j[Spring Data Neo4j 6+].
 Spring Data Neo4j shares JDK 8 as baseline with the Spring Framework until Spring Framework 6 is released.
+
+The minimal required JDK version to build the Cypher-DSL is *JDK 11*. To build the native examples, GraalVM 11 is required.

--- a/bin/runtests.java
+++ b/bin/runtests.java
@@ -1,0 +1,14 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS org.junit.platform:junit-platform-console-standalone:1.7.1
+//DEPS org.assertj:assertj-core:3.15.0
+//DEPS org.mockito:mockito-junit-jupiter:3.6.0
+import org.junit.platform.console.ConsoleLauncher;
+
+/**
+ * This script is mainly used to execute our tests standalone in CI with JDK 8.
+ */
+public class runtests {
+	public static void main(String...a) {
+		ConsoleLauncher.main(a);
+	}
+}

--- a/docs/appendix/building.adoc
+++ b/docs/appendix/building.adoc
@@ -6,15 +6,11 @@ For the full project, including examples and native tests:
 
 * GraalVM based on JDK 11: https://www.graalvm.org/downloads/
 
-For the project, incuding examples but skipping native tests
+For the project, including examples but skipping native tests
 
 * JDK 11+ (Can be https://openjdk.java.net[OpenJDK] or https://www.oracle.com/technetwork/java/index.html[Oracle JDK])
 
-Only the core modules:
-
-* JDK 8
-
-* Maven 3.6.3 (We provide the Maven wrapper, see `mvnw` respectively `mvnw.cmd` in the project root; the wrapper downloads the appropriate Maven version automatically)
+Maven 3.6.3 is our build tool of choice. We provide the Maven wrapper, see `mvnw` respectively `mvnw.cmd` in the project root; the wrapper downloads the appropriate Maven version automatically.
 
 The build requires a local copy of the project:
 
@@ -54,7 +50,7 @@ graalvm                  21.0.0              GraalVM Core                  -
 native-image             21.0.0              Native Image                  Early adopter       github.com
 ----
 
-You should see `native-image in the list. If not, install it via `gu install native-image`.
+You should see `native-image` in the list. If not, install it via `gu install native-image`.
 
 After that, use `./mvnw` on a Unix-like operating system to build the Cypher-DSL:
 
@@ -87,7 +83,7 @@ $ ./mvnw clean verify -pl \!org.neo4j:neo4j-cypher-dsl-native-tests
 
 === Build only the core module
 
-The core module can be build on plain JDK 8 with:
+The core module can be build on plain JDK 11 with:
 
 [source,console,subs="verbatim,attributes"]
 [[build-only-core-bash]]

--- a/neo4j-cypher-dsl/pom.xml
+++ b/neo4j-cypher-dsl/pom.xml
@@ -29,6 +29,7 @@
 	<artifactId>neo4j-cypher-dsl</artifactId>
 
 	<name>Neo4j Cypher DSL (Core)</name>
+	<description>The core module of the Cypher DSL, including all supported elements and the default renderer.</description>
 
 	<properties>
 		<java-module-name>org.neo4j.cypherdsl.core</java-module-name>

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractNode.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractNode.java
@@ -27,9 +27,9 @@ import static org.apiguardian.api.API.Status.INTERNAL;
  * in inheritors.
  *
  * @author Michael J. Simons
- * @since TBA
+ * @since 2021.1.0
  */
-@API(status = INTERNAL, since = "TBA")
+@API(status = INTERNAL, since = "2021.1.0")
 abstract class AbstractNode extends AbstractPropertyContainer implements Node {
 
 	@Override

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractNode.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractNode.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2019-2021 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.core;
+
+import org.apiguardian.api.API;
+
+import static org.apiguardian.api.API.Status.INTERNAL;
+
+/**
+ * Abstract base class for the {@link NodeImpl node implementation} to avoid default interface methods to be overridable
+ * in inheritors.
+ *
+ * @author Michael J. Simons
+ * @since TBA
+ */
+@API(status = INTERNAL, since = "TBA")
+abstract class AbstractNode extends AbstractPropertyContainer implements Node {
+
+	@Override
+	public final Condition hasLabels(String... labelsToQuery) {
+		return HasLabelCondition.create(this.getSymbolicName()
+						.orElseThrow(() -> new IllegalStateException("Cannot query a node without a symbolic name.")),
+				labelsToQuery);
+	}
+
+	@Override
+	public final Condition isEqualTo(Node otherNode) {
+
+		return this.getRequiredSymbolicName().isEqualTo(otherNode.getRequiredSymbolicName());
+	}
+
+	@Override
+	public final Condition isNotEqualTo(Node otherNode) {
+
+		return this.getRequiredSymbolicName().isNotEqualTo(otherNode.getRequiredSymbolicName());
+	}
+
+	@Override
+	public final Condition isNull() {
+
+		return this.getRequiredSymbolicName().isNull();
+	}
+
+	@Override
+	public final Condition isNotNull() {
+
+		return this.getRequiredSymbolicName().isNotNull();
+	}
+
+	@Override
+	public final SortItem descending() {
+
+		return this.getRequiredSymbolicName().descending();
+	}
+
+	@Override
+	public final SortItem ascending() {
+
+		return this.getRequiredSymbolicName().ascending();
+	}
+
+	@Override
+	public final AliasedExpression as(String alias) {
+
+		return this.getRequiredSymbolicName().as(alias);
+	}
+
+	@Override
+	public final FunctionInvocation internalId() {
+		return Functions.id(this);
+	}
+
+	@Override
+	public final FunctionInvocation labels() {
+		return Functions.labels(this);
+	}
+
+	@Override
+	public final Relationship relationshipTo(Node other, String... types) {
+		return new RelationshipImpl(null, this, Relationship.Direction.LTR, other, types);
+	}
+
+	@Override
+	public final Relationship relationshipFrom(Node other, String... types) {
+		return new RelationshipImpl(null, this, Relationship.Direction.RTL, other, types);
+	}
+
+	@Override
+	public final Relationship relationshipBetween(Node other, String... types) {
+		return new RelationshipImpl(null, this, Relationship.Direction.UNI, other, types);
+	}
+}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractPropertyContainer.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractPropertyContainer.java
@@ -28,9 +28,9 @@ import static org.apiguardian.api.API.Status.INTERNAL;
  * Abstract base class for all property containers to avoid default interface methods to be overridable in inheritors.
  *
  * @author Michael J. Simons
- * @since TBA
+ * @since 2021.1.0
  */
-@API(status = INTERNAL, since = "TBA")
+@API(status = INTERNAL, since = "2021.1.0")
 abstract class AbstractPropertyContainer implements PropertyContainer {
 
 	@Override

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractPropertyContainer.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractPropertyContainer.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2019-2021 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.core;
+
+import org.apiguardian.api.API;
+
+import java.util.List;
+
+import static org.apiguardian.api.API.Status.INTERNAL;
+
+/**
+ * Abstract base class for all property containers to avoid default interface methods to be overridable in inheritors.
+ *
+ * @author Michael J. Simons
+ * @since TBA
+ */
+@API(status = INTERNAL, since = "TBA")
+abstract class AbstractPropertyContainer implements PropertyContainer {
+
+	@Override
+	public final Property property(String name) {
+		return property(new String[]{name});
+	}
+
+	@Override
+	public final Property property(String... names) {
+		return Property.create(this, names);
+	}
+
+	@Override
+	public final Property property(Expression lookup) {
+		return Property.create(this, lookup);
+	}
+
+	@Override
+	public final Operation mutate(Parameter parameter) {
+		return Operations.mutate(this.getSymbolicName()
+						.orElseThrow(() -> new IllegalStateException("A property container must be named to be mutated.")),
+				parameter);
+	}
+
+	@Override
+	public final Operation mutate(MapExpression properties) {
+		return Operations.mutate(this.getSymbolicName()
+						.orElseThrow(() -> new IllegalStateException("A property container must be named to be mutated.")),
+				properties);
+	}
+
+	@Override
+	public final MapProjection project(List<Object> entries) {
+		return project(entries.toArray());
+	}
+
+	@Override
+	public final MapProjection project(Object... entries) {
+		return getRequiredSymbolicName().project(entries);
+	}
+}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
@@ -54,7 +54,7 @@ public final class Cypher {
 	 */
 	public static Node node(String primaryLabel, String... additionalLabels) {
 
-		return Node.create(primaryLabel, additionalLabels);
+		return new NodeImpl(primaryLabel, additionalLabels);
 	}
 
 	/**
@@ -67,7 +67,7 @@ public final class Cypher {
 	 */
 	public static Node node(String primaryLabel, List<String> additionalLabels) {
 
-		return Node.create(primaryLabel, additionalLabels.toArray(new String[] {}));
+		return new NodeImpl(primaryLabel, additionalLabels.toArray(new String[] {}));
 	}
 
 	/**
@@ -82,14 +82,14 @@ public final class Cypher {
 	 */
 	public static Node node(String primaryLabel, MapExpression properties, String... additionalLabels) {
 
-		return Node.create(primaryLabel, properties, additionalLabels);
+		return new NodeImpl(null, primaryLabel, properties, additionalLabels);
 	}
 
 	/**
 	 * @return A node matching any node.
 	 */
 	public static Node anyNode() {
-		return Node.create();
+		return new NodeImpl();
 	}
 
 	/**
@@ -104,7 +104,7 @@ public final class Cypher {
 	 * @return A node matching any node with the symbolic the given {@code symbolicName}.
 	 */
 	public static Node anyNode(String symbolicName) {
-		return Node.create().named(symbolicName);
+		return new NodeImpl().named(symbolicName);
 	}
 
 	/**
@@ -112,7 +112,7 @@ public final class Cypher {
 	 * @return A node matching any node with the symbolic the given {@code symbolicName}.
 	 */
 	public static Node anyNode(SymbolicName symbolicName) {
-		return Node.create().named(symbolicName);
+		return new NodeImpl().named(symbolicName);
 	}
 
 	/**

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
@@ -399,6 +399,7 @@ public final class Cypher {
 	 *
 	 * @param map A map to be turned into a MapExpression
 	 * @return A new map expression.
+	 * @since 2021.1.0
 	 */
 	public static MapExpression asExpression(Map<String, Object> map) {
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesProperties.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesProperties.java
@@ -54,8 +54,5 @@ public interface ExposesProperties<T extends ExposesProperties<?> & PropertyCont
 	 * @param newProperties A map with the new properties
 	 * @return The new property container.
 	 */
-	default T withProperties(Map<String, Object> newProperties) {
-
-		return withProperties(MapExpression.create(newProperties));
-	}
+	T withProperties(Map<String, Object> newProperties);
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Expression.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Expression.java
@@ -69,6 +69,16 @@ public interface Expression extends Visitable {
 	}
 
 	/**
+	 * An alias for {@link #isEqualTo(Expression)}.
+	 *
+	 * @param rhs The right hand side of the condition
+	 * @return A new condition
+	 */
+	default Condition eq(Expression rhs) {
+		return isEqualTo(rhs);
+	}
+
+	/**
 	 * Creates a {@code lhs <> rhs} condition.
 	 *
 	 * @param rhs The right hand side of the condition
@@ -76,6 +86,16 @@ public interface Expression extends Visitable {
 	 */
 	default Condition isNotEqualTo(Expression rhs) {
 		return Conditions.isNotEqualTo(this, rhs);
+	}
+
+	/**
+	 * An alias for {@link #isNotEqualTo(Expression)}.
+	 *
+	 * @param rhs The right hand side of the condition
+	 * @return A new condition
+	 */
+	default Condition ne(Expression rhs) {
+		return isNotEqualTo(rhs);
 	}
 
 	/**

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Hint.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Hint.java
@@ -133,7 +133,7 @@ public final class Hint implements Visitable {
 		Assertions.isTrue(labels.size() == 1, "Exactly one label is required for a SCAN hint.");
 
 		return new Hint(Type.SCAN,
-			Collections.singletonList(new IndexReference(node.getRequiredSymbolicName(), node.getLabels().get(0))),
+			Collections.singletonList(new IndexReference(node.getRequiredSymbolicName(), labels.get(0))),
 			null);
 	}
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Node.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Node.java
@@ -19,20 +19,10 @@
 package org.neo4j.cypherdsl.core;
 
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
-import static org.apiguardian.api.API.Status.INTERNAL;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
-import org.neo4j.cypherdsl.core.Relationship.Direction;
-import org.neo4j.cypherdsl.core.support.Visitable;
-import org.neo4j.cypherdsl.core.support.Visitor;
-import org.neo4j.cypherdsl.core.utils.Assertions;
 
 /**
  * See <a href="https://s3.amazonaws.com/artifacts.opencypher.org/M15/railroad/NodePattern.html">NodePattern</a>.
@@ -41,61 +31,9 @@ import org.neo4j.cypherdsl.core.utils.Assertions;
  * @since 1.0
  */
 @API(status = EXPERIMENTAL, since = "1.0")
-public final class Node implements PatternElement, PropertyContainer, ExposesRelationships<Relationship>, ExposesProperties<Node> {
+public interface Node extends PatternElement, PropertyContainer, ExposesProperties<Node>, ExposesRelationships<Relationship> {
 
-	static Node create(String primaryLabel, String... additionalLabels) {
-
-		return create(primaryLabel, null, additionalLabels);
-	}
-
-	static Node create(String primaryLabel, MapExpression properties, String... additionalLabels) {
-
-		Assertions.hasText(primaryLabel, "A primary label is required.");
-
-		for (String additionalLabel : additionalLabels) {
-			Assertions.hasText(additionalLabel, "An empty label is not allowed.");
-		}
-
-		return new Node(primaryLabel, properties == null ? null : new Properties(properties), additionalLabels);
-	}
-
-	/**
-	 * @return A node without labels and properties
-	 */
-	static Node create() {
-		return new Node(null, null);
-	}
-
-	private volatile SymbolicName symbolicName;
-
-	private final List<NodeLabel> labels;
-
-	private final Properties properties;
-
-	private Node(String primaryLabel, Properties properties, String... additionalLabels) {
-
-		this.symbolicName = null;
-
-		this.labels = new ArrayList<>();
-		if (!(primaryLabel == null || primaryLabel.isEmpty())) {
-			this.labels.add(new NodeLabel(primaryLabel));
-		}
-		this.labels.addAll(Arrays.stream(additionalLabels).map(NodeLabel::new).collect(Collectors.toList()));
-		this.properties = properties;
-	}
-
-	private Node(SymbolicName symbolicName, Properties properties, List<NodeLabel> labels) {
-
-		this.symbolicName = symbolicName;
-
-		this.labels = new ArrayList<>(labels);
-		this.properties = properties;
-	}
-
-	@API(status = INTERNAL)
-	List<NodeLabel> getLabels() {
-		return Collections.unmodifiableList(labels);
-	}
+	List<NodeLabel> getLabels();
 
 	/**
 	 * Creates a copy of this node with a new symbolic name.
@@ -103,11 +41,7 @@ public final class Node implements PatternElement, PropertyContainer, ExposesRel
 	 * @param newSymbolicName the new symbolic name.
 	 * @return The new node.
 	 */
-	public Node named(String newSymbolicName) {
-
-		Assertions.hasText(newSymbolicName, "Symbolic name is required.");
-		return new Node(SymbolicName.of(newSymbolicName), properties, labels);
-	}
+	Node named(String newSymbolicName);
 
 	/**
 	 * Creates a copy of this node with a new symbolic name.
@@ -115,79 +49,7 @@ public final class Node implements PatternElement, PropertyContainer, ExposesRel
 	 * @param newSymbolicName the new symbolic name.
 	 * @return The new node.
 	 */
-	public Node named(SymbolicName newSymbolicName) {
-
-		Assertions.notNull(newSymbolicName, "Symbolic name is required.");
-		return new Node(newSymbolicName, properties, labels);
-	}
-
-	@Override
-	public Node withProperties(MapExpression newProperties) {
-
-		return new Node(this.symbolicName, newProperties == null ? null : new Properties(newProperties), labels);
-	}
-
-	@Override
-	public Node withProperties(Object... keysAndValues) {
-
-		MapExpression newProperties = null;
-		if (keysAndValues != null && keysAndValues.length != 0) {
-			newProperties = MapExpression.create(keysAndValues);
-		}
-		return withProperties(newProperties);
-	}
-
-	/**
-	 * @return The optional symbolic name of this node.
-	 */
-	public Optional<SymbolicName> getSymbolicName() {
-		return Optional.ofNullable(symbolicName);
-	}
-
-	@Override
-	public SymbolicName getRequiredSymbolicName() {
-
-		SymbolicName requiredSymbolicName = this.symbolicName;
-		if (requiredSymbolicName == null) {
-			synchronized (this) {
-				requiredSymbolicName = this.symbolicName;
-				if (requiredSymbolicName == null) {
-					this.symbolicName = SymbolicName.unresolved();
-					requiredSymbolicName = this.symbolicName;
-				}
-			}
-		}
-		return requiredSymbolicName;
-	}
-
-	/**
-	 * @return A new function invocation returning the internal id of this node.
-	 */
-	public FunctionInvocation internalId() {
-		return Functions.id(this);
-	}
-
-	/**
-	 * @return A new function invocation returning the labels of this node.
-	 */
-	public FunctionInvocation labels() {
-		return Functions.labels(this);
-	}
-
-	@Override
-	public Relationship relationshipTo(Node other, String... types) {
-		return Relationship.create(this, Direction.LTR, other, types);
-	}
-
-	@Override
-	public Relationship relationshipFrom(Node other, String... types) {
-		return Relationship.create(this, Direction.RTL, other, types);
-	}
-
-	@Override
-	public Relationship relationshipBetween(Node other, String... types) {
-		return Relationship.create(this, Direction.UNI, other, types);
-	}
+	Node named(SymbolicName newSymbolicName);
 
 	/**
 	 * A condition that checks for the presence of labels on a node.
@@ -195,29 +57,7 @@ public final class Node implements PatternElement, PropertyContainer, ExposesRel
 	 * @param labelsToQuery A list of labels to query
 	 * @return A condition that checks whether this node has all of the labels to query
 	 */
-	public Condition hasLabels(String... labelsToQuery) {
-		return HasLabelCondition.create(this.getSymbolicName()
-				.orElseThrow(() -> new IllegalStateException("Cannot query a node without a symbolic name.")),
-			labelsToQuery);
-	}
-
-	@Override
-	public void accept(Visitor visitor) {
-
-		visitor.enter(this);
-		Visitable.visitIfNotNull(this.symbolicName, visitor);
-		this.labels.forEach(label -> label.accept(visitor));
-		Visitable.visitIfNotNull(this.properties, visitor);
-		visitor.leave(this);
-	}
-
-	@Override
-	public String toString() {
-		return "Node{" +
-				"symbolicName=" + symbolicName +
-				", labels=" + labels +
-				'}';
-	}
+	Condition hasLabels(String... labelsToQuery);
 
 	/**
 	 * Creates a new condition whether this node is equal to {@literal otherNode}.
@@ -225,10 +65,7 @@ public final class Node implements PatternElement, PropertyContainer, ExposesRel
 	 * @param otherNode The node to compare this node to.
 	 * @return A condition.
 	 */
-	public Condition isEqualTo(Node otherNode) {
-
-		return this.getRequiredSymbolicName().isEqualTo(otherNode.getRequiredSymbolicName());
-	}
+	Condition isEqualTo(Node otherNode);
 
 	/**
 	 * Creates a new condition whether this node is not equal to {@literal otherNode}.
@@ -236,50 +73,35 @@ public final class Node implements PatternElement, PropertyContainer, ExposesRel
 	 * @param otherNode The node to compare this node to.
 	 * @return A condition.
 	 */
-	public Condition isNotEqualTo(Node otherNode) {
-
-		return this.getRequiredSymbolicName().isNotEqualTo(otherNode.getRequiredSymbolicName());
-	}
+	Condition isNotEqualTo(Node otherNode);
 
 	/**
 	 * Creates a new condition based on this node whether it is null.
 	 *
 	 * @return A condition.
 	 */
-	public Condition isNull() {
-
-		return this.getRequiredSymbolicName().isNull();
-	}
+	Condition isNull();
 
 	/**
 	 * Creates a new condition based on this node whether it is not null.
 	 *
 	 * @return A condition.
 	 */
-	public Condition isNotNull() {
-
-		return this.getRequiredSymbolicName().isNotNull();
-	}
+	Condition isNotNull();
 
 	/**
 	 * Creates a new sort item of this node in descending order.
 	 *
 	 * @return A sort item.
 	 */
-	public SortItem descending() {
-
-		return this.getRequiredSymbolicName().descending();
-	}
+	SortItem descending();
 
 	/**
 	 * Creates a new sort item of this node in ascending order.
 	 *
 	 * @return A sort item.
 	 */
-	public SortItem ascending() {
-
-		return this.getRequiredSymbolicName().ascending();
-	}
+	SortItem ascending();
 
 	/**
 	 * Creates an alias for this node.
@@ -287,8 +109,15 @@ public final class Node implements PatternElement, PropertyContainer, ExposesRel
 	 * @param alias The alias to use.
 	 * @return The aliased expression.
 	 */
-	public AliasedExpression as(String alias) {
+	AliasedExpression as(String alias);
 
-		return this.getRequiredSymbolicName().as(alias);
-	}
+	/**
+	 * @return A new function invocation returning the internal id of this node.
+	 */
+	FunctionInvocation internalId();
+
+	/**
+	 * @return A new function invocation returning the labels of this node.
+	 */
+	FunctionInvocation labels();
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NodeImpl.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NodeImpl.java
@@ -40,9 +40,9 @@ import org.neo4j.cypherdsl.core.utils.Assertions;
  * @param <T> The type of this node
  * @author Michael J. Simons
  * @soundtrack Queen - The Miracle
- * @since TBA
+ * @since 2021.1.0
  */
-@API(status = EXPERIMENTAL, since = "TBA")
+@API(status = EXPERIMENTAL, since = "2021.1.0")
 public class NodeImpl<T extends Node> extends AbstractNode implements Node {
 
 	private volatile SymbolicName symbolicName;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NodeImpl.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NodeImpl.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2019-2021 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.core;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.apiguardian.api.API;
+import org.neo4j.cypherdsl.core.support.Visitable;
+import org.neo4j.cypherdsl.core.support.Visitor;
+import org.neo4j.cypherdsl.core.utils.Assertions;
+
+/**
+ * This is the base class for all nodes. It can be used with generics, specifying a valid type.
+ * This is useful when using it as a base class for a static meta model.
+ *
+ * @param <T> The type of this node
+ * @author Michael J. Simons
+ * @soundtrack Queen - The Miracle
+ * @since TBA
+ */
+@API(status = EXPERIMENTAL, since = "TBA")
+public class NodeImpl<T extends Node> extends AbstractNode implements Node {
+
+	private volatile SymbolicName symbolicName;
+
+	private final List<NodeLabel> labels;
+
+	private final Properties properties;
+
+	// ------------------------------------------------------------------------
+	// Public API to be used by the static meta model.
+	// Non-final methods are ok to be overwritten.
+	// ------------------------------------------------------------------------
+
+	protected NodeImpl(String primaryLabel, String... additionalLabels) {
+
+		this(null, primaryLabel, null, additionalLabels);
+	}
+
+	protected NodeImpl(SymbolicName symbolicName, List<NodeLabel> labels, Properties properties) {
+
+		this.symbolicName = symbolicName;
+		this.labels = new ArrayList<>(labels);
+		this.properties = properties;
+	}
+
+	@Override
+	public final T named(String newSymbolicName) {
+
+		Assertions.hasText(newSymbolicName, "Symbolic name is required.");
+		return named(SymbolicName.of(newSymbolicName));
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public T named(SymbolicName newSymbolicName) {
+
+		Assertions.notNull(newSymbolicName, "Symbolic name is required.");
+		return (T) new NodeImpl(newSymbolicName, labels, properties);
+	}
+
+	@Override
+	public final T withProperties(Object... keysAndValues) {
+
+		MapExpression newProperties = null;
+		if (keysAndValues != null && keysAndValues.length != 0) {
+			newProperties = MapExpression.create(keysAndValues);
+		}
+		return withProperties(newProperties);
+	}
+
+	@Override
+	public final T withProperties(Map<String, Object> newProperties) {
+
+		return withProperties(MapExpression.create(newProperties));
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public T withProperties(MapExpression newProperties) {
+
+		return (T) new NodeImpl(this.getSymbolicName().orElse(null), labels, Properties.create(newProperties));
+	}
+
+	protected final Properties getProperties() {
+		return properties;
+	}
+
+	@Override
+	public final List<NodeLabel> getLabels() {
+		return Collections.unmodifiableList(labels);
+	}
+
+	@Override
+	public final Optional<SymbolicName> getSymbolicName() {
+		return Optional.ofNullable(symbolicName);
+	}
+
+	@Override
+	public final SymbolicName getRequiredSymbolicName() {
+
+		SymbolicName requiredSymbolicName = this.symbolicName;
+		if (requiredSymbolicName == null) {
+			synchronized (this) {
+				requiredSymbolicName = this.symbolicName;
+				if (requiredSymbolicName == null) {
+					this.symbolicName = SymbolicName.unresolved();
+					requiredSymbolicName = this.symbolicName;
+				}
+			}
+		}
+		return requiredSymbolicName;
+	}
+
+	// ------------------------------------------------------------------------
+	// Internal API.
+	// ------------------------------------------------------------------------
+
+	NodeImpl() {
+
+		this(null, Collections.emptyList(), null);
+	}
+
+	NodeImpl(SymbolicName symbolicName, String primaryLabel, MapExpression properties, String... additionalLabels) {
+
+		this(symbolicName, assertLabels(primaryLabel, additionalLabels), Properties.create(properties));
+	}
+
+	@Override
+	public final void accept(Visitor visitor) {
+
+		visitor.enter(this);
+		this.getSymbolicName().ifPresent(s -> s.accept(visitor));
+		this.labels.forEach(label -> label.accept(visitor));
+		Visitable.visitIfNotNull(this.properties, visitor);
+		visitor.leave(this);
+	}
+
+	private static List<NodeLabel> assertLabels(String primaryLabel, String[] additionalLabels) {
+
+		Assertions.hasText(primaryLabel, "A primary label is required.");
+
+		if (additionalLabels != null) {
+			for (String additionalLabel : additionalLabels) {
+				Assertions.hasText(additionalLabel, "An empty label is not allowed.");
+			}
+		}
+
+		List<NodeLabel> labels = new ArrayList<>();
+		labels.add(new NodeLabel(primaryLabel));
+		labels.addAll(Arrays.stream(additionalLabels).map(NodeLabel::new).collect(Collectors.toList()));
+
+		return labels;
+	}
+}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Parameter.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Parameter.java
@@ -45,7 +45,7 @@ public final class Parameter<T> implements Expression {
 		return create(name, NO_VALUE);
 	}
 
-	static <T> Parameter<T> create(String name, Object value) {
+	static <T> Parameter<T> create(String name, T value) {
 
 		Assertions.hasText(name, "The name of the parameter is required!");
 
@@ -53,7 +53,7 @@ public final class Parameter<T> implements Expression {
 			return create(name.substring(1), value);
 		}
 
-		return new Parameter(name, value);
+		return new Parameter<>(name, value);
 	}
 
 	private Parameter(String name, T value) {

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Properties.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Properties.java
@@ -25,7 +25,8 @@ import org.neo4j.cypherdsl.core.support.Visitable;
 import org.neo4j.cypherdsl.core.support.Visitor;
 
 /**
- * Represents the properties of a {@link Node node} or a {@link Relationship relationship}.
+ * Represents the properties of a {@link Node node} or a {@link Relationship relationship} when used as part of the
+ * whole pattern (inside a {@code MATCH}, {@code CREATE} or {@code MERGE} clause as {@code {p1: v1, p2: v2, pn: vn}}.
  *
  * @author Michael J. Simons
  * @since 1.0
@@ -35,7 +36,18 @@ public final class Properties implements Visitable {
 
 	private final MapExpression properties;
 
-	Properties(MapExpression properties) {
+	/**
+	 * Wraps an expression into a {@link Properties} node.
+	 *
+	 * @param expression Nullable expression
+	 * @return A properties expression
+	 */
+	public static Properties create(MapExpression expression) {
+
+		return expression == null ? null : new Properties(expression);
+	}
+
+	private Properties(MapExpression properties) {
 		this.properties = properties;
 	}
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Property.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Property.java
@@ -32,7 +32,11 @@ import org.neo4j.cypherdsl.core.support.Visitor;
 import org.neo4j.cypherdsl.core.utils.Assertions;
 
 /**
- * A property that belongs to a property container (either Node or Relationship).
+ * A property. A property might belong to a container such as a {@link Node} or {@link Relationship}, but it's not uncommon
+ * to extract single properties from maps or from various datatypes such as a duration returned from stored procedures.
+ * The container can be retrieved via {@link #getContainer()} in case the property belongs to a node or relationship.
+ * <p>
+ * A property has always a reference to the name of the object it was extracted from (see {@link #containerReference}.
  *
  * @author Michael J. Simons
  * @since 1.0

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PropertyContainer.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PropertyContainer.java
@@ -45,13 +45,9 @@ public interface PropertyContainer extends Named {
 	 * @param name property name, must not be {@literal null} or empty.
 	 * @return a new {@link Property} associated with this named container
 	 */
-	default Property property(String name) {
-		return property(new String[] { name });
-	}
+	Property property(String name);
 
-	default Property property(String... names) {
-		return Property.create(this, names);
-	}
+	Property property(String... names);
 
 	/**
 	 * Creates a new {@link Property} associated with this property container. This property can be used as a lookup in
@@ -68,9 +64,7 @@ public interface PropertyContainer extends Named {
 	 * @return a new {@link Property} associated with this named container
 	 * @since 2021.0.0
 	 */
-	default Property property(Expression lookup) {
-		return Property.create(this, lookup);
-	}
+	Property property(Expression lookup);
 
 	/**
 	 * Creates an {@link Operation} mutating the properties of this container to a new value. The container does not
@@ -80,11 +74,7 @@ public interface PropertyContainer extends Named {
 	 * @return A new operation.
 	 * @since 2020.1.5
 	 */
-	default Operation mutate(Parameter parameter) {
-		return Operations.mutate(this.getSymbolicName()
-				.orElseThrow(() -> new IllegalStateException("A property container must be named to be mutated.")),
-			parameter);
-	}
+	Operation mutate(Parameter parameter);
 
 	/**
 	 * Creates an {@link Operation} mutating the properties of this container to a new value. The container does not
@@ -94,11 +84,7 @@ public interface PropertyContainer extends Named {
 	 * @return A new operation.
 	 * @since 2020.1.5
 	 */
-	default Operation mutate(MapExpression properties) {
-		return Operations.mutate(this.getSymbolicName()
-				.orElseThrow(() -> new IllegalStateException("A property container must be named to be mutated.")),
-			properties);
-	}
+	Operation mutate(MapExpression properties);
 
 	/**
 	 * Unwraps the list of entries into an array before creating a projection out of it.
@@ -107,9 +93,7 @@ public interface PropertyContainer extends Named {
 	 * @return A map projection.
 	 * @see SymbolicName#project(List)
 	 */
-	default MapProjection project(List<Object> entries) {
-		return project(entries.toArray());
-	}
+	MapProjection project(List<Object> entries);
 
 	/**
 	 * Creates a map projection based on this container. The container needs a symbolic name for this to work.
@@ -118,7 +102,5 @@ public interface PropertyContainer extends Named {
 	 * @return A map projection.
 	 * @see SymbolicName#project(Object...)
 	 */
-	default MapProjection project(Object... entries) {
-		return getRequiredSymbolicName().project(entries);
-	}
+	MapProjection project(Object... entries);
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RawLiteral.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RawLiteral.java
@@ -34,7 +34,7 @@ import org.neo4j.cypherdsl.core.utils.Assertions;
  * to it. To use a {@literal $E} escape it as {$literal \$E}.
  *
  * @author Michael J. Simons
- * @soundtrack Foo Fighters - Echoes, Silence, Patience & Grace
+ * @soundtrack Foo Fighters - Echoes, Silence, Patience &amp; Grace
  * @since 2021.0.2
  */
 @API(status = Status.INTERNAL)

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipChain.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipChain.java
@@ -153,6 +153,11 @@ public final class RelationshipChain implements RelationshipPattern {
 	}
 
 	@Override
+	public Condition asCondition() {
+		return new RelationshipPatternCondition(this);
+	}
+
+	@Override
 	public void accept(Visitor visitor) {
 
 		visitor.enter(this);

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipImpl.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipImpl.java
@@ -38,9 +38,9 @@ import org.neo4j.cypherdsl.core.utils.Assertions;
  * @param <E> The type at the pointy end of the relationship
  * @param <T> The type of the persistent relationship itself
  * @author Michael J. Simons
- * @since TBA
+ * @since 2021.1.0
  */
-@API(status = EXPERIMENTAL, since = "TBA")
+@API(status = EXPERIMENTAL, since = "2021.1.0")
 public class RelationshipImpl<S extends NodeImpl<?>, E extends NodeImpl<?>, T extends RelationshipImpl<S, E, T>>
 		extends AbstractPropertyContainer implements Relationship {
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipImpl.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipImpl.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2019-2021 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.core;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import org.apiguardian.api.API;
+import org.neo4j.cypherdsl.core.support.Visitor;
+import org.neo4j.cypherdsl.core.utils.Assertions;
+
+/**
+ * This is the base class for all relationships. It can be used with generics, specifying valid start and end nodes.
+ * This is useful when using it as a base class for a static meta model.
+ *
+ *
+ * @param <S> The type at the start of the relationship
+ * @param <E> The type at the pointy end of the relationship
+ * @param <T> The type of the persistent relationship itself
+ * @author Michael J. Simons
+ * @since TBA
+ */
+@API(status = EXPERIMENTAL, since = "TBA")
+public class RelationshipImpl<S extends NodeImpl<?>, E extends NodeImpl<?>, T extends RelationshipImpl<S, E, T>>
+		extends AbstractPropertyContainer implements Relationship {
+
+	private final Node left;
+
+	private final Node right;
+
+	private final Details details;
+
+	// ------------------------------------------------------------------------
+	// Public API to be used by the static meta model.
+	// Non-final methods are ok to be overwritten.
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Always creates a relationship from start to end (left to right).
+	 *
+	 * @param start start node
+	 * @param end   end node
+	 * @param type  type of the relationship
+	 */
+	protected RelationshipImpl(S start, String type, E end) {
+
+		this(null, start, Direction.LTR, end, type);
+	}
+
+	/**
+	 * Always creates a relationship from start to end (left to right).
+	 *
+	 * @param symbolicName an optional symbolic name
+	 * @param start        start node
+	 * @param end          end node
+	 * @param type         type of the relationship
+	 */
+	protected RelationshipImpl(SymbolicName symbolicName, Node start, String type, Properties properties, Node end) {
+
+		this(symbolicName, start, Direction.LTR, properties, end, type);
+	}
+
+	@Override
+	public final T named(String newSymbolicName) {
+
+		Assertions.hasText(newSymbolicName, "Symbolic name is required.");
+		return named(SymbolicName.of(newSymbolicName));
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public T named(SymbolicName newSymbolicName) {
+
+		// Sanity check of newSymbolicName delegated to the details.
+		return (T) new RelationshipImpl(this.left, this.details.named(newSymbolicName), this.right);
+	}
+
+	@Override
+	public final T withProperties(Object... keysAndValues) {
+
+		MapExpression newProperties = null;
+		if (keysAndValues != null && keysAndValues.length != 0) {
+			newProperties = MapExpression.create(keysAndValues);
+		}
+		return withProperties(newProperties);
+	}
+
+	@Override
+	public final T withProperties(Map<String, Object> newProperties) {
+
+		return withProperties(MapExpression.create(newProperties));
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public T withProperties(MapExpression newProperties) {
+
+		return (T) new RelationshipImpl(this.left, this.details.with(Properties.create(newProperties)), this.right);
+	}
+
+	@Override
+	public final Node getLeft() {
+		return left;
+	}
+
+	protected final String getRequiredType() {
+
+		List<String> types = getDetails().getTypes().getValues();
+		if (types.size() != 1) {
+			throw new NoSuchElementException("No value present");
+		}
+		return types.get(0);
+	}
+
+	@Override
+	public final Node getRight() {
+		return right;
+	}
+
+	@Override
+	public final Details getDetails() {
+		return details;
+	}
+
+	@Override
+	public final Relationship unbounded() {
+
+		return new RelationshipImpl(this.left, this.details.unbounded(), this.right);
+	}
+
+	@Override
+	public final Relationship min(Integer minimum) {
+
+		return new RelationshipImpl(this.left, this.details.min(minimum), this.right);
+	}
+
+	@Override
+	public final Relationship max(Integer maximum) {
+
+		return new RelationshipImpl(this.left, this.details.max(maximum), this.right);
+	}
+
+	@Override
+	public final Relationship length(Integer minimum, Integer maximum) {
+
+		return new RelationshipImpl(this.left, this.details.min(minimum).max(maximum), this.right);
+	}
+
+	@Override
+	public final Optional<SymbolicName> getSymbolicName() {
+		return details.getSymbolicName();
+	}
+
+	@Override
+	public final SymbolicName getRequiredSymbolicName() {
+		return details.getRequiredSymbolicName();
+	}
+
+	@Override
+	public final RelationshipChain relationshipTo(Node other, String... types) {
+		return RelationshipChain
+				.create(this)
+				.add(this.right.relationshipTo(other, types));
+	}
+
+	@Override
+	public final RelationshipChain relationshipFrom(Node other, String... types) {
+		return RelationshipChain
+				.create(this)
+				.add(this.right.relationshipFrom(other, types));
+	}
+
+	@Override
+	public final RelationshipChain relationshipBetween(Node other, String... types) {
+		return RelationshipChain
+				.create(this)
+				.add(this.right.relationshipBetween(other, types));
+	}
+
+	@Override
+	public final Condition asCondition() {
+		return new RelationshipPatternCondition(this);
+	}
+
+	// ------------------------------------------------------------------------
+	// Internal API.
+	// ------------------------------------------------------------------------
+
+	RelationshipImpl(SymbolicName symbolicName, Node left, Direction direction, Node right, String... types) {
+
+		this(symbolicName, left, direction, null, right, types);
+	}
+
+	RelationshipImpl(SymbolicName symbolicName, Node left, Direction direction, Properties properties, Node right, String... types) {
+
+		this(left, Details.create(direction, symbolicName, types).with(properties), right);
+	}
+
+	RelationshipImpl(Node left, Details details, Node right) {
+
+		Assertions.notNull(left, "Left node is required.");
+		Assertions.notNull(details, "Details are required.");
+		Assertions.notNull(right, "Right node is required.");
+
+		this.left = left;
+		this.right = right;
+		this.details = details;
+	}
+
+	@Override
+	public final void accept(Visitor visitor) {
+
+		visitor.enter(this);
+
+		left.accept(visitor);
+		details.accept(visitor);
+		right.accept(visitor);
+
+		visitor.leave(this);
+	}
+}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipPattern.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipPattern.java
@@ -50,7 +50,5 @@ public interface RelationshipPattern extends PatternElement, ExposesRelationship
 	 * @return A condition based on this pattern.
 	 * @since 2021.0.0
 	 */
-	default Condition asCondition() {
-		return new RelationshipPatternCondition(this);
-	}
+	Condition asCondition();
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Configuration.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Configuration.java
@@ -93,13 +93,13 @@ public final class Configuration {
 	public static final class Builder {
 
 		private boolean prettyPrint = false;
-		private IndentStyle indentStyle;
+		private IndentStyle indentStyle = IndentStyle.SPACE;
 		private int indentSize = 2;
 
 		private Builder() {
 		}
 
-		private static Builder newConfig() {
+		static Builder newConfig() {
 			return new Builder();
 		}
 
@@ -109,6 +109,10 @@ public final class Configuration {
 		}
 
 		public Builder withIndentStyle(IndentStyle indentStyle) {
+
+			if (indentStyle == null) {
+				throw new IllegalArgumentException("Indent style is required.");
+			}
 			this.indentStyle = indentStyle;
 			return this;
 		}
@@ -118,11 +122,6 @@ public final class Configuration {
 			return this;
 		}
 
-		public Builder but() {
-			return newConfig().withPrettyPrint(prettyPrint).withIndentStyle(indentStyle)
-				.withIndentSize(indentSize);
-		}
-
 		public Configuration build() {
 			return new Configuration(prettyPrint, indentStyle, indentSize);
 		}
@@ -130,7 +129,7 @@ public final class Configuration {
 
 	private Configuration(boolean prettyPrint, IndentStyle indentStyle, int indentSize) {
 		this.prettyPrint = prettyPrint;
-		this.indentStyle = indentStyle == null ? IndentStyle.SPACE : indentStyle;
+		this.indentStyle = indentStyle;
 		this.indentSize = indentSize;
 	}
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/utils/Strings.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/utils/Strings.java
@@ -75,13 +75,24 @@ public final class Strings {
 		if (!Character.isJavaIdentifierStart(cp)) {
 			return false;
 		}
-		for (int i = Character.charCount(cp);  i < id.length(); i += Character.charCount(cp)) {
+		for (int i = Character.charCount(cp); i < id.length(); i += Character.charCount(cp)) {
 			cp = id.codePointAt(i);
 			if (!Character.isJavaIdentifierPart(cp)) {
 				return false;
 			}
 		}
 		return true;
+	}
+
+	/**
+	 * A convinience method to decide whether a given {@code codePoint} is a valid Java identifier at the given position {@code p}.
+	 *
+	 * @param p         Position on which the {@code codePoint} is supposed to be used as identifier
+	 * @param codePoint A codepoint
+	 * @return True if the codePoint could be used as part of an identifier at the given position
+	 */
+	public static boolean isValidJavaIdentifierPartAt(int p, int codePoint) {
+		return p == 0 && Character.isJavaIdentifierStart(codePoint) || p > 0 && Character.isJavaIdentifierPart(codePoint);
 	}
 
 	private static boolean containsText(CharSequence str) {

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
@@ -3877,6 +3877,11 @@ class CypherIT {
 		@Test
 		void fragmentOfStatementShouldBeReusable() {
 
+			try {
+				Map.class.getMethod("of");
+			} catch (NoSuchMethodException e) {
+				throw new RuntimeException(e);
+			}
 			Node personNode = Cypher.node("Person").named("p");
 			Property ageProperty = personNode.property("age");
 

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
@@ -3877,11 +3877,6 @@ class CypherIT {
 		@Test
 		void fragmentOfStatementShouldBeReusable() {
 
-			try {
-				Map.class.getMethod("of");
-			} catch (NoSuchMethodException e) {
-				throw new RuntimeException(e);
-			}
 			Node personNode = Cypher.node("Person").named("p");
 			Property ageProperty = personNode.property("age");
 

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/FunctionsIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/FunctionsIT.java
@@ -173,7 +173,7 @@ class FunctionsIT {
 			expected.append(");");
 
 			Method m = Functions.class.getMethod(function.name().toLowerCase(Locale.ROOT), argTypes);
-			FunctionInvocation f = (FunctionInvocation) m.invoke(null, args);
+			FunctionInvocation f = (FunctionInvocation) m.invoke(null, (Object[]) args);
 			Assertions.assertThat(cypherRenderer.render(Cypher.returning(f).build()) + ";")
 				.isEqualTo(expected.toString());
 		}

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/IssueRelatedIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/IssueRelatedIT.java
@@ -587,6 +587,18 @@ class IssueRelatedIT {
 		return arguments.build();
 	}
 
+	@Test
+	void removeAllPropertiesShouldWork() {
+
+		Node n = Cypher.node("DeleteMe").named("n");
+		String cypher = Cypher.match(n)
+			.set(n, Cypher.mapOf())
+			.set(n.property("newProperty").to(Cypher.literalOf("aValue")))
+			.returning(n)
+			.build().getCypher();
+		assertThat(cypher).isEqualTo("MATCH (n:`DeleteMe`) SET n = {} SET n.newProperty = 'aValue' RETURN n");
+	}
+
 	@ParameterizedTest // GH-152
 	@MethodSource("relpatternChainingArgs")
 	void relpatternChaining(boolean multihops, int length, boolean backward, String expected) {

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/NodeImplTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/NodeImplTest.java
@@ -38,29 +38,35 @@ import org.neo4j.cypherdsl.core.support.Visitable;
 import org.neo4j.cypherdsl.core.support.Visitor;
 
 /**
+ * This tests focus on the internal node implementation.
+ *
  * @author Michael J. Simons
  */
-class NodeTest {
+class NodeImplTest {
 
 	@Test
 	void preconditionsShouldBeAsserted() {
 		String expectedMessage = "A primary label is required.";
 
-		assertThatIllegalArgumentException().isThrownBy(() -> Node.create("")).withMessage(expectedMessage);
-		assertThatIllegalArgumentException().isThrownBy(() -> Node.create(" \t")).withMessage(expectedMessage);
+		assertThatIllegalArgumentException().isThrownBy(() -> new NodeImpl("")).withMessage(expectedMessage);
+		assertThatIllegalArgumentException().isThrownBy(() -> new NodeImpl(" \t")).withMessage(expectedMessage);
+		assertThatIllegalArgumentException().isThrownBy(() -> Cypher.node("")).withMessage(expectedMessage);
+		assertThatIllegalArgumentException().isThrownBy(() -> Cypher.node(" \t")).withMessage(expectedMessage);
 	}
 
 	@Test
 	void shouldNotAddEmptyAdditionalLabels() {
 
-		assertThatIllegalArgumentException().isThrownBy(() -> Node.create("primary", " ", "\t "))
+		assertThatIllegalArgumentException().isThrownBy(() -> new NodeImpl("primary", " ", "\t "))
+			.withMessage("An empty label is not allowed.");
+		assertThatIllegalArgumentException().isThrownBy(() -> Cypher.node("primary", " ", "\t "))
 			.withMessage("An empty label is not allowed.");
 	}
 
 	@Test
 	void shouldCreateNodes() {
 
-		Node node = Node.create("primary", "secondary");
+		Node node = new NodeImpl("primary", "secondary");
 		List<String> labels = new ArrayList<>();
 		node.accept(new Visitor() {
 			@Override
@@ -81,8 +87,8 @@ class NodeTest {
 
 		private Stream<Arguments> createNodesWithProperties() {
 			return Stream.of(
-				Arguments.of(Node.create("N").named("n").withProperties("p", Cypher.literalTrue())),
-				Arguments.of(Node.create("N").named("n").withProperties(MapExpression.create("p", Cypher.literalTrue())))
+				Arguments.of(new NodeImpl("N").named("n").withProperties("p", Cypher.literalTrue())),
+				Arguments.of(new NodeImpl("N").named("n").withProperties(MapExpression.create("p", Cypher.literalTrue())))
 			);
 		}
 
@@ -115,7 +121,7 @@ class NodeTest {
 		@Test
 		void shouldCreateProperty() {
 
-			Node node = Node.create("N").named("n");
+			Node node = new NodeImpl("N").named("n");
 			Property property = node.property("p");
 
 			java.util.Set<Object> expected = new HashSet<>();

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/RawLiteralTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/RawLiteralTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
  * to it. To use a {@literal $E} escape it as {$literal \$E}.
  *
  * @author Michael J. Simons
- * @soundtrack Foo Fighters - Echoes, Silence, Patience & Grace
+ * @soundtrack Foo Fighters - Echoes, Silence, Patience &amp; Grace
  */
 class RawLiteralTest {
 

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/RelationshipImplTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/RelationshipImplTest.java
@@ -38,16 +38,16 @@ import org.neo4j.cypherdsl.core.support.Visitor;
 /**
  * @author Michael J. Simons
  */
-class RelationshipTest {
+class RelationshipImplTest {
 
 	@Test
 	void preconditionsShouldBeAsserted() {
 
 		assertThatIllegalArgumentException()
-			.isThrownBy(() -> Relationship.create(null, null, Node.create("a"), new String[0]))
+			.isThrownBy(() -> new RelationshipImpl(null, null, null, null, Cypher.node("a"), new String[0]))
 			.withMessage("Left node is required.");
 		assertThatIllegalArgumentException()
-			.isThrownBy(() -> Relationship.create(Node.create("a"), null, null, new String[0]))
+			.isThrownBy(() -> new RelationshipImpl(null, Cypher.node("a"), null, null, null, new String[0]))
 			.withMessage("Right node is required.");
 	}
 
@@ -57,9 +57,9 @@ class RelationshipTest {
 
 		private Stream<Arguments> createNodesWithProperties() {
 			return Stream.of(
-				Arguments.of(Node.create("N").named("n").relationshipTo(Cypher.anyNode())
+				Arguments.of(Cypher.node("N").named("n").relationshipTo(Cypher.anyNode())
 					.withProperties("p", Cypher.literalTrue())),
-				Arguments.of(Node.create("N").named("n").relationshipTo(Cypher.anyNode())
+				Arguments.of(Cypher.node("N").named("n").relationshipTo(Cypher.anyNode())
 					.withProperties(MapExpression.create("p", Cypher.literalTrue())))
 			);
 		}
@@ -101,7 +101,7 @@ class RelationshipTest {
 		@Test
 		void shouldCreateProperty() {
 
-			Relationship relationship = Node.create("N").named("n").relationshipTo(Cypher.anyNode()).named("r");
+			Relationship relationship = Cypher.node("N").named("n").relationshipTo(Cypher.anyNode()).named("r");
 			Property property = relationship.property("p");
 
 			java.util.Set<Object> expected = new HashSet<>();

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/model/ActedIn.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/model/ActedIn.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019-2021 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.model;
+
+import org.neo4j.cypherdsl.core.MapExpression;
+import org.neo4j.cypherdsl.core.Node;
+import org.neo4j.cypherdsl.core.Properties;
+import org.neo4j.cypherdsl.core.Property;
+import org.neo4j.cypherdsl.core.RelationshipImpl;
+import org.neo4j.cypherdsl.core.SymbolicName;
+
+/**
+ * @author Michael J. Simons
+ * @soundtrack Höhner - Die ersten 30 Jahre
+ */
+public final class ActedIn extends RelationshipImpl<Person, Movie, ActedIn> {
+
+	public final Property ROLE = this.property("role");
+
+	protected ActedIn(Person start, Movie end) {
+		super(start, "ACTED_IN", end);
+	}
+
+	private ActedIn(SymbolicName symbolicName, Node start, String type, Properties properties, Node end) {
+		super(symbolicName, start, type, properties, end);
+	}
+
+	@Override
+	public ActedIn named(SymbolicName newSymbolicName) {
+
+		return new ActedIn(newSymbolicName, getLeft(), getRequiredType(), getDetails().getProperties(), getRight());
+	}
+
+	@Override
+	public ActedIn withProperties(MapExpression newProperties) {
+
+		return new ActedIn(getSymbolicName().orElse(null), getLeft(), getRequiredType(), Properties.create(newProperties), getRight());
+	}
+}

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/model/Directed.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/model/Directed.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2019-2021 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.model;
+
+import org.neo4j.cypherdsl.core.MapExpression;
+import org.neo4j.cypherdsl.core.Node;
+import org.neo4j.cypherdsl.core.NodeImpl;
+import org.neo4j.cypherdsl.core.Properties;
+import org.neo4j.cypherdsl.core.RelationshipImpl;
+import org.neo4j.cypherdsl.core.SymbolicName;
+
+/**
+ * I modelled the relationships "DIRECTED" and "ACTED_IN" in this test slightly different to get a feeling how to deal
+ * with the same type of relationship between different nodes. A person might as well be the director of a musical etc.
+ *
+ * @author Michael J. Simons
+ * @soundtrack Höhner - Die ersten 30 Jahre
+ * @param <E> End node
+ */
+public final class Directed<E extends NodeImpl<?>> extends RelationshipImpl<Person, E, Directed<E>> {
+
+	protected Directed(Person start, E end) {
+		super(start, "DIRECTED", end);
+	}
+
+	private Directed(SymbolicName symbolicName, Node start, String type, Properties properties, Node end) {
+		super(symbolicName, start, type, properties, end);
+	}
+
+	@Override
+	public Directed<E> named(SymbolicName newSymbolicName) {
+
+		return new Directed<>(newSymbolicName, getLeft(), getRequiredType(), getDetails().getProperties(), getRight());
+	}
+
+	@Override
+	public Directed<E> withProperties(MapExpression newProperties) {
+
+		return new Directed<>(getSymbolicName().orElse(null), getLeft(), getRequiredType(), Properties.create(newProperties), getRight());
+	}
+}

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/model/FreeridingRelation.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/model/FreeridingRelation.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2019-2021 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.model;
+
+import org.neo4j.cypherdsl.core.MapExpression;
+import org.neo4j.cypherdsl.core.Node;
+import org.neo4j.cypherdsl.core.NodeImpl;
+import org.neo4j.cypherdsl.core.Properties;
+import org.neo4j.cypherdsl.core.RelationshipImpl;
+import org.neo4j.cypherdsl.core.SymbolicName;
+
+/**
+ * Basically only the holder of the type.
+ *
+ * @author Michael J. Simons
+ * @param <S> Start node
+ * @param <E> End node
+ */
+public final class FreeridingRelation<S extends NodeImpl<?>, E extends NodeImpl<?>>
+	extends RelationshipImpl<S, E, FreeridingRelation<S, E>> {
+
+	protected FreeridingRelation(S start, E end) {
+		super(start, "FREERIDING", end);
+	}
+
+	private FreeridingRelation(SymbolicName symbolicName, Node start, String type, Properties properties, Node end) {
+		super(symbolicName, start, type, properties, end);
+	}
+
+	@Override
+	public FreeridingRelation<S, E> named(SymbolicName newSymbolicName) {
+
+		return new FreeridingRelation<>(newSymbolicName, getLeft(), getRequiredType(), getDetails().getProperties(),
+			getRight());
+	}
+
+	@Override
+	public FreeridingRelation<S, E> withProperties(MapExpression newProperties) {
+
+		return new FreeridingRelation<>(getSymbolicName().orElse(null), getLeft(), getRequiredType(),
+			Properties.create(newProperties), getRight());
+	}
+}

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/model/Movie.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/model/Movie.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2019-2021 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.model;
+
+import java.util.List;
+
+import org.neo4j.cypherdsl.core.MapExpression;
+import org.neo4j.cypherdsl.core.NodeImpl;
+import org.neo4j.cypherdsl.core.NodeLabel;
+import org.neo4j.cypherdsl.core.Properties;
+import org.neo4j.cypherdsl.core.Property;
+import org.neo4j.cypherdsl.core.SymbolicName;
+
+/**
+ * @author Michael J. Simons
+ */
+public final class Movie extends NodeImpl<Movie> {
+
+	public static final Movie MOVIE = new Movie();
+
+	public final Property TAGLINE = this.property("tagline");
+
+	public final Property TITLE = this.property("title");
+
+	public final Property RELEASED = this.property("released");
+
+	public Movie() {
+		super("Movie");
+	}
+
+	private Movie(SymbolicName symbolicName, List<NodeLabel> labels, Properties properties) {
+		super(symbolicName, labels, properties);
+	}
+
+	@Override
+	public Movie named(SymbolicName newSymbolicName) {
+
+		return new Movie(newSymbolicName, getLabels(), getProperties());
+	}
+
+	@Override
+	public Movie withProperties(MapExpression newProperties) {
+
+		return new Movie(getSymbolicName().orElse(null), getLabels(), Properties.create(newProperties));
+	}
+}

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/model/Person.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/model/Person.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2019-2021 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.model;
+
+import java.util.List;
+
+import org.neo4j.cypherdsl.core.MapExpression;
+import org.neo4j.cypherdsl.core.NodeImpl;
+import org.neo4j.cypherdsl.core.NodeLabel;
+import org.neo4j.cypherdsl.core.Properties;
+import org.neo4j.cypherdsl.core.Property;
+import org.neo4j.cypherdsl.core.SymbolicName;
+
+/**
+ * @author Michael J. Simons
+ * @soundtrack Höhner - Die ersten 30 Jahre
+ */
+public final class Person extends NodeImpl<Person> {
+
+	public static final Person PERSON = new Person();
+
+	public final Directed<Movie> DIRECTED = new Directed<>(this, Movie.MOVIE);
+
+	public final ActedIn ACTED_IN = new ActedIn(this, Movie.MOVIE);
+
+	public final Property NAME = this.property("name");
+
+	public final Property FIRST_NAME = this.property("firstName");
+
+	public final Property BORN = this.property("born");
+
+	public Person() {
+		super("Person");
+	}
+
+	private Person(SymbolicName symbolicName, List<NodeLabel> labels, Properties properties) {
+		super(symbolicName, labels, properties);
+	}
+
+	@Override
+	public Person named(SymbolicName newSymbolicName) {
+
+		return new Person(newSymbolicName, getLabels(), getProperties());
+	}
+
+	@Override
+	public Person withProperties(MapExpression newProperties) {
+
+		return new Person(getSymbolicName().orElse(null), getLabels(), Properties.create(newProperties));
+	}
+}

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/model/StaticModelIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/model/StaticModelIT.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2019-2021 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.model;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.neo4j.cypherdsl.core.Cypher;
+
+/**
+ * @author Michael J. Simons
+ */
+class StaticModelIT {
+
+	@Test
+	void simpleMatchShouldWork() {
+
+		String cypher = Cypher.match(Movie.MOVIE)
+			.returning(Movie.MOVIE)
+			.build().getCypher();
+
+		Assertions.assertThat(cypher)
+			.matches("MATCH \\(\\w+:`Movie`\\) RETURN \\w+");
+	}
+
+	@Test
+	void renamingShouldWork() {
+
+		Movie m1 = Movie.MOVIE.named("m1");
+		String cypher = Cypher.match(m1)
+			.where(m1.TITLE.isEqualTo(Cypher.literalOf("The Matrix")))
+			.returning(m1)
+			.build().getCypher();
+
+		Assertions.assertThat(cypher)
+			.isEqualTo("MATCH (m1:`Movie`) WHERE m1.title = 'The Matrix' RETURN m1");
+	}
+
+	@Test
+	void propertiesShouldWorkInMatchWithType() {
+
+		Movie m1 = Movie.MOVIE.withProperties(Movie.MOVIE.TITLE, Cypher.literalOf("The Matrix")).named("m1");
+		String cypher = Cypher.match(m1)
+			.returning(m1)
+			.build().getCypher();
+
+		Assertions.assertThat(cypher)
+			.isEqualTo("MATCH (m1:`Movie` {title: 'The Matrix'}) RETURN m1");
+	}
+
+	@Test
+	void relRropertiesShouldWorkInMatchWithType() {
+
+		ActedIn actedIn = Person.PERSON.ACTED_IN.withProperties(Person.PERSON.ACTED_IN.ROLE, Cypher.literalOf("Neo"))
+			.named("n");
+		String cypher = Cypher.match(actedIn)
+			.returning(Movie.MOVIE)
+			.build().getCypher();
+
+		Assertions.assertThat(cypher)
+			.matches("MATCH \\(\\w+:`Person`\\)-\\[n:`ACTED_IN` \\{role: 'Neo'}]->\\(\\w+:`Movie`\\) RETURN \\w+");
+	}
+
+	@Test
+	void renamingRelationshipsShouldWork() {
+
+		Directed<Movie> directed = Person.PERSON.DIRECTED.named("d");
+		String cypher = Cypher.match(directed)
+			.returning(Movie.MOVIE)
+			.build().getCypher();
+
+		Assertions.assertThat(cypher)
+			.matches("MATCH \\(\\w+:`Person`\\)-\\[d:`DIRECTED`]->\\(\\w+:`Movie`\\) RETURN \\w+");
+	}
+
+	@Test
+	void matchOnRelationshipsShouldWork() {
+
+		String cypher = Cypher.match(Person.PERSON.DIRECTED)
+			.returning(Movie.MOVIE)
+			.build().getCypher();
+
+		Assertions.assertThat(cypher)
+			.matches("MATCH \\(\\w+:`Person`\\)-\\[\\w+:`DIRECTED`]->\\(\\w+:`Movie`\\) RETURN \\w+");
+	}
+
+	@Test
+	void multipleRelationships() {
+
+		String cypher = Cypher.match(Person.PERSON.DIRECTED)
+			.match(Person.PERSON.ACTED_IN)
+			.returning(Person.PERSON.DIRECTED, Person.PERSON.ACTED_IN)
+			.build().getCypher();
+
+		Assertions.assertThat(cypher)
+			.matches(
+				"MATCH \\(\\w+:`Person`\\)-\\[\\w+:`DIRECTED`]->\\(\\w+:`Movie`\\) MATCH \\(\\w+\\)-\\[\\w+:`ACTED_IN`]->\\(\\w+\\) RETURN \\w+, \\w+");
+	}
+
+	@Test
+	void workWithPropertiesShouldBePossible() {
+
+		String cypher = Cypher.match(Person.PERSON)
+			.returning(Person.PERSON.NAME, Person.PERSON.BORN)
+			.build().getCypher();
+
+		Assertions.assertThat(cypher)
+			.matches("MATCH \\(\\w+:`Person`\\) RETURN \\w+\\.name, \\w+\\.born");
+	}
+
+	@Test
+	void queryingNonStaticInformationAndPathsShouldWork() {
+
+		Person otherPerson = Person.PERSON.named("o");
+		String cypher = Cypher.match(Person.PERSON.withProperties(Person.PERSON.NAME, Cypher.literalOf("Tom Hanks"))
+			.relationshipTo(otherPerson, "WORKED_WITH"))
+			.returning(otherPerson.NAME)
+			.build().getCypher();
+
+		Assertions.assertThat(cypher)
+			.matches(
+				"MATCH \\(\\w+:`Person` \\{name: 'Tom Hanks'}\\)-\\[:`WORKED_WITH`]->\\(o:`Person`\\) RETURN o\\.name");
+	}
+
+	@Test
+	void workingOnTheDelegateShouldMakeSens() {
+
+		String cypher = Cypher.match(Person.PERSON)
+			.returning(Person.PERSON.NAME.concat(Cypher.literalOf(" whatever")))
+			.build().getCypher();
+
+		Assertions.assertThat(cypher)
+			.matches("MATCH \\(\\w+:`Person`\\) RETURN \\(\\w+\\.name \\+ ' whatever'\\)");
+	}
+
+	@Test
+	void oldQueryDSLExampleRevisited() {
+
+		Person person = new Person().named("person");
+		Assertions.assertThat(
+			Cypher.match(person)
+				.where(person.FIRST_NAME.eq(Cypher.literalOf("P")).
+					and(person.property("age").gt(Cypher.literalOf(25)))).returning(person).build().getCypher()
+		).isEqualTo("MATCH (person:`Person`) WHERE (person.firstName = 'P' AND person.age > 25) RETURN person");
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
 		<flatten-maven-plugin.version>1.2.1</flatten-maven-plugin.version>
 		<jacoco-maven-plugin.version>0.8.6</jacoco-maven-plugin.version>
 		<java-module-name></java-module-name>
-		<java.version>1.8</java.version>
+		<java.version>8</java.version>
 		<jqassistant-dashboard-plugin.version>${jqassistant.version}</jqassistant-dashboard-plugin.version>
 		<jqassistant.plugin.git.version>1.8.0</jqassistant.plugin.git.version>
 		<jqassistant.plugin.version>${jqassistant.version}</jqassistant.plugin.version>
@@ -130,8 +130,6 @@
 		<maven-site-plugin.version>3.9.1</maven-site-plugin.version>
 		<maven-source-plugin.version>3.2.1</maven-source-plugin.version>
 		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-		<maven.compiler.source>${java.version}</maven.compiler.source>
-		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<maven.version>3.6.3</maven.version>
 		<mockito.version>3.6.0</mockito.version>
 		<project.build.docs>${project.build.directory}/docs</project.build.docs>
@@ -211,6 +209,7 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>${maven-compiler-plugin.version}</version>
 					<configuration>
+						<release>${java.version}</release>
 						<compilerArgument>-Xlint:unchecked</compilerArgument>
 					</configuration>
 				</plugin>


### PR DESCRIPTION
This commit turns both `Node` and `Relationship` into interfaces, providing one implementation each as base class for an external API.

Care has been taken to remove all default methods from the interfaces those implementions implement as we only want to provide a small, dedidicate API people can overwrite.

Some ideas on how to use those classes as a static meta model have been added.

The build has been simplified: JDK 11 is required now for building the project, GraalVM JDK 11 for the project including native test.
We still do build with `--release 8`. To make ensure compatibitly, another Github Action workflow has been introduced running the tests a second time in isolation.