### PR TITLE
Add support for path with node.

### DIFF
--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NamedPath.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NamedPath.java
@@ -83,22 +83,13 @@ public final class NamedPath implements PatternElement, Named {
 	public interface OngoingDefinitionWithName {
 
 		/**
-		 * Create a new named path based on a relationship pattern.
+		 * Create a new named path based on a {@link PatternElement} single node.
 		 *
-		 * @param pattern The pattern to be used as named path.
+		 * @param patternElement The PatternElement to be used in named path.
 		 * @return A named path.
 		 */
 		@NotNull @Contract(pure = true)
-		NamedPath definedBy(RelationshipPattern pattern);
-
-		/**
-		 * Create a new named path based on a single node.
-		 *
-		 * @param node The node to be used in named path.
-		 * @return A named path.
-		 */
-		@NotNull @Contract(pure = true)
-		NamedPath definedBy(Node node);
+		NamedPath definedBy(PatternElement patternElement);
 
 		/**
 		 * Create a new named path that references a given, symbolic name. No checks are done if the referenced name
@@ -134,13 +125,18 @@ public final class NamedPath implements PatternElement, Named {
 		}
 
 		@Override
-		public NamedPath definedBy(RelationshipPattern pattern) {
-			return new NamedPath(name, pattern);
-		}
-
-		@Override
-		public @NotNull NamedPath definedBy(Node node) {
-			return new NamedPath(name, node);
+		public NamedPath definedBy(PatternElement pattern) {
+			PatternElement newOptionalNewPattern = pattern;
+			SymbolicName newName = name;
+			if (pattern instanceof NamedPath) {
+				if (((NamedPath) pattern).optionalPattern != null) {
+					newOptionalNewPattern = (PatternElement) ((NamedPath) pattern).optionalPattern;
+					newName = ((NamedPath) pattern).name;
+				} else {
+					throw new IllegalArgumentException("Cannot use the provided NamedPath because the pattern is null.");
+				}
+			}
+			return new NamedPath(newName, newOptionalNewPattern);
 		}
 
 		@Override
@@ -170,14 +166,9 @@ public final class NamedPath implements PatternElement, Named {
 		this.optionalPattern = null;
 	}
 
-	private NamedPath(SymbolicName name, RelationshipPattern optionalPattern) {
+	private NamedPath(SymbolicName name, PatternElement optionalPattern) {
 		this.name = name;
 		this.optionalPattern = optionalPattern;
-	}
-
-	private NamedPath(SymbolicName name, Node node) {
-		this.name = name;
-		this.optionalPattern = node;
 	}
 
 	private NamedPath(SymbolicName name, FunctionInvocation algorithm) {

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NamedPath.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NamedPath.java
@@ -84,6 +84,7 @@ public final class NamedPath implements PatternElement, Named {
 
 		/**
 		 * Create a new named path based on a {@link PatternElement} single node.
+		 * If a {@link NamedPath} will be provided, it will get used directly.
 		 *
 		 * @param patternElement The PatternElement to be used in named path.
 		 * @return A named path.
@@ -126,17 +127,10 @@ public final class NamedPath implements PatternElement, Named {
 
 		@Override
 		public NamedPath definedBy(PatternElement pattern) {
-			PatternElement newOptionalNewPattern = pattern;
-			SymbolicName newName = name;
 			if (pattern instanceof NamedPath) {
-				if (((NamedPath) pattern).optionalPattern != null) {
-					newOptionalNewPattern = (PatternElement) ((NamedPath) pattern).optionalPattern;
-					newName = ((NamedPath) pattern).name;
-				} else {
-					throw new IllegalArgumentException("Cannot use the provided NamedPath because the pattern is null.");
-				}
+				return (NamedPath) pattern;
 			}
-			return new NamedPath(newName, newOptionalNewPattern);
+			return new NamedPath(name, pattern);
 		}
 
 		@Override

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NamedPath.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NamedPath.java
@@ -92,6 +92,15 @@ public final class NamedPath implements PatternElement, Named {
 		NamedPath definedBy(RelationshipPattern pattern);
 
 		/**
+		 * Create a new named path based on a single node.
+		 *
+		 * @param node The node to be used in named path.
+		 * @return A named path.
+		 */
+		@NotNull @Contract(pure = true)
+		NamedPath definedBy(Node node);
+
+		/**
 		 * Create a new named path that references a given, symbolic name. No checks are done if the referenced name
 		 * actually points to a path.
 		 *
@@ -130,6 +139,11 @@ public final class NamedPath implements PatternElement, Named {
 		}
 
 		@Override
+		public @NotNull NamedPath definedBy(Node node) {
+			return new NamedPath(name, node);
+		}
+
+		@Override
 		public NamedPath get() {
 			return new NamedPath(name);
 		}
@@ -159,6 +173,11 @@ public final class NamedPath implements PatternElement, Named {
 	private NamedPath(SymbolicName name, RelationshipPattern optionalPattern) {
 		this.name = name;
 		this.optionalPattern = optionalPattern;
+	}
+
+	private NamedPath(SymbolicName name, Node node) {
+		this.name = name;
+		this.optionalPattern = node;
 	}
 
 	private NamedPath(SymbolicName name, FunctionInvocation algorithm) {

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
@@ -20,7 +20,6 @@ package org.neo4j.cypherdsl.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -4181,7 +4180,7 @@ class CypherIT {
 		}
 
 		@Test // GH-200
-		void shouldWorkWithNamedPaths() {
+		void shouldDirectlyUseProvidedNamedPaths() {
 			NamedPath p = Cypher.path("p").definedBy(Cypher.anyNode("n"));
 			NamedPath x = Cypher.path("x").definedBy(p);
 			Statement statement = Cypher.match(x).returning(p).build();
@@ -4189,12 +4188,6 @@ class CypherIT {
 			assertThat(cypherRenderer.render(statement)).isEqualTo("MATCH p = (n) RETURN p");
 		}
 
-		@Test // GH-200
-		void shouldThrowExceptionIfIncompleteNamedPathProvided() {
-			NamedPath p = Cypher.path("p").definedBy(null);
-			assertThatThrownBy(() -> Cypher.path("x").definedBy(p))
-				.hasMessageContaining("Cannot use the provided NamedPath because the pattern is null.");
-		}
 	}
 
 	@Nested

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
@@ -4161,6 +4161,14 @@ class CypherIT {
 			assertThat(cypherRenderer.render(statement))
 				.isEqualTo("RETURN [p = (n)-[:`LIKES`|`OWNS`*]->() | p]");
 		}
+
+		@Test // GH-200
+		void shouldWorkWithNodes() {
+			NamedPath p = Cypher.path("p").definedBy(Cypher.anyNode("n"));
+			Statement statement = Cypher.match(p).returning(p).build();
+
+			assertThat(cypherRenderer.render(statement)).isEqualTo("MATCH p = (n) RETURN p");
+		}
 	}
 
 	@Nested

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
@@ -4192,7 +4192,7 @@ class CypherIT {
 		@Test // GH-200
 		void shouldThrowExceptionIfIncompleteNamedPathProvided() {
 			NamedPath p = Cypher.path("p").definedBy(null);
-			assertThatThrownBy(()-> Cypher.path("x").definedBy(p))
+			assertThatThrownBy(() -> Cypher.path("x").definedBy(p))
 				.hasMessageContaining("Cannot use the provided NamedPath because the pattern is null.");
 		}
 	}


### PR DESCRIPTION
According to https://s3.amazonaws.com/artifacts.opencypher.org/M15/railroad/PatternElement.html the `Node`(Pattern) is a valid type in parallel to the `RelationshipPattern` for path definitions.

Maybe this is too naive from my side but it seems to not break anything else or broadens the API too much when supporting this.

Closes #200