### PR TITLE
feat: Add callbacks for a "pattern element created event".

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,7 @@
 :artifactId: neo4j-cypher-dsl
 
 // This will be next version and also the one that will be put into the manual for the main branch
-:neo4j-cypher-dsl-version: 2022.1.1-SNAPSHOT
+:neo4j-cypher-dsl-version: 2022.2.0-SNAPSHOT
 // This is the latest released version, used only in the readme
 :neo4j-cypher-dsl-version-latest: 2022.1.0
 

--- a/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/CypherDslASTFactory.java
+++ b/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/CypherDslASTFactory.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
@@ -143,6 +144,9 @@ final class CypherDslASTFactory implements
 	private <T extends Expression> T applyCallbackFor(ExpressionCreatedEventType type, T newExpression) {
 
 		var callbacks = this.options.getOnNewExpressionCallbacks().getOrDefault(type, List.of());
+		if (callbacks.isEmpty()) {
+			return newExpression;
+		}
 
 		// We checked this when creating the callbacks
 		@SuppressWarnings("unchecked")
@@ -240,9 +244,23 @@ final class CypherDslASTFactory implements
 	}
 
 	@Override
-	public Clause matchClause(InputPosition p, boolean optional, List<PatternElement> patternElements, InputPosition patternPos, List<Hint> hints,
-		Where where) {
-		return Clauses.match(optional, patternElements, where, hints);
+	public Clause matchClause(InputPosition p, boolean optional, List<PatternElement> patternElements, InputPosition patternPos, List<Hint> hints, Where where) {
+
+		var callbacks = this.options.getOnNewPatternElementCallbacks().getOrDefault(PatternElementCreatedEventType.ON_MATCH, List.of());
+		return Clauses.match(optional, transformIfPossible(callbacks, patternElements), where, hints);
+	}
+
+	private List<PatternElement> transformIfPossible(List<UnaryOperator<PatternElement>> callbacks,
+		List<PatternElement> patternElements) {
+		if (callbacks.isEmpty()) {
+			return patternElements;
+		}
+
+		var transformer = Function.<PatternElement>identity();
+		for (UnaryOperator<PatternElement> callback : callbacks) {
+			transformer = transformer.andThen(callback);
+		}
+		return patternElements.stream().map(transformer).collect(Collectors.toList());
 	}
 
 	@Override
@@ -273,7 +291,9 @@ final class CypherDslASTFactory implements
 
 	@Override
 	public Clause createClause(InputPosition p, List<PatternElement> patternElements) {
-		return Clauses.create(patternElements);
+
+		var callbacks = this.options.getOnNewPatternElementCallbacks().getOrDefault(PatternElementCreatedEventType.ON_CREATE, List.of());
+		return Clauses.create(transformIfPossible(callbacks, patternElements));
 	}
 
 	@Override

--- a/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/CypherDslASTFactory.java
+++ b/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/CypherDslASTFactory.java
@@ -256,6 +256,7 @@ final class CypherDslASTFactory implements
 			return patternElements;
 		}
 
+		@SuppressWarnings("squid:S4276") // The function is needed due to the assigment below
 		var transformer = Function.<PatternElement>identity();
 		for (UnaryOperator<PatternElement> callback : callbacks) {
 			transformer = transformer.andThen(callback);

--- a/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/Options.java
+++ b/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/Options.java
@@ -153,8 +153,8 @@ public final class Options {
 		 *
 		 * @param patternElementCreatedEventType The type of the event
 		 * @param callback                   A callback
-		 * @return This builde
-		 * @since 2022.1.1
+		 * @return This builder
+		 * @since 2022.2.0
 		 */
 		public Builder withCallback(PatternElementCreatedEventType patternElementCreatedEventType, UnaryOperator<PatternElement> callback) {
 

--- a/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/Options.java
+++ b/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/Options.java
@@ -28,11 +28,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.apiguardian.api.API;
 import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.Clauses;
 import org.neo4j.cypherdsl.core.Expression;
+import org.neo4j.cypherdsl.core.PatternElement;
 import org.neo4j.cypherdsl.core.Return;
 import org.neo4j.cypherdsl.core.utils.Assertions;
 
@@ -75,7 +77,11 @@ public final class Options {
 
 		private BiFunction<TypeParsedEventType, Collection<String>, Collection<String>> typeFilter = (e, t) -> t;
 
-		private final Map<ExpressionCreatedEventType, List<Function<Expression, ? extends Expression>>> onNewExpressionCallbacks = new EnumMap<>(ExpressionCreatedEventType.class);
+		private final Map<ExpressionCreatedEventType, List<Function<Expression, ? extends Expression>>> onNewExpressionCallbacks
+			= new EnumMap<>(ExpressionCreatedEventType.class);
+
+		private final Map<PatternElementCreatedEventType, List<UnaryOperator<PatternElement>>> onNewPatternElementCallbacks
+			= new EnumMap<>(PatternElementCreatedEventType.class);
 
 		private Function<ReturnDefinition, Return> returnClauseFactory;
 
@@ -139,6 +145,26 @@ public final class Options {
 		}
 
 		/**
+		 * Adds a callback for when a {@link PatternElement} is created during one of the phases described by {@link PatternElementCreatedEventType}.
+		 * For one type of event one or more callbacks can be declared which will be called in order in which they have been declared.
+		 * Callbacks can just collect or actually visit the elements created or they are free to create new ones, effectively rewriting the query.
+		 * <p>
+		 * Parsing will be aborted when a callback throws a {@link RuntimeException}.
+		 *
+		 * @param patternElementCreatedEventType The type of the event
+		 * @param callback                   A callback
+		 * @return This builde
+		 * @since 2022.1.1
+		 */
+		public Builder withCallback(PatternElementCreatedEventType patternElementCreatedEventType, UnaryOperator<PatternElement> callback) {
+
+			var callbacks = this.onNewPatternElementCallbacks
+				.computeIfAbsent(patternElementCreatedEventType, k -> new ArrayList<>());
+			callbacks.add(callback);
+			return this;
+		}
+
+		/**
 		 * Configures the factory for return clauses. The idea here is that you might intercept what is being returned
 		 * or how it is sorted, limited and the like. The {@link ReturnDefinition definition} passed to the factory contains
 		 * all necessary information for delegating to the {@link org.neo4j.cypherdsl.core.Clauses#returning(boolean, List, List, Expression, Expression)}
@@ -166,6 +192,8 @@ public final class Options {
 
 	private final Map<ExpressionCreatedEventType, List<Function<Expression, ? extends Expression>>> onNewExpressionCallbacks;
 
+	private final Map<PatternElementCreatedEventType, List<UnaryOperator<PatternElement>>> onNewPatternElementCallbacks;
+
 	private final Function<ReturnDefinition, Return> returnClauseFactory;
 
 	private Options(Builder builder) {
@@ -176,6 +204,10 @@ public final class Options {
 		Map<ExpressionCreatedEventType, List<Function<Expression, ? extends Expression>>> tmp = new EnumMap<>(ExpressionCreatedEventType.class);
 		builder.onNewExpressionCallbacks.forEach((k, v) -> tmp.put(k, List.copyOf(v)));
 		this.onNewExpressionCallbacks = Map.copyOf(tmp);
+
+		Map<PatternElementCreatedEventType, List<UnaryOperator<PatternElement>>> tmp2 = new EnumMap<>(PatternElementCreatedEventType.class);
+		builder.onNewPatternElementCallbacks.forEach((k, v) -> tmp2.put(k, List.copyOf(v)));
+		this.onNewPatternElementCallbacks = Map.copyOf(tmp2);
 
 		this.returnClauseFactory = builder.returnClauseFactory != null ?
 			builder.returnClauseFactory :
@@ -195,6 +227,10 @@ public final class Options {
 
 	Map<ExpressionCreatedEventType, List<Function<Expression, ? extends Expression>>> getOnNewExpressionCallbacks() {
 		return onNewExpressionCallbacks;
+	}
+
+	Map<PatternElementCreatedEventType, List<UnaryOperator<PatternElement>>> getOnNewPatternElementCallbacks() {
+		return onNewPatternElementCallbacks;
 	}
 
 	Function<ReturnDefinition, Return> getReturnClauseFactory() {

--- a/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/PatternElementCreatedEventType.java
+++ b/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/PatternElementCreatedEventType.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypherdsl.parser;
+
+import static org.apiguardian.api.API.Status.STABLE;
+
+import org.apiguardian.api.API;
+
+/**
+ * @author Michael J. Simons
+ * @soundtrack Black Sabbath - The End: Live in Birmingham
+ * @since 2022.1.1
+ */
+@API(status = STABLE, since = "2022.1.1")
+public enum PatternElementCreatedEventType {
+
+	/**
+	 * A {@link org.neo4j.cypherdsl.core.PatternElement} is create during the creation of a {@code MATCH} clause.
+	 */
+	ON_MATCH,
+	/**
+	 * A {@link org.neo4j.cypherdsl.core.PatternElement} is create during the creation of a {@code CREATE} clause.
+	 */
+	ON_CREATE
+}

--- a/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/PatternElementCreatedEventType.java
+++ b/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/PatternElementCreatedEventType.java
@@ -28,7 +28,7 @@ import org.apiguardian.api.API;
  * @soundtrack Black Sabbath - The End: Live in Birmingham
  * @since 2022.1.1
  */
-@API(status = STABLE, since = "2022.1.1")
+@API(status = STABLE, since = "2022.2.0")
 public enum PatternElementCreatedEventType {
 
 	/**

--- a/neo4j-cypher-dsl-parser/src/test/java/org/neo4j/cypherdsl/parser/OptionsTest.java
+++ b/neo4j-cypher-dsl-parser/src/test/java/org/neo4j/cypherdsl/parser/OptionsTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypherdsl.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.UnaryOperator;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Michael J. Simons
+ */
+class OptionsTest {
+
+	@Test // GH-299
+	void patternElementCallBacksShouldBeConfigurable() {
+
+		var builder = Options.newOptions()
+			.withCallback(PatternElementCreatedEventType.ON_CREATE, UnaryOperator.identity());
+		var options = builder.build();
+		assertThat(options.getOnNewPatternElementCallbacks())
+			.containsKey(PatternElementCreatedEventType.ON_CREATE);
+		assertThat(options.getOnNewPatternElementCallbacks().get(PatternElementCreatedEventType.ON_CREATE)).hasSize(1);
+
+		builder.withCallback(PatternElementCreatedEventType.ON_CREATE, UnaryOperator.identity());
+		options = builder.build();
+		assertThat(options.getOnNewPatternElementCallbacks())
+			.containsKey(PatternElementCreatedEventType.ON_CREATE);
+		assertThat(options.getOnNewPatternElementCallbacks().get(PatternElementCreatedEventType.ON_CREATE)).hasSize(2);
+	}
+}


### PR DESCRIPTION
This allows to intercept all kinds of pattern elements (nodes and relationships) when needed in both `CREATE` and `MATCH` clauses.

Also added examples how to use them as well as how to achieve something similar with filters.

Closes #299.