### PR TITLE
Support additional mutate expression types

### DIFF
--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Operations.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Operations.java
@@ -37,7 +37,8 @@ import org.neo4j.cypherdsl.core.utils.Assertions;
 public final class Operations {
 
 	private static final java.util.Set<Class<? extends Expression>> VALID_MUTATORS =
-		Collections.unmodifiableSet(new HashSet<>(Arrays.asList(MapExpression.class, Parameter.class)));
+		Collections.unmodifiableSet(new HashSet<>(Arrays.asList(MapExpression.class, Parameter.class, MapProjection.class, SymbolicName.class,
+				FunctionInvocation.class)));
 
 	/**
 	 * Creates an unary minus operation.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
@@ -2059,6 +2059,51 @@ class CypherIT {
 			assertThat(cypherRenderer.render(statement))
 				.isEqualTo("CREATE (u:`User`) SET u += {e: 'F'} RETURN u");
 		}
+
+
+		@Test
+		void mergeMutateWithMapProjection() {
+			Statement statement;
+			SymbolicName map = Cypher.name("map");
+
+			statement =
+				Cypher.with(Cypher.mapOf("p", Cypher.literalOf("Hello, Welt"), "i", Cypher.literalOf(1)).as(map))
+					.merge(userNode)
+					.mutate(userNode, map.project(Cypher.asterisk()))
+					.build();
+
+			assertThat(cypherRenderer.render(statement))
+				.isEqualTo(
+					"WITH {p: 'Hello, Welt', i: 1} AS map MERGE (u:`User`) SET u += map{.*}");
+		}
+
+		@Test
+		void mergeMutateWithSymbolicName() {
+			Statement statement;
+			SymbolicName map = Cypher.name("map");
+
+			statement =
+				Cypher.with(Cypher.mapOf("p", Cypher.literalOf("Hello, Welt"), "i", Cypher.literalOf(1)).as(map))
+					.merge(userNode)
+					.mutate(userNode, map)
+					.build();
+
+			assertThat(cypherRenderer.render(statement))
+				.isEqualTo(
+					"WITH {p: 'Hello, Welt', i: 1} AS map MERGE (u:`User`) SET u += map");
+		}
+		
+		@Test
+		void mergeMutateWithFunctionCall() {
+			Statement statement;
+			statement = Cypher.merge(userNode)
+				.mutate(userNode, Cypher.call("returns.map").asFunction())
+				.build();
+
+			assertThat(cypherRenderer.render(statement))
+				.isEqualTo(
+					"MERGE (u:`User`) SET u += returns.map()");
+		}
 	}
 
 	@Nested

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
@@ -2092,7 +2092,7 @@ class CypherIT {
 				.isEqualTo(
 					"WITH {p: 'Hello, Welt', i: 1} AS map MERGE (u:`User`) SET u += map");
 		}
-		
+
 		@Test
 		void mergeMutateWithFunctionCall() {
 			Statement statement;


### PR DESCRIPTION
It seems some mutate value expressions are not supported with this error being thrown from `Operations.java#mutate`:

```
A property container can only be mutated by a map, or a parameter or property pointing to a map.
```

Refer to the added test cases for the new expression support added by this PR.  I'm not sure if there are other expression types that should also be considered (or if it might actually be better to just accept any `Expression` and allow the query to fail at runtime?).