### PR TITLE
Fix rendering of nested FOREACH statements

### DIFF
--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/DefaultVisitor.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/DefaultVisitor.java
@@ -761,7 +761,8 @@ class DefaultVisitor extends ReflectiveVisitor implements RenderingVisitor {
 
 	void leave(Foreach foreach) {
 
-		builder.setCharAt(builder.length() - 1, ')');
+		builder.setCharAt(builder.length() - 1, ')'); // replace trailing space with ')'
+		builder.append(" ");
 	}
 
 	void enter(ExistentialSubquery subquery) {

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
@@ -2972,6 +2972,49 @@ class CypherIT {
 	}
 
 	@Nested
+	class ForeachClause {
+		@Test
+		void shouldRenderForeach() {
+			Node n = Cypher.anyNode("n");
+
+			Clause clause = Clauses.forEach(Cypher.name("a"), Cypher.listOf(), Arrays.asList(
+				Clauses.merge(Arrays.asList(n), Arrays.asList(
+					MergeAction.of(
+						MergeAction.Type.ON_CREATE,
+						(Set)Clauses.set(Arrays.asList(Cypher.name("n").property("prop").to(Cypher.literalOf(1))))
+					)
+				)))
+			);
+
+			assertThat(cypherRenderer.render(Statement.of(Arrays.asList(clause))))
+				.isEqualTo(
+					"FOREACH (a IN [] | MERGE (n) ON CREATE SET n.prop = 1)");
+
+		}
+
+		@Test
+		void shouldRenderNestedForeach() {
+			Node n = Cypher.anyNode("n");
+
+			Clause clause = Clauses.forEach(Cypher.name("a"), Cypher.listOf(), Arrays.asList(
+				Clauses.forEach(Cypher.name("a"), Cypher.listOf(), Arrays.asList(
+					Clauses.merge(Arrays.asList(n), Arrays.asList(
+						MergeAction.of(
+							MergeAction.Type.ON_CREATE,
+							(Set)Clauses.set(Arrays.asList(Cypher.name("n").property("prop").to(Cypher.literalOf(1))))
+						)
+					)))
+				)
+			));
+
+			assertThat(cypherRenderer.render(Statement.of(Arrays.asList(clause))))
+				.isEqualTo(
+					"FOREACH (a IN [] | FOREACH (a IN [] | MERGE (n) ON CREATE SET n.prop = 1))");
+
+		}
+	}
+
+	@Nested
 	class Expressions {
 		@Test
 		void shouldRenderParameters() {

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
@@ -2981,7 +2981,7 @@ class CypherIT {
 				Clauses.merge(Arrays.asList(n), Arrays.asList(
 					MergeAction.of(
 						MergeAction.Type.ON_CREATE,
-						(Set)Clauses.set(Arrays.asList(Cypher.name("n").property("prop").to(Cypher.literalOf(1))))
+						(Set) Clauses.set(Arrays.asList(Cypher.name("n").property("prop").to(Cypher.literalOf(1))))
 					)
 				)))
 			);
@@ -3001,7 +3001,7 @@ class CypherIT {
 					Clauses.merge(Arrays.asList(n), Arrays.asList(
 						MergeAction.of(
 							MergeAction.Type.ON_CREATE,
-							(Set)Clauses.set(Arrays.asList(Cypher.name("n").property("prop").to(Cypher.literalOf(1))))
+							(Set) Clauses.set(Arrays.asList(Cypher.name("n").property("prop").to(Cypher.literalOf(1))))
 						)
 					)))
 				)


### PR DESCRIPTION
When rendering AST that has nested `ForEach` clauses, there ends up being a missing `)` at the end because the `ForEach` renderer assumes a trailing space, and because `ForEach` also doesn't add a trailing space, if they are nested the outer `ForEach` ends up overwriting the closing `)` of the inner `ForEach` instead of adding a new one. 

This PR adds the trailing space to `ForEach` and test(s).


