### PR TITLE
refactor: Rework feature #84732cbd7 to be explicit.

### DIFF
--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DefaultStatementBuilder.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DefaultStatementBuilder.java
@@ -54,7 +54,7 @@ import org.neo4j.cypherdsl.core.utils.Assertions;
 class DefaultStatementBuilder implements StatementBuilder,
 	OngoingUpdate, OngoingMerge, OngoingReadingWithWhere, OngoingReadingWithoutWhere, OngoingMatchAndUpdate,
 	BuildableMatchAndUpdate,
-	BuildableOngoingMergeAction, ExposesSubqueryCall.BuildableSubquery {
+	BuildableOngoingMergeAction, ExposesSubqueryCall.BuildableSubquery, StatementBuilder.VoidCall {
 
 	/**
 	 * Current list of reading or update clauses to be generated.
@@ -1605,6 +1605,11 @@ class DefaultStatementBuilder implements StatementBuilder,
 			}
 		}
 
+		@Override
+		public VoidCall withoutResults() {
+			return new DefaultStatementBuilder(this.build());
+		}
+
 		@NotNull
 		@Override
 		public ProcedureCall build() {
@@ -1867,6 +1872,12 @@ class DefaultStatementBuilder implements StatementBuilder,
 
 			DefaultStatementBuilder.this.currentSinglePartElements.add(this.buildCall());
 			return DefaultStatementBuilder.this.match(optional, pattern);
+		}
+
+		@Override
+		public VoidCall withoutResults() {
+			DefaultStatementBuilder.this.currentSinglePartElements.add(this.buildCall());
+			return DefaultStatementBuilder.this;
 		}
 	}
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementBuilder.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementBuilder.java
@@ -20,14 +20,14 @@ package org.neo4j.cypherdsl.core;
 
 import static org.apiguardian.api.API.Status.STABLE;
 
+import java.util.Collection;
+
 import org.apiguardian.api.API;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.internal.RelationshipPatternCondition;
 import org.neo4j.cypherdsl.core.utils.Assertions;
 import org.neo4j.cypherdsl.core.utils.CheckReturnValue;
-
-import java.util.Collection;
 
 /**
  * @author Michael J. Simons
@@ -1105,6 +1105,14 @@ public interface StatementBuilder
 	interface OngoingStandaloneCallWithoutArguments extends
 		StatementBuilder.BuildableStatement<Statement>, ExposesCall.ExposesWithArgs<OngoingStandaloneCallWithArguments>,
 		ExposesCall.ExposesYield<OngoingStandaloneCallWithReturnFields>, ExposesCall.AsFunction {
+
+		/**
+		 * Turn this call into a void call to continue with querying
+		 *
+		 * @return the call, continue with a normal query from here.
+		 * @since 2022.4.0
+		 */
+		VoidCall withoutResults();
 	}
 
 	/**
@@ -1113,6 +1121,14 @@ public interface StatementBuilder
 	interface OngoingStandaloneCallWithArguments extends
 		StatementBuilder.BuildableStatement<Statement>,
 		ExposesCall.ExposesYield<OngoingStandaloneCallWithReturnFields>, ExposesCall.AsFunction {
+
+		/**
+		 * Turn this call into a void call to continue with querying
+		 *
+		 * @return the call, continue with a normal query from here.
+		 * @since 2022.4.0
+		 */
+		VoidCall withoutResults();
 	}
 
 	/**
@@ -1128,16 +1144,39 @@ public interface StatementBuilder
 	 */
 	interface OngoingInQueryCallWithoutArguments extends
 		ExposesCall.ExposesWithArgs<OngoingInQueryCallWithArguments>,
-		ExposesCall.ExposesYield<OngoingInQueryCallWithReturnFields>,
-		ExposesReturning {
+		ExposesCall.ExposesYield<OngoingInQueryCallWithReturnFields> {
+
+		/**
+		 * Turn this call into a void call to continue with querying
+		 *
+		 * @return the call, continue with a normal query from here.
+		 * @since 2022.4.0
+		 */
+		VoidCall withoutResults();
 	}
 
 	/**
 	 * The union of an in-query call exposing yields.
 	 */
 	interface OngoingInQueryCallWithArguments extends
-		ExposesCall.ExposesYield<OngoingInQueryCallWithReturnFields>,
-		ExposesReturning {
+		ExposesCall.ExposesYield<OngoingInQueryCallWithReturnFields> {
+
+		/**
+		 * Turn this call into a void call to continue with querying
+		 *
+		 * @return the call, continue with a normal query from here.
+		 * @since 2022.4.0
+		 */
+		VoidCall withoutResults();
+	}
+
+	/**
+	 * The result of a call to a stored procedure not having any results. It is possible to continue with "normal"
+	 * querying after the execution of such a procedure.
+	 *
+	 * @since 2022.4.0
+	 */
+	interface VoidCall extends OngoingReading {
 	}
 
 	/**

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/ScopingStrategy.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/ScopingStrategy.java
@@ -37,6 +37,7 @@ import org.neo4j.cypherdsl.core.IdentifiableElement;
 import org.neo4j.cypherdsl.core.Named;
 import org.neo4j.cypherdsl.core.Order;
 import org.neo4j.cypherdsl.core.PatternComprehension;
+import org.neo4j.cypherdsl.core.ProcedureCall;
 import org.neo4j.cypherdsl.core.Property;
 import org.neo4j.cypherdsl.core.Return;
 import org.neo4j.cypherdsl.core.Statement;
@@ -111,7 +112,11 @@ public final class ScopingStrategy {
 			} else {
 				this.afterStatement = new HashSet<>(lastScope);
 			}
-			lastScope.clear();
+
+			// A procedure call doesn't change scope.
+			if (!(visitable instanceof ProcedureCall)) {
+				lastScope.clear();
+			}
 		} else if (hasLocalScope(visitable)) {
 			this.dequeOfVisitedNamed.pop();
 		} else {


### PR DESCRIPTION
This allows to diverge from a procedure call without a result into a
regular flow and be explicit about the fact that a procedure doesn't
produce anything and is essentially just kind of a throwing validator.

This closes #349.
