### PR TITLE
Fix handling of `WITH *, <expr>` 

### DIFF
--- a/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/CypherDslASTFactory.java
+++ b/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/CypherDslASTFactory.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apiguardian.api.API;
 import org.jetbrains.annotations.NotNull;
@@ -200,6 +201,11 @@ final class CypherDslASTFactory implements
 
 	public List<Expression> newReturnItems(InputPosition p, boolean returnAll, List<Expression> returnItems) {
 		var finalReturnItems = returnItems;
+
+		if (returnAll) {
+			finalReturnItems = Stream.concat(Stream.of(Cypher.asterisk()), finalReturnItems.stream()).collect(Collectors.toList());
+		}
+
 		if (finalReturnItems.isEmpty()) {
 			if (!returnAll) {
 				throw new IllegalArgumentException("Cannot return nothing.");

--- a/neo4j-cypher-dsl-parser/src/test/java/org/neo4j/cypherdsl/parser/CypherParserTest.java
+++ b/neo4j-cypher-dsl-parser/src/test/java/org/neo4j/cypherdsl/parser/CypherParserTest.java
@@ -292,6 +292,15 @@ class CypherParserTest {
 		assertThat(statement.getCypher()).isEqualTo("RETURN 1 AS foo");
 	}
 
+	@Test
+	void shouldParseReturnAll() {
+		var statement1 = CypherParser.parseStatement("WITH 1 AS foo WITH *, 2 AS bar RETURN *");
+		assertThat(statement1.getCypher()).isEqualTo("WITH 1 AS foo WITH *, 2 AS bar RETURN *");
+
+		var statement2 = CypherParser.parseStatement("WITH 1 AS foo WITH *, 2 AS bar RETURN foo");
+		assertThat(statement2.getCypher()).isEqualTo("WITH 1 AS foo WITH *, 2 AS bar RETURN foo");
+	}
+
 	@ParameterizedTest
 	@ValueSource(strings = { "CREATE", "MERGE", "MATCH" })
 	void patternElementCallBacksShouldBeApplied(String clause) {


### PR DESCRIPTION
When parsing a statement that includes a `WITH` clause with a `*` AND other expressions:

```
WITH 'foo' AS foo
WITH *, 'bar' AS bar
RETURN *
```

.. the resulting AST for the 2nd `WITH` clause is missing the `*`.  When it gets rendered back to Cypher, it will render (incorrectly) to this:

```
WITH 'foo' AS foo
WITH 'bar' AS bar
RETURN *
```

Fix is to honor the `returnAll` flag that is set by the parser when `*` is present