### PR TITLE
refactor: Remove superflous whitespaces before `MapExpression` in pretty printer.

### DIFF
--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/PrettyPrintingVisitor.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/PrettyPrintingVisitor.java
@@ -207,6 +207,15 @@ class PrettyPrintingVisitor extends DefaultVisitor {
 	@Override
 	void enter(MapExpression map) {
 		indentationLevel++;
+		int cnt = 0;
+		for (int i = builder.length() - 1; i >= 0; --i) {
+			if (Character.isWhitespace(builder.charAt(i))) {
+				++cnt;
+			} else {
+				break;
+			}
+		}
+		builder.setLength(builder.length() - cnt);
 		builder.append(" ");
 		super.enter(map);
 	}

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
@@ -4625,9 +4625,9 @@ class CypherIT {
 							"RETURN u {\n" +
 							"  name: u.name,\n" +
 							"  anyThing: anyThing,\n" +
-							"  nesting1:  {\n" +
+							"  nesting1: {\n" +
 							"    name: u.name,\n" +
-							"    nesting2:  {\n" +
+							"    nesting2: {\n" +
 							"      name: b.name,\n" +
 							"      pattern: [(u)-[:LIKES]->(other) WHERE other.foo = $foo | other {\n" +
 							"        .x,\n" +
@@ -4678,9 +4678,9 @@ class CypherIT {
 							"RETURN u {\n" +
 							"\tname: u.name,\n" +
 							"\tanyThing: anyThing,\n" +
-							"\tnesting1:  {\n" +
+							"\tnesting1: {\n" +
 							"\t\tname: u.name,\n" +
-							"\t\tnesting2:  {\n" +
+							"\t\tnesting2: {\n" +
 							"\t\t\tname: b.name,\n" +
 							"\t\t\tpattern: [(u)-[:LIKES]->(other) WHERE other.foo = $foo | other {\n" +
 							"\t\t\t\t.x,\n" +

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/IssueRelatedIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/IssueRelatedIT.java
@@ -908,7 +908,7 @@ class IssueRelatedIT {
 			.isEqualTo(
 				"MATCH (node:Division)\n" +
 				"WITH DISTINCT node\n" +
-				"WHERE NOT (node)-[:IN]->(:Department)-[:INSIDE  {\n" +
+				"WHERE NOT (node)-[:IN]->(:Department)-[:INSIDE {\n" +
 				"  rel_property: true\n" +
 				"}]->(:Department)-[:EMPLOYS]->(:Employee)\n" +
 				"RETURN *"
@@ -938,7 +938,7 @@ class IssueRelatedIT {
 			.isEqualTo(
 				"MATCH (node:Division)\n" +
 				"WITH DISTINCT node\n" +
-				"WHERE NOT (node)-[:IN]->(:Department)-[:INSIDE  {\n" +
+				"WHERE NOT (node)-[:IN]->(:Department)-[:INSIDE {\n" +
 				"  rel_property: true\n" +
 				"}]->(:Department)-[:EMPLOYS]->(:Employee)\n" +
 				"RETURN *"
@@ -1238,10 +1238,10 @@ class IssueRelatedIT {
 
 		assertThat(Renderer.getRenderer(Configuration.prettyPrinting()).render(statement))
 			.isEqualTo(""
-				+ "MERGE (existingNode:CordraObject  {\n"
+				+ "MERGE (existingNode:CordraObject {\n"
 				+ "  _id: 'test/55de0539eb1e14f26a04'\n"
 				+ "})\n"
-				+ "SET existingNode =  {\n"
+				+ "SET existingNode = {\n"
 				+ "  _id: 'test/55de0539eb1e14f26a04',\n"
 				+ "  _type: 'Movie',\n"
 				+ "  title: 'Top Gun',\n"
@@ -1269,10 +1269,10 @@ class IssueRelatedIT {
 
 		assertThat(Renderer.getRenderer(Configuration.prettyPrinting()).render(statement))
 			.isEqualTo(""
-				+ "MERGE (existingNode:CordraObject  {\n"
+				+ "MERGE (existingNode:CordraObject {\n"
 				+ "  _id: 'test/55de0539eb1e14f26a04'\n"
 				+ "})\n"
-				+ "SET existingNode =  {\n"
+				+ "SET existingNode = {\n"
 				+ "  _id: 'test/55de0539eb1e14f26a04',\n"
 				+ "  _type: 'Movie',\n"
 				+ "  title: 'Top Gun',\n"
@@ -1295,7 +1295,7 @@ class IssueRelatedIT {
 
 		assertThat(Renderer.getRenderer(Configuration.prettyPrinting()).render(statement))
 			.isEqualTo(""
-				+ "MERGE (existingNode:CordraObject  {\n"
+				+ "MERGE (existingNode:CordraObject {\n"
 				+ "  _id: 'test/55de0539eb1e14f26a04'\n"
 				+ "})\n"
 				+ "SET existingNode = $aNewMap\n"


### PR DESCRIPTION
Closes #400
