### PR TITLE
bug: Improve quotation pattern.

### DIFF
--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/AbstractClassNameGenerator.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/AbstractClassNameGenerator.java
@@ -21,7 +21,6 @@ package org.neo4j.cypherdsl.codegen.core;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 import org.apiguardian.api.API;
-import org.neo4j.cypherdsl.core.utils.Strings;
 
 /**
  * Shared type name generator for the default naming strategies for generated node and relationship implementations.
@@ -47,7 +46,7 @@ abstract class AbstractClassNameGenerator {
 		int i = 0;
 		while (i < suggestedName.length()) {
 			codePoint = suggestedName.codePointAt(i);
-			if (Strings.isValidJavaIdentifierPartAt(i, codePoint)) {
+			if (Identifiers.isValidAt(i, codePoint)) {
 				if (sb.length() == 0) {
 					codePoint = Character.toUpperCase(codePoint);
 				}

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/FieldNameGenerator.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/FieldNameGenerator.java
@@ -18,8 +18,6 @@
  */
 package org.neo4j.cypherdsl.codegen.core;
 
-import org.neo4j.cypherdsl.core.utils.Strings;
-
 /**
  * A generator for constant field names.
  *
@@ -43,7 +41,7 @@ interface FieldNameGenerator {
 		int i = 0;
 		while (i < name.length()) {
 			codePoint = name.codePointAt(i);
-			if (Strings.isValidJavaIdentifierPartAt(i, codePoint)) {
+			if (Identifiers.isValidAt(i, codePoint)) {
 				if (nextIsLower || Character.isLowerCase(codePoint)) {
 					prevWasLower = true;
 					nextIsLower = false;

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/Identifiers.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/Identifiers.java
@@ -16,20 +16,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.cypherdsl.core.utils;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-import org.junit.jupiter.api.RepeatedTest;
+package org.neo4j.cypherdsl.codegen.core;
 
 /**
+ * Utilities for dealing with identifiers.
+ *
  * @author Michael J. Simons
- * @soundtrack Genesis - We Can't Dance
  */
-class StringsTest {
+final class Identifiers {
 
-	@RepeatedTest(8)
-	void shouldGeneratedValidSymbolicNames() {
-		assertThat(Strings.isIdentifier(Strings.randomIdentifier(32))).isTrue();
+	/**
+	 * A convenience method to decide whether a given {@code codePoint} is a valid Java identifier at the given position {@code p}.
+	 *
+	 * @param p         Position on which the {@code codePoint} is supposed to be used as identifier
+	 * @param codePoint A codepoint
+	 * @return True if the codePoint could be used as part of an identifier at the given position
+	 */
+	static boolean isValidAt(int p, int codePoint) {
+		return p == 0 && Character.isJavaIdentifierStart(codePoint) || p > 0 && Character.isJavaIdentifierPart(
+			codePoint);
+	}
+
+	private Identifiers() {
 	}
 }

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/core/CypherDSLExamplesTest.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/core/CypherDSLExamplesTest.java
@@ -36,6 +36,7 @@ import org.neo4j.cypherdsl.core.Statement;
 import org.neo4j.cypherdsl.core.SymbolicName;
 import org.neo4j.cypherdsl.core.renderer.Configuration;
 import org.neo4j.cypherdsl.core.renderer.Renderer;
+import org.neo4j.cypherdsl.support.schema_name.SchemaNames;
 // end::cypher-dsl-imports[]
 
 /**
@@ -55,7 +56,7 @@ class CypherDSLExamplesTest {
 		// tag::escaping[]
 		var relationship = Cypher.node("Person").named("a")
 			.relationshipTo(Cypher.node("Movie").named("m"), "ACTED_IN").named("r");
-
+		SchemaNames.sanitize("");
 		var statement = Cypher.match(relationship).returning(relationship).build();
 
 		var defaultRenderer = Renderer.getDefaultRenderer();

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/core/CypherDSLExamplesTest.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/core/CypherDSLExamplesTest.java
@@ -36,7 +36,6 @@ import org.neo4j.cypherdsl.core.Statement;
 import org.neo4j.cypherdsl.core.SymbolicName;
 import org.neo4j.cypherdsl.core.renderer.Configuration;
 import org.neo4j.cypherdsl.core.renderer.Renderer;
-import org.neo4j.cypherdsl.support.schema_name.SchemaNames;
 // end::cypher-dsl-imports[]
 
 /**
@@ -56,7 +55,7 @@ class CypherDSLExamplesTest {
 		// tag::escaping[]
 		var relationship = Cypher.node("Person").named("a")
 			.relationshipTo(Cypher.node("Movie").named("m"), "ACTED_IN").named("r");
-		SchemaNames.sanitize("");
+
 		var statement = Cypher.match(relationship).returning(relationship).build();
 
 		var defaultRenderer = Renderer.getDefaultRenderer();

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-driver/pom.xml
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-driver/pom.xml
@@ -34,7 +34,6 @@
 	<properties>
 		<java-module-name>org.neo4j.cypherdsl.examples.driver</java-module-name>
 		<java.version>11</java.version>
-		<testcontainers.version>1.17.3</testcontainers.version>
 	</properties>
 
 	<dependencyManagement>
@@ -90,14 +89,12 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>neo4j</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/neo4j-cypher-dsl-schema-name-support/README.adoc
+++ b/neo4j-cypher-dsl-schema-name-support/README.adoc
@@ -1,0 +1,3 @@
+= Schema Name support
+
+This module consists of only one class, `SchemaNames`, that allows sanitization and quotation of possible schema names, making them safe to use in string concatenated queries for dynamic manipulation of types and labels. The project is safe to be shaded, it has no dependencies and does not restrict access to its class apart on the package level.

--- a/neo4j-cypher-dsl-schema-name-support/pom.xml
+++ b/neo4j-cypher-dsl-schema-name-support/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright (c) 2019-2022 "Neo4j,"
+ | Neo4j Sweden AB [https://neo4j.com]
+ |
+ | This file is part of Neo4j.
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this file except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |     https://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.neo4j</groupId>
+		<artifactId>neo4j-cypher-dsl-parent</artifactId>
+		<version>${revision}${sha1}${changelist}</version>
+	</parent>
+
+	<artifactId>neo4j-cypher-dsl-schema-name-support</artifactId>
+
+	<name>Neo4j Cypher DSL (Schema Name Support)</name>
+	<description>Utilities for quoting schema names to be safely used in string concatenations.</description>
+
+	<properties>
+		<java-module-name>org.neo4j.cypherdsl.support.schema_name</java-module-name>
+		<sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.neo4j.driver</groupId>
+			<artifactId>neo4j-java-driver</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>neo4j</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/neo4j-cypher-dsl-schema-name-support/src/main/java/org/neo4j/cypherdsl/support/schema_name/SchemaNames.java
+++ b/neo4j-cypher-dsl-schema-name-support/src/main/java/org/neo4j/cypherdsl/support/schema_name/SchemaNames.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2019-2022 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.support.schema_name;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A <a href="https://s3.amazonaws.com/artifacts.opencypher.org/M18/railroad/SchemaName.html">SchemaName</a> can appear according to the OpenCypher-Spec
+ * all the following places:
+ * <ul>
+ *     <li>NodePattern aka Label</li>
+ *     <li>RelationshipPattern aka Type</li>
+ *     <li>PropertyLookup</li>
+ * </ul>
+ * Some papers refer to a schema name as symbolic names, too. A symbolic name in the context of the Cypher-DSL is usually used
+ * to describe variables inside a statement, so we stick with the term schema name here.
+ * <p>
+ * A schema name must be escaped in statements with backticks - also known as grave accents - ({@code `}) when it contains
+ * content that is not a valid identifier or if the name is a reserved word.
+ * <p>
+ * Backticks themselves must be escaped with a backtick itself: {@code ``}.
+ * <p>
+ * This utility can be used standalone, the distributed module does not have any dependencies.
+ *
+ * @author Michael J. Simons
+ * @since 2022.8.0
+ */
+public final class SchemaNames {
+
+	private static final String ESCAPED_UNICODE_BACKTICK = "\\u0060";
+
+	private static final Pattern PATTERN_ESCAPED_4DIGIT_UNICODE = Pattern.compile("\\\\u+(\\p{XDigit}{4})");
+	private static final Pattern PATTERN_LABEL_AND_TYPE_QUOTATION = Pattern.compile("(?<!`)`(?:`{2})*(?!`)");
+
+	private static final List<String[]> SUPPORTED_ESCAPE_CHARS = Collections.unmodifiableList(Arrays.asList(
+		new String[] { "\\b", "\b" },
+		new String[] { "\\f", "\f" },
+		new String[] { "\\n", "\n" },
+		new String[] { "\\r", "\r" },
+		new String[] { "\\t", "\t" },
+		new String[] { "\\`", "``" }
+	));
+
+	private static final int CACHE_SIZE = 128;
+
+	private static class CacheKey {
+
+		private final String value;
+
+		private final int major;
+
+		private final int minor;
+
+		CacheKey(String value, int major, int minor) {
+			this.value = value;
+			this.major = major;
+			this.minor = minor;
+		}
+
+		@Override public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			CacheKey cacheKey = (CacheKey) o;
+			return major == cacheKey.major && minor == cacheKey.minor && value.equals(cacheKey.value);
+		}
+
+		@Override public int hashCode() {
+			return Objects.hash(value, major, minor);
+		}
+	}
+
+	private static class SchemaName {
+
+		private final String value;
+
+		private final boolean needsQuotation;
+
+		SchemaName(String value, boolean needsQuotation) {
+			this.value = value;
+			this.needsQuotation = needsQuotation;
+		}
+	}
+
+	/**
+	 * Cypher-DSL has a concrete implementation of such a simple cache, but it should be in this module itself.
+	 */
+	private static final Map<CacheKey, SchemaName> CACHE = Collections.synchronizedMap(
+		new LinkedHashMap<CacheKey, SchemaName>(CACHE_SIZE / 4, 0.75f, true) {
+			private static final long serialVersionUID = -8109893585632797360L;
+
+			@Override
+			protected boolean removeEldestEntry(Map.Entry<CacheKey, SchemaName> eldest) {
+				return size() >= CACHE_SIZE;
+			}
+		});
+
+	/**
+	 * Sanitizes the given input to be used as a valid schema name, adds quotes if necessary
+	 *
+	 * @param value The value to sanitize
+	 * @return A value that is safe to be used in string concatenation, an empty optional indicates a value that cannot be safely quoted
+	 */
+	public static Optional<String> sanitize(String value) {
+		return sanitize(value, false);
+	}
+
+	/**
+	 * Sanitizes the given input to be used as a valid schema name
+	 *
+	 * @param value The value to sanitize
+	 * @param enforceQuotes If quotation should be enforced, even when not necessary
+	 * @return A value that is safe to be used in string concatenation, an empty optional indicates a value that cannot be safely quoted
+	 */
+	public static Optional<String> sanitize(String value, boolean enforceQuotes) {
+		return sanitize(value, enforceQuotes, -1, -1);
+	}
+
+	/**
+	 * Sanitizes the given input to be used as a valid schema name
+	 *
+	 * @param value The value to sanitize
+	 * @param enforceQuotes If quotation should be enforced, even when not necessary
+	 * @param major Neo4j major version, use a value &lt; 0 to assume the latest major version
+	 * @param minor Neo4j minor version, use a value &lt; to assume any minor version
+	 * @return A value that is safe to be used in string concatenation, an empty optional indicates a value that cannot be safely quoted
+	 */
+	public static Optional<String> sanitize(String value, boolean enforceQuotes, int major, int minor) {
+
+		if (major >= 0 && (major < 3 || major > 6)) {
+			throw new IllegalArgumentException("Unsupported major version: " + major);
+		}
+
+		if (value == null || value.isEmpty()) {
+			return Optional.empty();
+		}
+
+		CacheKey cacheKey = new CacheKey(value, major < 0 ? -1 : major, minor < 0 ? -1 : minor);
+		SchemaName escapedValue = CACHE.computeIfAbsent(cacheKey, SchemaNames::sanitze);
+
+		if (!(enforceQuotes || escapedValue.needsQuotation)) {
+			return Optional.of(escapedValue.value);
+		}
+
+		return Optional.of(String.format(Locale.ENGLISH, "`%s`", escapedValue.value));
+	}
+
+	private static SchemaName sanitze(CacheKey key) {
+
+		String workingValue = key.value;
+
+		// Replace current and future escaped chars
+		for (String[] pair : SUPPORTED_ESCAPE_CHARS) {
+			workingValue = workingValue.replace(pair[0], pair[1]);
+		}
+		workingValue = workingValue.replace(ESCAPED_UNICODE_BACKTICK, "`");
+
+		// Replace escaped octal hex
+		// Excluding the support for 6 digit literals, as this contradicts the overall example in CIP-59r
+		Matcher matcher = PATTERN_ESCAPED_4DIGIT_UNICODE.matcher(workingValue);
+		StringBuffer sb = new StringBuffer();
+		while (matcher.find()) {
+			String replacement = Character.toString((char) Integer.parseInt(matcher.group(1), 16));
+			matcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+		}
+		matcher.appendTail(sb);
+		workingValue = sb.toString();
+
+		if (substituteRemainingEscapedUnicodeLiteral(key.major, key.minor)) {
+			workingValue = workingValue.replace("\\u", "\\u005C\\u0075");
+		}
+
+		matcher = PATTERN_LABEL_AND_TYPE_QUOTATION.matcher(workingValue);
+		workingValue = matcher.replaceAll("`$0");
+
+		if (unescapeEscapedBackslashes(key.major)) {
+			workingValue = workingValue.replace("\\\\", "\\");
+		}
+
+		return new SchemaName(workingValue, !isIdentifier(workingValue));
+	}
+
+	/**
+	 * True if the start of an escaped unicode literal {@code \\u} should be obsfuscated by two escaped literals for {@code \} and {@code u}.
+	 *
+	 * @param major neo4j Major version
+	 * @param minor Neo4j minor version
+	 * @return {@literal true} if the beginning of an escaped unicude literal needs special treatment
+	 */
+	private static boolean substituteRemainingEscapedUnicodeLiteral(int major, int minor) {
+		if (major == -1) {
+			return true;
+		}
+		return major >= 4 && major <= 5 && (minor == -1 || minor >= 2);
+	}
+
+	/**
+	 * @param major neo4j Major version
+	 * @return {@literal true} if escaped backslashes aren't supported and must be unescaped
+	 */
+	private static boolean unescapeEscapedBackslashes(int major) {
+		return major <= 5;
+	}
+
+	/**
+	 * This is a literal copy of {@code javax.lang.model.SourceVersion#isIdentifier(CharSequence)} included here to
+	 * be not dependent on the compiler module.
+	 *
+	 * @param name A possible Java identifier
+	 * @return True, if {@code name} represents an identifier.
+	 */
+	private static boolean isIdentifier(CharSequence name) {
+
+		String id = name.toString();
+		int cp = id.codePointAt(0);
+		if (!Character.isJavaIdentifierStart(cp)) {
+			return false;
+		}
+		for (int i = Character.charCount(cp); i < id.length(); i += Character.charCount(cp)) {
+			cp = id.codePointAt(i);
+			if (!Character.isJavaIdentifierPart(cp)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private SchemaNames() {
+	}
+}

--- a/neo4j-cypher-dsl-schema-name-support/src/main/java/org/neo4j/cypherdsl/support/schema_name/SchemaNames.java
+++ b/neo4j-cypher-dsl-schema-name-support/src/main/java/org/neo4j/cypherdsl/support/schema_name/SchemaNames.java
@@ -30,22 +30,30 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * A <a href="https://s3.amazonaws.com/artifacts.opencypher.org/M18/railroad/SchemaName.html">SchemaName</a> can appear according to the OpenCypher-Spec
- * all the following places:
+ * A <a href="https://s3.amazonaws.com/artifacts.opencypher.org/M18/railroad/SchemaName.html">SchemaName</a> can appear
+ * according to the OpenCypher-Spec all the following places:
+ *
  * <ul>
  *     <li>NodePattern aka Label</li>
  *     <li>RelationshipPattern aka Type</li>
  *     <li>PropertyLookup</li>
  * </ul>
- * Some papers refer to a schema name as symbolic names, too. A symbolic name in the context of the Cypher-DSL is usually used
- * to describe variables inside a statement, so we stick with the term schema name here.
- * <p>
+ *
+ * Some papers refer to a schema name as symbolic names, too. A symbolic name in the context of the Cypher-DSL is usually
+ * used to describe variables inside a statement, so we stick with the term schema name here.<p>
+ *
  * A schema name must be escaped in statements with backticks - also known as grave accents - ({@code `}) when it contains
- * content that is not a valid identifier or if the name is a reserved word.
- * <p>
+ * content that is not a valid identifier or if the name is a reserved word.<p>
+ *
  * Backticks themselves must be escaped with a backtick itself: {@code ``}.
- * <p>
- * This utility can be used standalone, the distributed module does not have any dependencies.
+ * <strong>We always treat two consecutive backticks as escaped backticks.</strong> An odd number of backticks will
+ * always lead to another backtick being inserted so that the single one will be escaped proper. As a concrete example
+ * this means an input like {@code ```} will be sanitised and quoted as {@code ``````}. These are one leading and one
+ * closing backtick as this schema name needs to be quoted plus one more to escape the outlier. When used as a label or
+ * type, the resulting label will be {@code ``}.<p>
+ *
+ * This utility can be used standalone, the distributed module does not have any dependencies. Shading is ok as well,
+ * there is no encapsulation to break.
  *
  * @author Michael J. Simons
  * @since 2022.8.0

--- a/neo4j-cypher-dsl-schema-name-support/src/test/java/org/neo4j/cypherdsl/support/schema_name/SchemaNamesIT.java
+++ b/neo4j-cypher-dsl-schema-name-support/src/test/java/org/neo4j/cypherdsl/support/schema_name/SchemaNamesIT.java
@@ -55,20 +55,23 @@ class SchemaNamesIT {
 	private static final Map<Neo4jContainer<?>, Driver> CACHED_CONNECTIONS = Collections.synchronizedMap(
 		new HashMap<>());
 	private static final String LATEST_VERSION = "4.4";
-	private static final Map<String, String> CATEGORIES = new HashMap<String, String>() {
-		private static final long serialVersionUID = -5617035309491104978L;
 
-		{
-			put("Q", "Quoting");
-			put("U", "Unicode");
-			put("B", "Backslashes");
-			put("E", "Escaping");
+	enum Category {
+		Q("Quoting"),
+		U("Unicode"),
+		B("Backslashes"),
+		E("Escaping");
+
+		private final String value;
+
+		Category(String value) {
+			this.value = value;
 		}
-	};
+	}
 
 	static class TestItem {
 
-		private final String category;
+		private final Category category;
 
 		private final String description;
 
@@ -76,14 +79,14 @@ class SchemaNamesIT {
 
 		private final String expected;
 
-		TestItem(String category, String description, String input, String expected) {
+		TestItem(Category category, String description, String input, String expected) {
 			this.category = category;
 			this.description = description;
 			this.input = input;
 			this.expected = expected;
 		}
 
-		public String category() {
+		public Category category() {
 			return category;
 		}
 
@@ -101,43 +104,43 @@ class SchemaNamesIT {
 	}
 
 	List<TestItem> TEST_DATA = Arrays.asList(
-		new TestItem("Q", "Simple label", "ABC", "ABC"),
-		new TestItem("Q", "Simple label with non identifiers", "A Label", "A Label"),
-		new TestItem("Q", "Simple label with backticks", "A` C", "A` C"),
-		new TestItem("Q", "Escaped quotes", "A`` C", "A` C"),
-		new TestItem("Q", "Backticks after blank ", "A `Label", "A `Label"),
-		new TestItem("Q", "Non consecutive backticks", "`A `Label", "`A `Label"),
-		new TestItem("U", "Single unicode, no quoting needed", "ᑖ", "ᑖ"),
-		new TestItem("U", "Single multibyte unicode, quoting needed", "⚡️", "⚡️"),
-		new TestItem("U", "Unicode pair inside label", "Spring Data Neo4j⚡️RX", "Spring Data Neo4j⚡️RX"),
-		new TestItem("Q", "Single backtick", "`", "`"),
-		new TestItem("Q", "Single unicode literal backtick", "\u0060", "`"),
-		new TestItem("Q", "One escaped, one unescaped backtick", "```", "``"),
-		new TestItem("Q", "One escaped, one unescaped unicode literal backtick", "\u0060\u0060\u0060", "``"),
-		new TestItem("U", "One escaped, one unescaped Cypher unicode literal backtick", "\\u0060\\u0060\\u0060", "``"),
-		new TestItem("Q", "Backtick at end", "Hello`", "Hello`"),
-		new TestItem("Q", "Escaped backticks", "Hi````there", "Hi``there"),
-		new TestItem("Q", "Mixed escaped and non escaped backticks", "Hi`````there", "Hi```there"),
-		new TestItem("Q", "Even number of scattered backticks", "`a`b`c`", "`a`b`c`"),
-		new TestItem("Q", "Even number of scattered backticks (unicode literals)", "\u0060a`b`c\u0060d\u0060", "`a`b`c`d`"),
-		new TestItem("Q", "Even number of scattered backticks (Cypher unicode literals)", "\\u0060a`b`c\\u0060d\\u0060", "`a`b`c`d`"),
-		new TestItem("B", "Escaped backslash followed by backtick", "Foo\\\\`bar", "Foo\\`bar"),
-		new TestItem("U", "Escaped (invalid) unicode literal", "admin\\user", "admin\\user"),
-		new TestItem("U", "Escaped (invalid) Cypher unicode literal", "admin\\\\user", "admin\\user"),
-		new TestItem("U", "Cypher unicode literals", "\\u0075\\u1456", "uᑖ"),
-		new TestItem("U", "Unicode literal", "\u1456", "ᑖ"),
-		new TestItem("U", "Non recursive Cypher unicode literals", "something\\u005C\\u00751456", "something\\u1456"),
-		new TestItem("U", "Unicode literals creating a backtick unicode", "\u005C\\u0060", "`"),
-		new TestItem("U", "Unicode literals creating only the literal text of a a unicode literal", "\\u005Cu0060", "\\u0060"),
-		new TestItem("U", "Cypher unicode literals creating unicode backtick literal", "\\u005C\\u0060", "\\`"),
-		new TestItem("B", "Single backslash", "x\\y", "x\\y"),
-		new TestItem("B", "Escaped single backslash", "x\\\\y", "x\\y"),
-		new TestItem("B", "Escaped multiple backslash", "x\\\\\\\\y", "x\\\\y"),
-		new TestItem("E", "Escaped backticks (Future Neo4j)", "x\\`y", "x`y"),
-		new TestItem("E", "Escaped backticks (Future Neo4j)", "x\\```y", "x``y"),
-		new TestItem("E", "Escaped backticks (Future Neo4j)", "x`\\```y", "x```y"),
-		new TestItem("Q", "Unicode literal backtick at end", "Foo \u0060", "Foo `"),
-		new TestItem("Q", "Cypher unicode literal backtick at end", "Foo \\u0060", "Foo `")
+		new TestItem(Category.Q, "Simple label", "ABC", "ABC"),
+		new TestItem(Category.Q, "Simple label with non identifiers", "A Label", "A Label"),
+		new TestItem(Category.Q, "Simple label with backticks", "A` C", "A` C"),
+		new TestItem(Category.Q, "Escaped quotes", "A`` C", "A` C"),
+		new TestItem(Category.Q, "Backticks after blank ", "A `Label", "A `Label"),
+		new TestItem(Category.Q, "Non consecutive backticks", "`A `Label", "`A `Label"),
+		new TestItem(Category.U, "Single unicode, no quoting needed", "ᑖ", "ᑖ"),
+		new TestItem(Category.U, "Single multibyte unicode, quoting needed", "⚡️", "⚡️"),
+		new TestItem(Category.U, "Unicode pair inside label", "Spring Data Neo4j⚡️RX", "Spring Data Neo4j⚡️RX"),
+		new TestItem(Category.Q, "Single backtick", "`", "`"),
+		new TestItem(Category.Q, "Single unicode literal backtick", "\u0060", "`"),
+		new TestItem(Category.Q, "One escaped, one unescaped backtick", "```", "``"),
+		new TestItem(Category.Q, "One escaped, one unescaped unicode literal backtick", "\u0060\u0060\u0060", "``"),
+		new TestItem(Category.U, "One escaped, one unescaped Cypher unicode literal backtick", "\\u0060\\u0060\\u0060", "``"),
+		new TestItem(Category.Q, "Backtick at end", "Hello`", "Hello`"),
+		new TestItem(Category.Q, "Escaped backticks", "Hi````there", "Hi``there"),
+		new TestItem(Category.Q, "Mixed escaped and non escaped backticks", "Hi`````there", "Hi```there"),
+		new TestItem(Category.Q, "Even number of scattered backticks", "`a`b`c`", "`a`b`c`"),
+		new TestItem(Category.Q, "Even number of scattered backticks (unicode literals)", "\u0060a`b`c\u0060d\u0060", "`a`b`c`d`"),
+		new TestItem(Category.Q, "Even number of scattered backticks (Cypher unicode literals)", "\\u0060a`b`c\\u0060d\\u0060", "`a`b`c`d`"),
+		new TestItem(Category.B, "Escaped backslash followed by backtick", "Foo\\\\`bar", "Foo\\`bar"),
+		new TestItem(Category.U, "Escaped (invalid) unicode literal", "admin\\user", "admin\\user"),
+		new TestItem(Category.U, "Escaped (invalid) Cypher unicode literal", "admin\\\\user", "admin\\user"),
+		new TestItem(Category.U, "Cypher unicode literals", "\\u0075\\u1456", "uᑖ"),
+		new TestItem(Category.U, "Unicode literal", "\u1456", "ᑖ"),
+		new TestItem(Category.U, "Non recursive Cypher unicode literals", "something\\u005C\\u00751456", "something\\u1456"),
+		new TestItem(Category.U, "Unicode literals creating a backtick unicode", "\u005C\\u0060", "`"),
+		new TestItem(Category.U, "Unicode literals creating only the literal text of a a unicode literal", "\\u005Cu0060", "\\u0060"),
+		new TestItem(Category.U, "Cypher unicode literals creating unicode backtick literal", "\\u005C\\u0060", "\\`"),
+		new TestItem(Category.B, "Single backslash", "x\\y", "x\\y"),
+		new TestItem(Category.B, "Escaped single backslash", "x\\\\y", "x\\y"),
+		new TestItem(Category.B, "Escaped multiple backslash", "x\\\\\\\\y", "x\\\\y"),
+		new TestItem(Category.E, "Escaped backticks (Future Neo4j)", "x\\`y", "x`y"),
+		new TestItem(Category.E, "Escaped backticks (Future Neo4j)", "x\\```y", "x``y"),
+		new TestItem(Category.E, "Escaped backticks (Future Neo4j)", "x`\\```y", "x```y"),
+		new TestItem(Category.Q, "Unicode literal backtick at end", "Foo \u0060", "Foo `"),
+		new TestItem(Category.Q, "Cypher unicode literal backtick at end", "Foo \\u0060", "Foo `")
 	);
 
 	@TestFactory
@@ -174,7 +177,7 @@ class SchemaNamesIT {
 									assertThat(summary.counters().nodesCreated()).isOne();
 								}
 							}));
-						return DynamicContainer.dynamicContainer(CATEGORIES.getOrDefault(entry.getKey(), "Misc"), nested);
+						return DynamicContainer.dynamicContainer(entry.getKey().value, nested);
 					});
 				return DynamicContainer.dynamicContainer(version, categories);
 			});

--- a/neo4j-cypher-dsl-schema-name-support/src/test/java/org/neo4j/cypherdsl/support/schema_name/SchemaNamesIT.java
+++ b/neo4j-cypher-dsl-schema-name-support/src/test/java/org/neo4j/cypherdsl/support/schema_name/SchemaNamesIT.java
@@ -85,6 +85,13 @@ class SchemaNamesIT {
 		// new TestInput("\\u000151", "ő", "ő"),
 		{ "\u1456", "ᑖ" },
 		{ "something\\u005C\\u00751456", "something\\u1456" },
+		// Similar to the above, but creating backtick
+		// First is literal unicode backslash, than u0060, will turn into \\u00160, turned into a backtick and quoted
+		{ "\u005C\\u0060", "`"},
+		// First is escaped unicode backslash, than u0060 but the CIP says only one iteration of resolving
+		{ "\\u005Cu0060", "\\u0060"},
+		// Escaped literals for the backslash and the backtick following each other
+		{ "\\u005C\\u0060", "\\`"},
 		{ "x\\y", "x\\y" },
 		// Already escaped backslash
 		{ "x\\\\y", "x\\y" },

--- a/neo4j-cypher-dsl-schema-name-support/src/test/java/org/neo4j/cypherdsl/support/schema_name/SchemaNamesIT.java
+++ b/neo4j-cypher-dsl-schema-name-support/src/test/java/org/neo4j/cypherdsl/support/schema_name/SchemaNamesIT.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2019-2022 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.support.schema_name;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.DynamicContainer;
+import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Config;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Result;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.summary.ResultSummary;
+import org.neo4j.driver.types.Node;
+import org.testcontainers.containers.Neo4jContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * @author Michael J. Simons
+ */
+@Testcontainers(disabledWithoutDocker = true)
+class SchemaNamesIT {
+
+	private static final Config DRIVER_CONFIG = Config.builder().withMaxConnectionPoolSize(1).build();
+	private static Map<Neo4jContainer<?>, Driver> CACHED_CONNECTIONS = Collections.synchronizedMap(new HashMap<>());
+	private static String LATEST_VERSION = "4.4";
+
+	String[][] TEST_DATA = new String[][] {
+		{ "ABC", "ABC" },
+		{ "A C", "A C" },
+		{ "A` C", "A` C" },
+		{ "A`` C", "A` C" },
+		{ "ALabel", "ALabel" },
+		{ "A Label", "A Label" },
+		{ "A `Label", "A `Label" },
+		{ "`A `Label", "`A `Label" },
+		{ "Spring Data Neo4j⚡️RX", "Spring Data Neo4j⚡️RX" },
+		{ "`", "`" },
+		{ "\u0060", "`" },
+		{ "```", "``" },
+		{ "\u0060\u0060\u0060", "``" },
+		{ "\\u0060\\u0060\\u0060", "``" },
+		{ "Hello`", "Hello`" },
+		{ "Hi````there", "Hi``there" },
+		{ "Hi`````there", "Hi```there" },
+		{ "`a`b`c`", "`a`b`c`" },
+		{ "\u0060a`b`c\u0060d\u0060", "`a`b`c`d`" },
+		{ "\\u0060a`b`c\\u0060d\\u0060", "`a`b`c`d`" },
+		{ "Foo\\\\`bar", "Foo\\`bar" },
+		// Escape the unicode literal for java
+		{ "admin\\user", "admin\\user" },
+		// Escape the unicode literal for cypher
+		{ "admin\\\\user", "admin\\user" },
+		// The unicode escaped
+		{ "\\u0075\\u1456", "uᑖ" },
+		// Not supported, "Potential additional rules mentioned in the GQL standard that would be potentially worth considering could take over:"
+		// new TestInput("\\u000151", "ő", "ő"),
+		{ "\u1456", "ᑖ" },
+		{ "something\\u005C\\u00751456", "something\\u1456" },
+		{ "x\\y", "x\\y" },
+		// Already escaped backslash
+		{ "x\\\\y", "x\\y" },
+		// Escaped backticks
+		{ "x\\`y", "x`y" },
+		{ "x\\```y", "x``y" },
+		{ "x`\\```y", "x```y" },
+		// This is the backtick itself in the string
+		{ "Foo \u0060", "Foo `" },
+		// This is the backtick unicode escaped so that without further processing `foo \u0060` would end up at Cypher,
+		{ "Foo \\u0060", "Foo `" },
+	};
+
+	@TestFactory
+	Stream<DynamicNode> shouldHaveConsistentResultsOnAllSupportedVersions() {
+		return Stream.of("3.5", "4.0", "4.1", "4.2", "4.3", "4.4")
+			.map(version -> {
+				@SuppressWarnings("resource")
+				Neo4jContainer<?> neo4j = new Neo4jContainer<>("neo4j:" + version).withReuse(true);
+				neo4j.start();
+
+				Stream<DynamicTest> dynamicTestStream = Arrays.stream(TEST_DATA)
+					.map(v -> {
+						String[] majorMinor = version.split("\\.");
+						int major = -1;
+						int minor = -1;
+						// Latest supported must work without config
+						if (!LATEST_VERSION.equals(version)) {
+							major = Integer.parseInt(majorMinor[0]);
+							minor = Integer.parseInt(majorMinor[1]);
+						}
+						String schemaName = SchemaNames.sanitize(v[0], false, major, minor).orElseThrow(NoSuchElementException::new);
+						return DynamicTest.dynamicTest(schemaName, () -> {
+								Driver driver = CACHED_CONNECTIONS.computeIfAbsent(neo4j,
+									server -> GraphDatabase.driver(server.getBoltUrl(),
+										AuthTokens.basic("neo4j", neo4j.getAdminPassword()), DRIVER_CONFIG));
+								try (Session session = driver.session();) {
+									Result result = session.run(String.format("CREATE (n:%s) RETURN n", schemaName));
+									Node node = result.single().get(0).asNode();
+									assertThat(node.labels()).containsExactly(v[1]);
+									ResultSummary summary = result.consume();
+									assertThat(summary.counters().nodesCreated()).isOne();
+								}
+							}
+						);
+					});
+				return DynamicContainer.dynamicContainer(version, dynamicTestStream);
+			});
+	}
+
+	@AfterAll
+	static void closeConnections() {
+		CACHED_CONNECTIONS.values().forEach(Driver::close);
+	}
+}

--- a/neo4j-cypher-dsl-schema-name-support/src/test/java/org/neo4j/cypherdsl/support/schema_name/SchemaNamesTest.java
+++ b/neo4j-cypher-dsl-schema-name-support/src/test/java/org/neo4j/cypherdsl/support/schema_name/SchemaNamesTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2019-2022 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.support.schema_name;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Michael J. Simons
+ */
+class SchemaNamesTest {
+
+	@Test
+	void shouldDealWithNull() {
+		assertThat(SchemaNames.sanitize(null)).isEmpty();
+	}
+
+	@Test
+	void shouldDealWithEmpty() {
+		assertThat(SchemaNames.sanitize("")).isEmpty();
+	}
+
+	@Test
+	void shouldThrowOnInvalidVersions() {
+		assertThatIllegalArgumentException().isThrownBy(() -> SchemaNames.sanitize("whatever", false, 2, 3))
+			.withMessage("Unsupported major version: 2");
+		assertThatIllegalArgumentException().isThrownBy(() -> SchemaNames.sanitize("whatever", false, 7, 3))
+			.withMessage("Unsupported major version: 7");
+	}
+
+	@Test
+	void shouldSupportFutureNeo4j() {
+		assertThat(SchemaNames.sanitize("x\\\\y", false, 6, -1)).hasValue("`x\\\\y`");
+	}
+
+	@Test
+	void shouldBeAbleToForceQUotes() {
+		assertThat(SchemaNames.sanitize("a", true, -1, -1)).hasValue("`a`");
+	}
+
+	@Test
+	void shouldQuoteEmptyString() {
+		assertThat(SchemaNames.sanitize(" ", false, -1, -1)).hasValue("` `");
+	}
+
+	@Test
+	void shouldCacheData() throws Exception {
+		Field cacheField = SchemaNames.class.getDeclaredField("CACHE");
+		cacheField.setAccessible(true);
+		Map<?, ?> cache = (Map<?, ?>) cacheField.get(null);
+
+		cache.clear();
+		assertThatNoException().isThrownBy(() -> SchemaNames.sanitize("a"));
+		assertThatNoException().isThrownBy(() -> SchemaNames.sanitize("b"));
+		assertThatNoException().isThrownBy(() -> SchemaNames.sanitize("a"));
+
+		assertThat(cache).hasSize(2);
+	}
+}

--- a/neo4j-cypher-dsl-test-results/pom.xml
+++ b/neo4j-cypher-dsl-test-results/pom.xml
@@ -19,6 +19,11 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.neo4j</groupId>
+			<artifactId>neo4j-cypher-dsl-schema-name-support</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.neo4j</groupId>
 			<artifactId>neo4j-cypher-dsl</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/neo4j-cypher-dsl/pom.xml
+++ b/neo4j-cypher-dsl/pom.xml
@@ -38,6 +38,11 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.neo4j</groupId>
+			<artifactId>neo4j-cypher-dsl-schema-name-support</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.apiguardian</groupId>
 			<artifactId>apiguardian-api</artifactId>
 		</dependency>
@@ -136,6 +141,40 @@
 									<version>${javax.annotation-api.version}</version>
 								</annotationProcessorPath>
 							</annotationProcessorPaths>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<artifactSet>
+								<includes>
+									<include>org.neo4j:neo4j-cypher-dsl-schema-name-support</include>
+								</includes>
+							</artifactSet>
+							<relocations>
+								<relocation>
+									<pattern>org.neo4j.cypherdsl.support.schema_name</pattern>
+									<shadedPattern>org.neo4j.cypherdsl.core.internal</shadedPattern>
+								</relocation>
+							</relocations>
+							<createSourcesJar>true</createSourcesJar>
+							<filters>
+								<filter>
+									<artifact>org.neo4j:neo4j-cypher-dsl-schema-name-support</artifact>
+									<includes>
+										<include>**/SchemaNames*class</include>
+									</includes>
+								</filter>
+							</filters>
 						</configuration>
 					</execution>
 				</executions>

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/SymbolicName.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/SymbolicName.java
@@ -31,7 +31,6 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.utils.Assertions;
 import org.neo4j.cypherdsl.core.utils.LRUCache;
-import org.neo4j.cypherdsl.core.utils.Strings;
 
 /**
  * A symbolic name to identify nodes, relationships and aliased items.
@@ -54,7 +53,6 @@ public final class SymbolicName implements Expression, IdentifiableElement {
 	static SymbolicName of(String name) {
 
 		Assertions.hasText(name, "Name must not be empty.");
-		Assertions.isTrue(Strings.isIdentifier(name), "Name must be a valid identifier.");
 		return CACHE.computeIfAbsent(name, SymbolicName::new);
 	}
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/utils/Strings.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/utils/Strings.java
@@ -35,7 +35,7 @@ public final class Strings {
 
 	/**
 	 * @param str A string to be checked for text.
-	 * @return True, if the strign is neither null nor empty nor blank.
+	 * @return True, if the string is neither null nor empty nor blank.
 	 */
 	public static boolean hasText(String str) {
 		return str != null && !str.isEmpty() && containsText(str);
@@ -57,43 +57,6 @@ public final class Strings {
 			.limit(length)
 			.collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
 			.toString();
-	}
-
-	/**
-	 * This is a literal copy of {@code javax.lang.model.SourceVersion#isIdentifier(CharSequence)} included here to
-	 * be not dependent on the compiler module.
-	 *
-	 * @param name A possible Java identifier
-	 * @return True, if {@code name} represents an identifier.
-	 */
-	public static boolean isIdentifier(CharSequence name) {
-		String id = name.toString();
-
-		if (id.length() == 0) {
-			return false;
-		}
-		int cp = id.codePointAt(0);
-		if (!Character.isJavaIdentifierStart(cp)) {
-			return false;
-		}
-		for (int i = Character.charCount(cp); i < id.length(); i += Character.charCount(cp)) {
-			cp = id.codePointAt(i);
-			if (!Character.isJavaIdentifierPart(cp)) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	/**
-	 * A convenience method to decide whether a given {@code codePoint} is a valid Java identifier at the given position {@code p}.
-	 *
-	 * @param p         Position on which the {@code codePoint} is supposed to be used as identifier
-	 * @param codePoint A codepoint
-	 * @return True if the codePoint could be used as part of an identifier at the given position
-	 */
-	public static boolean isValidJavaIdentifierPartAt(int p, int codePoint) {
-		return p == 0 && Character.isJavaIdentifierStart(codePoint) || p > 0 && Character.isJavaIdentifierPart(codePoint);
 	}
 
 	private static boolean containsText(CharSequence str) {

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/renderer/DefaultVisitorTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/renderer/DefaultVisitorTest.java
@@ -84,7 +84,7 @@ class DefaultVisitorTest {
 		"`A `Label, ```A ``Label`",
 		"Spring Data Neo4j⚡️RX, `Spring Data Neo4j⚡️RX`",
 		"Foo \u0060, `Foo ```", // This is the backtick itself in the string
-		"Foo \\u0060, `Foo `\\u0060`", // This is the backtick unicode escaped so that without further processing `foo \u0060` would end up at Cypher,
+		"Foo \\u0060, `Foo ```", // This is the backtick unicode escaped so that without further processing `foo \u0060` would end up at Cypher,
 		"`, ````",
 		"\u0060, ````",
 		"```, ``````",
@@ -93,7 +93,7 @@ class DefaultVisitorTest {
 		"Hi````there, `Hi````there`",
 		"Hi`````there, `Hi``````there`",
 		"`a`b`c`, ```a``b``c```",
-		"\u0060a`b`c\u0060d\u0060, ```a``b``c``d```",
+		"\u0060a`b`c\u0060d\u0060, ```a``b``c``d```"
 	})
 	void shouldEscapeIfNecessary(String name, String expectedEscapedName) {
 
@@ -103,7 +103,7 @@ class DefaultVisitorTest {
 	@Test
 	void shouldNotUnnecessaryEscape() {
 
-		assertThat(visitor.escapeIfNecessary(" ")).isEqualTo(" ");
+		assertThat(visitor.escapeIfNecessary(" ")).isEqualTo("` `");
 		assertThat(visitor.escapeIfNecessary(null)).isNull();
 		assertThat(visitor.escapeIfNecessary("a")).isEqualTo("a");
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
 	</developers>
 
 	<modules>
+		<module>neo4j-cypher-dsl-schema-name-support</module>
 		<module>neo4j-cypher-dsl-build</module>
 		<module>neo4j-cypher-dsl</module>
 		<module>neo4j-cypher-dsl-codegen</module>
@@ -132,7 +133,7 @@
 		<covered-ratio-complexity>0.75</covered-ratio-complexity>
 		<covered-ratio-instructions>0.75</covered-ratio-instructions>
 		<cypher-dsl.version.next />
-		<cypher-dsl.version.old>2022.3.0</cypher-dsl.version.old>
+		<cypher-dsl.version.old>2022.7.1</cypher-dsl.version.old>
 		<error_prone_annotations.version>2.12.1</error_prone_annotations.version>
 		<exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
 		<flatten-maven-plugin.version>1.3.0</flatten-maven-plugin.version>
@@ -183,6 +184,7 @@
 		<sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
 		<sortpom-maven-plugin.version>2.15.0</sortpom-maven-plugin.version>
 		<spring-data-neo4j.version>6.3.2</spring-data-neo4j.version>
+		<testcontainers.version>1.17.3</testcontainers.version>
 	</properties>
 
 	<dependencyManagement>
@@ -377,6 +379,16 @@
 				<artifactId>mockito-junit-jupiter</artifactId>
 				<version>${mockito.version}</version>
 				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.testcontainers</groupId>
+				<artifactId>junit-jupiter</artifactId>
+				<version>${testcontainers.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.testcontainers</groupId>
+				<artifactId>neo4j</artifactId>
+				<version>${testcontainers.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -591,6 +603,7 @@
 							</file>
 						</newVersion>
 						<parameter>
+							<ignoreNonResolvableArtifacts>true</ignoreNonResolvableArtifacts>
 							<breakBuildBasedOnSemanticVersioning>true</breakBuildBasedOnSemanticVersioning>
 							<!--
 							 | See this helpful discussion: https://github.com/siom79/japicmp/issues/201
@@ -614,6 +627,13 @@
 								</overrideCompatibilityChangeParameter>
 							</overrideCompatibilityChangeParameters>
 							<excludes>
+								<!--
+								 | Internal packages, protected by Java Module system on module path.
+								 -->
+								<exclude>org.neo4j.cypherdsl.core.internal</exclude>
+								<!-- Not exported either, but let's be a more lenient. -->
+								<exclude>org.neo4j.cypherdsl.core.utils.Strings#isValidJavaIdentifierPartAt(int,int)</exclude>
+								<exclude>org.neo4j.cypherdsl.core.utils.Strings#isIdentifier(java.lang.CharSequence)</exclude>
 								<!--
 								 | Those are shaded classes from Neo4j and we work around their changes.
 								 -->


### PR DESCRIPTION
* Too many escapes of the backslash
* No need to check for the actual ` and the unicode value
* BUT a need to check for the escaped unicode proper (which is literael
  \\u0060, written down as Java String becomes \\\\u0060, no further
  escapeing for the regex necessary
