### PR TITLE
fix: Allow `match` after unwind as defined by OpenCypher.

### DIFF
--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementBuilder.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementBuilder.java
@@ -172,7 +172,7 @@ public interface StatementBuilder
 	 * @since 1.0
 	 */
 	interface OngoingReading
-		extends ExposesReturning, ExposesWith, ExposesUpdatingClause, ExposesUnwind, ExposesCreate,
+		extends ExposesReturning, ExposesWith, ExposesUpdatingClause, ExposesUnwind, ExposesCreate, ExposesMatch,
 		ExposesCall<OngoingInQueryCallWithoutArguments>, ExposesSubqueryCall {
 	}
 


### PR DESCRIPTION
fixes #524
