### PR TITLE
issue/backports 20221219

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,13 +13,14 @@ jobs:
     outputs:
       revision: ${{ steps.revision_step.outputs.revision }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Required for JQAssistant
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+          distribution: zulu
       - name: Enable Sonar for local PRs not from Dependabot
         if:  ${{ github.event.sender.login != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         run: echo "USE_SONAR=sonar" >> $GITHUB_ENV
@@ -34,13 +35,13 @@ jobs:
           echo "OLD_VERSION=$(./bin/extract-version.sh latest)" >> $GITHUB_ENV
           echo "::set-output name=revision::$REVISION"
       - name: Cache SonarCloud packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -73,17 +74,18 @@ jobs:
         run: echo "REVISION=${{ needs.build.outputs.revision }}" >> $GITHUB_ENV
       - uses: actions/checkout@v1
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           # We build with 11, but down below we run with 8.
           java-version: 11
+          distribution: zulu
       - name: Download artifacts
         uses: actions/download-artifact@v1
         with:
           name: artifacts
           path: binaries
       - name: Recreate test classes
-        run: ./mvnw --no-transfer-progress test-compile -pl org.neo4j:neo4j-cypher-dsl -am
+        run: ./mvnw --no-transfer-progress -Dfast package -pl org.neo4j:neo4j-cypher-dsl -am
       - name: Run tests
         run: >
           docker run -v `pwd`:/ws --workdir=/ws jbangdev/jbang-action:0.95.0 --java 8 bin/runtests.java
@@ -104,7 +106,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Determine revision
         run: echo "REVISION=${{ needs.build.outputs.revision }}" >> $GITHUB_ENV
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Download artifacts
         uses: actions/download-artifact@v1
         with:
@@ -127,7 +129,7 @@ jobs:
     steps:
       - name: Determine revision
         run: echo "REVISION=${{ needs.build.outputs.revision }}" >> $GITHUB_ENV
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Download artifacts
         uses: actions/download-artifact@v1
         with:
@@ -135,8 +137,9 @@ jobs:
           path: repository
       - name: Install dependencies
         run: "mkdir -p $HOME/.m2 && mv $GITHUB_WORKSPACE/repository $HOME/.m2/"
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
+          distribution: zulu
           java-version: ${{ matrix.java }}
       - name: Run Maven build
         run: >

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -17,18 +17,19 @@ jobs:
         run: >
           echo "refName=${GITHUB_REF##*/}" >> $GITHUB_ENV
       - name: Checkout relevant branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ env.refName }}
       - name: Checkout gh-pages
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: gh-pages
           path: target/gh-pages
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+          distribution: zulu
       - name: Run docs generation
         run: >
           ./mvnw --no-transfer-progress asciidoctor:process-asciidoc@generate-docs -pl org.neo4j:neo4j-cypher-dsl-parent -Dproject.build.docs=target/gh-pages/${refName} &&

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementBuilder.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementBuilder.java
@@ -172,7 +172,7 @@ public interface StatementBuilder
 	 * @since 1.0
 	 */
 	interface OngoingReading
-		extends ExposesReturning, ExposesWith, ExposesUpdatingClause, ExposesUnwind, ExposesCreate,
+		extends ExposesReturning, ExposesWith, ExposesUpdatingClause, ExposesUnwind, ExposesCreate, ExposesMatch,
 		ExposesCall<OngoingInQueryCallWithoutArguments>, ExposesSubqueryCall {
 	}
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Configuration.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Configuration.java
@@ -119,6 +119,12 @@ public final class Configuration {
 			return new Builder();
 		}
 
+		/**
+		 * Enables or disables pretty printing. Enabling pretty printing will disable unnecessary escaping of labels and types.
+		 *
+		 * @param prettyPrint use {@literal true} for enabling pretty printing
+		 * @return this builder
+		 */
 		public Builder withPrettyPrint(boolean prettyPrint) {
 			this.prettyPrint = prettyPrint;
 			if (this.prettyPrint) {

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
 		<maven-source-plugin.version>3.2.1</maven-source-plugin.version>
 		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
 		<maven.version>3.8.4</maven.version>
-		<mockito.version>4.9.0</mockito.version>
+		<mockito.version>4.10.0</mockito.version>
 		<moditect-maven-plugin.version>1.0.0.RC2</moditect-maven-plugin.version>
 		<neo4j-java-driver.version>4.4.9</neo4j-java-driver.version>
 		<neo4j.version>4.4.12</neo4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -620,6 +620,9 @@
 								 | Those are shaded classes from Neo4j and we work around their changes.
 								 -->
 								<exclude>org.neo4j.cypherdsl.parser.internal</exclude>
+
+								<!-- 2022.8.2, Not to be implemented by users, also a bug fix as it has been oversight -->
+								<exclude>org.neo4j.cypherdsl.core.StatementBuilder$OngoingReading</exclude>
 							</excludes>
 						</parameter>
 					</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
 		<changelist>-SNAPSHOT</changelist>
 		<checker-qual.version>3.28.0</checker-qual.version>
 		<checkstyle.version>10.5.0</checkstyle.version>
-		<compile-testing.version>0.20</compile-testing.version>
+		<compile-testing.version>0.21.0</compile-testing.version>
 		<covered-ratio-complexity>0.75</covered-ratio-complexity>
 		<covered-ratio-instructions>0.75</covered-ratio-instructions>
 		<cypher-dsl.version.next />

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
 		<javapoet.version>1.13.0</javapoet.version>
 		<javax.annotation-api.version>1.3.2</javax.annotation-api.version>
 		<jaxb.version>2.3.1</jaxb.version>
-		<jetbrains-annotations.version>23.0.0</jetbrains-annotations.version>
+		<jetbrains-annotations.version>23.1.0</jetbrains-annotations.version>
 		<joda-time.version>2.12.2</joda-time.version>
 		<jsr305.version>3.0.2</jsr305.version>
 		<junit-jupiter.version>5.9.1</junit-jupiter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
 		<project.build.docs>${project.build.directory}/docs</project.build.docs>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<querydsl.version>5.0.0</querydsl.version>
-		<reactor.version>2022.0.0</reactor.version>
+		<reactor.version>2022.0.1</reactor.version>
 		<revision>9999</revision>
 		<sha1 />
 		<slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
- build: Upgrade various actions to non-deprecated versions. (#519)
- build(deps): Bump mockito.version from 4.9.0 to 4.10.0 (#528)
- build(deps): Bump reactor-bom from 2022.0.0 to 2022.0.1 (#527)
- build(deps): Bump compile-testing from 0.20 to 0.21.0 (#526)
- build(deps): Bump annotations from 23.0.0 to 23.1.0 (#521)
- docs: Make clear that pretty printing does not always escape names
- fix: Allow `match` after unwind as defined by OpenCypher. (#531)
