### PR TITLE
issue/backports 20230102

### DIFF
--- a/neo4j-cypher-dsl-build/pom.xml
+++ b/neo4j-cypher-dsl-build/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-| Copyright (c) 2019-2022 "Neo4j,"
+| Copyright (c) 2019-2023 "Neo4j,"
 | Neo4j Sweden AB [https://neo4j.com]
 |
 | This file is part of Neo4j.

--- a/neo4j-cypher-dsl-build/src/main/java/org/neo4j/cypherdsl/build/Entry.java
+++ b/neo4j-cypher-dsl-build/src/main/java/org/neo4j/cypherdsl/build/Entry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-build/src/main/java/org/neo4j/cypherdsl/build/RegisterForReflection.java
+++ b/neo4j-cypher-dsl-build/src/main/java/org/neo4j/cypherdsl/build/RegisterForReflection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-build/src/main/java/org/neo4j/cypherdsl/build/RegisterForReflectionProcessor.java
+++ b/neo4j-cypher-dsl-build/src/main/java/org/neo4j/cypherdsl/build/RegisterForReflectionProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-build/src/test/java/org/neo4j/cypherdsl/build/RegisterForReflectionProcessorTest.java
+++ b/neo4j-cypher-dsl-build/src/test/java/org/neo4j/cypherdsl/build/RegisterForReflectionProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/pom.xml
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- | Copyright (c) 2019-2022 "Neo4j,"
+ | Copyright (c) 2019-2023 "Neo4j,"
  | Neo4j Sweden AB [https://neo4j.com]
  |
  | This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/AbstractClassNameGenerator.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/AbstractClassNameGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/AbstractModelBuilder.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/AbstractModelBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/ClassNameGenerator.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/ClassNameGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/Configuration.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/Configuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/FieldNameGenerator.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/FieldNameGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/Identifiers.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/Identifiers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/ModelBuilder.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/ModelBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/NodeImplBuilder.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/NodeImplBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/NodeModelBuilder.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/NodeModelBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/NodeNameGenerator.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/NodeNameGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/PropertyDefinition.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/PropertyDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/RelationshipImplBuilder.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/RelationshipImplBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/RelationshipModelBuilder.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/RelationshipModelBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/RelationshipNameGenerator.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/RelationshipNameGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/RelationshipPropertyDefinition.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java/org/neo4j/cypherdsl/codegen/core/RelationshipPropertyDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java11/module-info.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/main/java11/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/test/java/org/neo4j/cypherdsl/codegen/core/ConfigurationTest.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/test/java/org/neo4j/cypherdsl/codegen/core/ConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/test/java/org/neo4j/cypherdsl/codegen/core/ConstantFieldNamingStrategyTest.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/test/java/org/neo4j/cypherdsl/codegen/core/ConstantFieldNamingStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/test/java/org/neo4j/cypherdsl/codegen/core/NodeImplBuilderTest.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/test/java/org/neo4j/cypherdsl/codegen/core/NodeImplBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/test/java/org/neo4j/cypherdsl/codegen/core/NodeNameGeneratorTest.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/test/java/org/neo4j/cypherdsl/codegen/core/NodeNameGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/test/java/org/neo4j/cypherdsl/codegen/core/RelationshipNameGeneratorTest.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-core/src/test/java/org/neo4j/cypherdsl/codegen/core/RelationshipNameGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/main/java/org/neo4j/cypherdsl/codegen/sdn6/SDN6AnnotationProcessor.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/main/java/org/neo4j/cypherdsl/codegen/sdn6/SDN6AnnotationProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/main/java/org/neo4j/cypherdsl/codegen/sdn6/TypeElementVisitor.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/main/java/org/neo4j/cypherdsl/codegen/sdn6/TypeElementVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/SDN6AnnotationProcessorTest.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/SDN6AnnotationProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/abstract_rels/Actor.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/abstract_rels/Actor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/abstract_rels/Movie.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/abstract_rels/Movie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/abstract_rels/Person.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/abstract_rels/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/different_properties_for_rel_type/Movie.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/different_properties_for_rel_type/Movie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/different_properties_for_rel_type/MovieAppearance.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/different_properties_for_rel_type/MovieAppearance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/different_properties_for_rel_type/Person.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/different_properties_for_rel_type/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/different_properties_for_rel_type/Play.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/different_properties_for_rel_type/Play.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/different_properties_for_rel_type/TheaterAppearance.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/different_properties_for_rel_type/TheaterAppearance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/different_properties_for_rel_type/package-info.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/different_properties_for_rel_type/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/enums_and_inner_classes/ConnectorTransport.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/enums_and_inner_classes/ConnectorTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/enums_and_inner_classes/InnerInnerClassConverter.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/enums_and_inner_classes/InnerInnerClassConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/enums_and_inner_classes/OtherEnum.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/enums_and_inner_classes/OtherEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/enums_and_inner_classes/SpringBasedConverter.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/enums_and_inner_classes/SpringBasedConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/ids/ExternalGeneratedId.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/ids/ExternalGeneratedId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/ids/ExternalGeneratedIdImplicit.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/ids/ExternalGeneratedIdImplicit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/ids/InternalGeneratedId.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/ids/InternalGeneratedId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/ids/InternalGeneratedIdWithSpringId.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/ids/InternalGeneratedIdWithSpringId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/ids/InternalGeneratedPrimitiveLongId.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/ids/InternalGeneratedPrimitiveLongId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/labels/NodesWithDifferentLabelAnnotations.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/labels/NodesWithDifferentLabelAnnotations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/primitives/Connector.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/primitives/Connector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_properties_for_rel_type/Movie.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_properties_for_rel_type/Movie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_properties_for_rel_type/MovieAppearance.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_properties_for_rel_type/MovieAppearance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_properties_for_rel_type/Person.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_properties_for_rel_type/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_properties_for_rel_type/Play.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_properties_for_rel_type/Play.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_properties_for_rel_type/TheaterAppearance.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_properties_for_rel_type/TheaterAppearance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_properties_for_rel_type/package-info.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_properties_for_rel_type/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_rel_different_source/Book.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_rel_different_source/Book.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_rel_different_source/Movie.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_rel_different_source/Movie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_rel_different_source/Person.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_rel_different_source/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_rel_different_target/Book.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_rel_different_target/Book.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_rel_different_target/Movie.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_rel_different_target/Movie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_rel_different_target/Person.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_rel_different_target/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_rel_different_target/package-info.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_rel_different_target/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_rel_mixed/Book.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_rel_mixed/Book.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_rel_mixed/Movie.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_rel_mixed/Movie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_rel_mixed/Person.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_rel_mixed/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_rel_mixed_different_directions/Book.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_rel_mixed_different_directions/Book.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_rel_mixed_different_directions/Movie.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_rel_mixed_different_directions/Movie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_rel_mixed_different_directions/Person.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/same_rel_mixed_different_directions/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/self_referential/Example.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/self_referential/Example.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/simple/Actor.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/simple/Actor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/simple/Movie.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/simple/Movie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/simple/Person.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/simple/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/simple/package-info.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/java/org/neo4j/cypherdsl/codegen/sdn6/models/simple/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/resources/org/neo4j/cypherdsl/codegen/sdn6/models/related_classes_not_on_cp_like_in_reallife/Movie.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/resources/org/neo4j/cypherdsl/codegen/sdn6/models/related_classes_not_on_cp_like_in_reallife/Movie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/resources/org/neo4j/cypherdsl/codegen/sdn6/models/related_classes_not_on_cp_like_in_reallife/Person.java
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/src/test/resources/org/neo4j/cypherdsl/codegen/sdn6/models/related_classes_not_on_cp_like_in_reallife/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-codegen/pom.xml
+++ b/neo4j-cypher-dsl-codegen/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- | Copyright (c) 2019-2022 "Neo4j,"
+ | Copyright (c) 2019-2023 "Neo4j,"
  | Neo4j Sweden AB [https://neo4j.com]
  |
  | This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/pom.xml
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-| Copyright (c) 2019-2022 "Neo4j,"
+| Copyright (c) 2019-2023 "Neo4j,"
 | Neo4j Sweden AB [https://neo4j.com]
 |
 | This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/core/ArbitraryProceduresAndFunctionsTest.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/core/ArbitraryProceduresAndFunctionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/core/CypherDSLExamplesTest.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/core/CypherDSLExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/core/FunctionsListTest.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/core/FunctionsListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/core/IssuesExamplesTest.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/core/IssuesExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/core/PropertiesTest.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/core/PropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/model/AbstractNodeDefinition.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/model/AbstractNodeDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/model/AbstractRelationshipDefinition.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/model/AbstractRelationshipDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/model/ActedIn.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/model/ActedIn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/model/BelongsTo.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/model/BelongsTo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/model/Department.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/model/Department.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/model/Directed.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/model/Directed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/model/Division.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/model/Division.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/model/Movie.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/model/Movie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/model/Person.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/model/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/model/StaticModelIT.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/model/StaticModelIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/model/UnboundRelation.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-core/src/test/java/org/neo4j/cypherdsl/examples/model/UnboundRelation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-driver/pom.xml
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-driver/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-| Copyright (c) 2019-2022 "Neo4j,"
+| Copyright (c) 2019-2023 "Neo4j,"
 | Neo4j Sweden AB [https://neo4j.com]
 |
 | This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-driver/src/test/java/org/neo4j/cypherdsl/examples/drivers/ExecutableStatementsIT.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-driver/src/test/java/org/neo4j/cypherdsl/examples/drivers/ExecutableStatementsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-parser/pom.xml
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-parser/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-| Copyright (c) 2019-2022 "Neo4j,"
+| Copyright (c) 2019-2023 "Neo4j,"
 | Neo4j Sweden AB [https://neo4j.com]
 |
 | This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/pom.xml
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-| Copyright (c) 2019-2022 "Neo4j,"
+| Copyright (c) 2019-2023 "Neo4j,"
 | Neo4j Sweden AB [https://neo4j.com]
 |
 | This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/pom.xml
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/pom.xml
@@ -36,7 +36,7 @@
 	<description>Example how to use the SDN 6 code generator.</description>
 
 	<properties>
-		<checkstyle.version>10.5.0</checkstyle.version>
+		<checkstyle.version>10.6.0</checkstyle.version>
 		<java-module-name>org.neo4j.cypherdsl.examples.sdn6</java-module-name>
 		<java.version>11</java.version>
 		<maven-checkstyle-plugin.version>3.2.0</maven-checkstyle-plugin.version>

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/Application.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/misc/Example.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/misc/Example.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/movies/Actor.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/movies/Actor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/movies/Genre.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/movies/Genre.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/movies/GenreRepository.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/movies/GenreRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/movies/Movie.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/movies/Movie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/movies/MovieRepository.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/movies/MovieRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/movies/MovieService.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/movies/MovieService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/movies/MoviesController.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/movies/MoviesController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/movies/NewPersonCmd.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/movies/NewPersonCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/movies/PeopleController.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/movies/PeopleController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/movies/PeopleRepository.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/movies/PeopleRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/movies/PeopleService.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/movies/PeopleService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/movies/Person.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/movies/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/movies/PersonDetails.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/movies/PersonDetails.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/test/java/org/neo4j/cypherdsl/examples/sdn6/ApplicationIT.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/test/java/org/neo4j/cypherdsl/examples/sdn6/ApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/test/java/org/neo4j/cypherdsl/examples/sdn6/UsageTest.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/test/java/org/neo4j/cypherdsl/examples/sdn6/UsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-examples/pom.xml
+++ b/neo4j-cypher-dsl-examples/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- | Copyright (c) 2019-2022 "Neo4j,"
+ | Copyright (c) 2019-2023 "Neo4j,"
  | Neo4j Sweden AB [https://neo4j.com]
  |
  | This file is part of Neo4j.

--- a/neo4j-cypher-dsl-native-tests/pom.xml
+++ b/neo4j-cypher-dsl-native-tests/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-| Copyright (c) 2019-2022 "Neo4j,"
+| Copyright (c) 2019-2023 "Neo4j,"
 | Neo4j Sweden AB [https://neo4j.com]
 |
 | This file is part of Neo4j.

--- a/neo4j-cypher-dsl-native-tests/src/main/java/org/neo4j/cypherdsl/graalvm/Application.java
+++ b/neo4j-cypher-dsl-native-tests/src/main/java/org/neo4j/cypherdsl/graalvm/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-native-tests/src/test/java/org/neo4j/cypherdsl/graalvm/NativeApplicationIT.java
+++ b/neo4j-cypher-dsl-native-tests/src/test/java/org/neo4j/cypherdsl/graalvm/NativeApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-schema-name-support/pom.xml
+++ b/neo4j-cypher-dsl-schema-name-support/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- | Copyright (c) 2019-2022 "Neo4j,"
+ | Copyright (c) 2019-2023 "Neo4j,"
  | Neo4j Sweden AB [https://neo4j.com]
  |
  | This file is part of Neo4j.

--- a/neo4j-cypher-dsl-schema-name-support/src/main/java/org/neo4j/cypherdsl/support/schema_name/SchemaNames.java
+++ b/neo4j-cypher-dsl-schema-name-support/src/main/java/org/neo4j/cypherdsl/support/schema_name/SchemaNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-schema-name-support/src/test/java/org/neo4j/cypherdsl/support/schema_name/SchemaNamesIT.java
+++ b/neo4j-cypher-dsl-schema-name-support/src/test/java/org/neo4j/cypherdsl/support/schema_name/SchemaNamesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl-schema-name-support/src/test/java/org/neo4j/cypherdsl/support/schema_name/SchemaNamesTest.java
+++ b/neo4j-cypher-dsl-schema-name-support/src/test/java/org/neo4j/cypherdsl/support/schema_name/SchemaNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/pom.xml
+++ b/neo4j-cypher-dsl/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- | Copyright (c) 2019-2022 "Neo4j,"
+ | Copyright (c) 2019-2023 "Neo4j,"
  | Neo4j Sweden AB [https://neo4j.com]
  |
  | This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractCase.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractNode.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractPropertyContainer.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractPropertyContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractStatement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Aliased.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Aliased.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AliasedExpression.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AliasedExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Arguments.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Arguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Asterisk.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Asterisk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/BooleanFunctionCondition.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/BooleanFunctionCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/BooleanLiteral.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/BooleanLiteral.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/BuiltInFunctions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/BuiltInFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Case.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Case.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Clause.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Clause.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Clauses.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Clauses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ClausesBasedStatement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ClausesBasedStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Comparison.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Comparison.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/CompoundCondition.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/CompoundCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Condition.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Condition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Conditions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Conditions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ConflictingParametersException.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ConflictingParametersException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ConstantCondition.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ConstantCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Create.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Create.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DecoratedQuery.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DecoratedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DefaultLoadCSVStatementBuilder.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DefaultLoadCSVStatementBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DefaultStatementBuilder.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DefaultStatementBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Delete.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Delete.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DistinctExpression.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DistinctExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExistentialSubquery.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExistentialSubquery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesCall.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesCreate.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesCreate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesHints.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesHints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesLoadCSV.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesLoadCSV.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesLogicalOperators.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesLogicalOperators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesMatch.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesMatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesMerge.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesMerge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesPatternLengthAccessors.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesPatternLengthAccessors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesProperties.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesRelationships.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesRelationships.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesReturning.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesReturning.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesSubqueryCall.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesSubqueryCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesUnwind.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesUnwind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesWhere.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesWhere.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Expression.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Expression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExpressionCondition.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExpressionCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExpressionList.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExpressionList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Expressions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Expressions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Foreach.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Foreach.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ForeignAdapter.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ForeignAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ForeignAdapterFactory.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ForeignAdapterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/FunctionInvocation.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/FunctionInvocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Functions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Functions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/HasLabelCondition.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/HasLabelCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Hint.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Hint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/IdentifiableElement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/IdentifiableElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/IdentifiableExpressionCollectingVisitor.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/IdentifiableExpressionCollectingVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/InTransactions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/InTransactions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/InternalNodeImpl.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/InternalNodeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/InternalPropertyImpl.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/InternalPropertyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/InternalRelationshipImpl.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/InternalRelationshipImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/KeyValueMapEntry.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/KeyValueMapEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Limit.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Limit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListComprehension.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListComprehension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListExpression.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListLiteral.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListLiteral.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListOperator.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListPredicate.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Literal.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Literal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/LoadCSVStatementBuilder.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/LoadCSVStatementBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MapExpression.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MapExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MapProjection.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MapProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Match.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Match.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Merge.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Merge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MergeAction.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MergeAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MessageKeys.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MessageKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MultiPartElement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MultiPartElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MultiPartQuery.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MultiPartQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Named.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Named.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NamedPath.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NamedPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Neo4jVersion.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Neo4jVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NestedExpression.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NestedExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Node.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Node.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NodeBase.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NodeBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NodeLabel.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NodeLabel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NodeLabels.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NodeLabels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NullLiteral.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NullLiteral.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NumberLiteral.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NumberLiteral.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Operation.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Operation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Operations.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Operations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Operator.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Operator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Order.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Order.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Parameter.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Parameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ParameterCollectingVisitor.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ParameterCollectingVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Pattern.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Pattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PatternComprehension.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PatternComprehension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PatternElement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PatternElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Predicates.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Predicates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ProcedureCall.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ProcedureCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ProcedureCallImpl.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ProcedureCallImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Properties.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Properties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Property.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Property.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PropertyContainer.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PropertyContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PropertyLookup.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PropertyLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/QueryDSLAdapter.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/QueryDSLAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RawLiteral.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RawLiteral.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ReadingClause.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ReadingClause.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Reduction.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Reduction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Relationship.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Relationship.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipBase.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipChain.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipPattern.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipPattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Remove.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Remove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ResultStatement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ResultStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Return.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Return.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ReturnBody.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ReturnBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Set.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Set.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/SinglePartQuery.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/SinglePartQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Skip.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Skip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/SortItem.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/SortItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Statement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Statement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementBuilder.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementContextImpl.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StringLiteral.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StringLiteral.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Subquery.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Subquery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/SymbolicName.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/SymbolicName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/TemporalLiteral.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/TemporalLiteral.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/UnionPart.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/UnionPart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/UnionQuery.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/UnionQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Unwind.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Unwind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/UpdatingClause.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/UpdatingClause.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Where.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Where.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/With.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/With.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ast/EnterResult.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ast/EnterResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ast/ProvidesAffixes.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ast/ProvidesAffixes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ast/TypedSubtree.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ast/TypedSubtree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ast/Visitable.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ast/Visitable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ast/Visitor.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ast/Visitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ast/VisitorWithResult.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ast/VisitorWithResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ast/package-info.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ast/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/DefaultExecutableResultStatement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/DefaultExecutableResultStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/DefaultExecutableStatement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/DefaultExecutableStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/DefaultReactiveExecutableResultStatement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/DefaultReactiveExecutableResultStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/DefaultReactiveExecutableStatement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/DefaultReactiveExecutableStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/ExecutableResultStatement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/ExecutableResultStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/ExecutableStatement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/ExecutableStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/ReactiveExecutableResultStatement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/ReactiveExecutableResultStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/ReactiveExecutableStatement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/ReactiveExecutableStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/package-info.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/executables/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/CaseElse.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/CaseElse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/CaseWhenThen.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/CaseWhenThen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/ConstantParameterHolder.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/ConstantParameterHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/Distinct.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/Distinct.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/HandlerException.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/HandlerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/LiteralBase.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/LiteralBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/LoadCSV.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/LoadCSV.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/Namespace.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/Namespace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/ProcedureName.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/ProcedureName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/ReflectiveVisitor.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/ReflectiveVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/RelationshipLength.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/RelationshipLength.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/RelationshipPatternCondition.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/RelationshipPatternCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/RelationshipTypes.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/RelationshipTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/ScopingStrategy.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/ScopingStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/StatementContext.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/StatementContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/UsingPeriodicCommit.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/UsingPeriodicCommit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/YieldItems.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/YieldItems.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/package-info.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/package-info.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/querydsl/CypherContext.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/querydsl/CypherContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/querydsl/CypherTemplates.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/querydsl/CypherTemplates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/querydsl/ToCypherFormatStringVisitor.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/querydsl/ToCypherFormatStringVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/querydsl/UnsupportedOperatorException.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/querydsl/UnsupportedOperatorException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/querydsl/package-info.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/querydsl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/ConfigurableRenderer.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/ConfigurableRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Configuration.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Configuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/DefaultVisitor.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/DefaultVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Dialect.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Dialect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Neo4j5ComparisonVisitor.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Neo4j5ComparisonVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Neo4j5FunctionInvocationVisitor.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Neo4j5FunctionInvocationVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/PrettyPrintingVisitor.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/PrettyPrintingVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Renderer.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Renderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/RenderingVisitor.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/RenderingVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Symbols.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Symbols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/package-info.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/utils/Assertions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/utils/Assertions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/utils/CheckReturnValue.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/utils/CheckReturnValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/utils/LRUCache.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/utils/LRUCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/utils/Strings.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/utils/Strings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/utils/package-info.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/utils/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/main/java11/module-info.java
+++ b/neo4j-cypher-dsl/src/main/java11/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/BooleanLiteralTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/BooleanLiteralTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/BuiltInFunctionsTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/BuiltInFunctionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/ClausesTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/ClausesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/ComparisonTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/ComparisonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/DefaultStatementBuilderTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/DefaultStatementBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/DialectIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/DialectIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/ExpressionTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/ExpressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/ForeignAdapterFactoryTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/ForeignAdapterFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/FunctionInvocationTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/FunctionInvocationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/FunctionsIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/FunctionsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/FunctionsTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/FunctionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/HintsIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/HintsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/IdentifiableExpressionsIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/IdentifiableExpressionsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/InternalNodeImplTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/InternalNodeImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/InternalPropertyImplTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/InternalPropertyImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/InternalRelationshipImplTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/InternalRelationshipImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/IssueRelatedIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/IssueRelatedIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/LoadCSVIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/LoadCSVIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/PackageAndAPIStructureTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/PackageAndAPIStructureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/ParameterIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/ParameterIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/PredicatesTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/PredicatesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/ProcedureCallsIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/ProcedureCallsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/RawLiteralTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/RawLiteralTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/RelationshipChainTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/RelationshipChainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/StringLiteralTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/StringLiteralTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/SubqueriesIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/SubqueriesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/SymbolicNameTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/SymbolicNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/TemporalLiteralTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/TemporalLiteralTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/TestUtils.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/internal/LoadCSVTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/internal/LoadCSVTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/internal/ReflectiveVisitorTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/internal/ReflectiveVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/querydsl/Person.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/querydsl/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/querydsl/Place.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/querydsl/Place.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/querydsl/QueryDSLAdapterTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/querydsl/QueryDSLAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/querydsl/Stuff.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/querydsl/Stuff.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/querydsl/UnsupportedOperatorExceptionTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/querydsl/UnsupportedOperatorExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/renderer/ConfigurationTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/renderer/ConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/renderer/DefaultVisitorTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/renderer/DefaultVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/renderer/PrettyPrintingVisitorTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/renderer/PrettyPrintingVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 "Neo4j,"
+ * Copyright (c) 2019-2023 "Neo4j,"
  * Neo4j Sweden AB [https://neo4j.com]
  *
  * This file is part of Neo4j.

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
 		<cglib.version>3.3.0</cglib.version>
 		<changelist>-SNAPSHOT</changelist>
 		<checker-qual.version>3.28.0</checker-qual.version>
-		<checkstyle.version>10.5.0</checkstyle.version>
+		<checkstyle.version>10.6.0</checkstyle.version>
 		<compile-testing.version>0.21.0</compile-testing.version>
 		<covered-ratio-complexity>0.75</covered-ratio-complexity>
 		<covered-ratio-instructions>0.75</covered-ratio-instructions>

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
 		<maven-source-plugin.version>3.2.1</maven-source-plugin.version>
 		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
 		<maven.version>3.8.4</maven.version>
-		<mockito.version>4.10.0</mockito.version>
+		<mockito.version>4.11.0</mockito.version>
 		<moditect-maven-plugin.version>1.0.0.RC2</moditect-maven-plugin.version>
 		<neo4j-java-driver.version>4.4.9</neo4j-java-driver.version>
 		<neo4j.version>4.4.12</neo4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- | Copyright (c) 2019-2022 "Neo4j,"
+ | Copyright (c) 2019-2023 "Neo4j,"
  | Neo4j Sweden AB [https://neo4j.com]
  |
  | This file is part of Neo4j.


### PR DESCRIPTION
- build(deps): Bump mockito.version from 4.10.0 to 4.11.0 (#536)
- build(deps): Bump checkstyle from 10.5.0 to 10.6.0 (#537)
- chore: Extend license header to 2023.
