### PR TITLE
refactor: Improve `returning` and `with`.

### DIFF
--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Asterisk.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Asterisk.java
@@ -46,4 +46,15 @@ public final class Asterisk extends LiteralBase<String> {
 	public String asString() {
 		return super.getContent();
 	}
+
+	enum IdentifiableAsterisk implements IdentifiableElement {
+
+		INSTANCE;
+
+		@NotNull
+		@Override
+		public Expression asExpression() {
+			return Asterisk.INSTANCE;
+		}
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
@@ -461,21 +461,6 @@ public final class Cypher {
 	 * can be unwound later on etc. A leading {@code WITH} cannot be used with patterns obviously and needs its
 	 * arguments to have an alias.
 	 *
-	 * @param variables One ore more variables.
-	 * @return An ongoing with clause.
-	 * @since 2021.2.2
-	 */
-	@NotNull @Contract(pure = true)
-	public static StatementBuilder.OrderableOngoingReadingAndWithWithoutWhere with(SymbolicName... variables) {
-
-		return Statement.builder().with(variables);
-	}
-
-	/**
-	 * Starts a statement with a leading {@code WITH}. Those are useful for passing on lists of various type that
-	 * can be unwound later on etc. A leading {@code WITH} cannot be used with patterns obviously and needs its
-	 * arguments to have an alias.
-	 *
 	 * @param elements One ore more variables.
 	 * @return An ongoing with clause.
 	 * @since 2020.1.2
@@ -490,50 +475,18 @@ public final class Cypher {
 	 * Starts a statement with a leading {@code WITH}. Those are useful for passing on lists of various type that
 	 * can be unwound later on etc. A leading {@code WITH} cannot be used with patterns obviously and needs its
 	 * arguments to have an alias.
-	 *
-	 * @param expressions One or more aliased expressions.
-	 * @return An ongoing with clause.
-	 * @since 2021.2.2
-	 */
-	@NotNull @Contract(pure = true)
-	public static StatementBuilder.OrderableOngoingReadingAndWithWithoutWhere with(AliasedExpression... expressions) {
-
-		return Statement.builder().with(expressions);
-	}
-
-	/**
-	 * Starts a statement with a leading {@code WITH}. Those are useful for passing on lists of various type that
-	 * can be unwound later on etc. A leading {@code WITH} cannot be used with patterns obviously and needs its
-	 * arguments to have an alias.
 	 * <p>
 	 * This method takes both aliased and non-aliased expression. The later will produce only valid Cypher when used in
 	 * combination with a correlated subquery via {@link Cypher#call(Statement)}.
 	 *
-	 * @param expressions One or more expressions.
-	 * @return An ongoing with clause.
-	 */
-	@NotNull @Contract(pure = true)
-	public static StatementBuilder.OrderableOngoingReadingAndWithWithoutWhere with(Expression... expressions) {
-
-		return Statement.builder().with(expressions);
-	}
-
-	/**
-	 * Starts a statement with a leading {@code WITH}. Those are useful for passing on lists of various type that
-	 * can be unwound later on etc. A leading {@code WITH} cannot be used with patterns obviously and needs its
-	 * arguments to have an alias.
-	 * <p>
-	 * This method takes both aliased and non-aliased expression. The later will produce only valid Cypher when used in
-	 * combination with a correlated subquery via {@link Cypher#call(Statement)}.
-	 *
-	 * @param expressions One ore more expressions.
+	 * @param elements One ore more expressions.
 	 * @return An ongoing with clause.
 	 * @since 2021.2.2
 	 */
 	@NotNull @Contract(pure = true)
-	public static StatementBuilder.OrderableOngoingReadingAndWithWithoutWhere with(Collection<Expression> expressions) {
+	public static StatementBuilder.OrderableOngoingReadingAndWithWithoutWhere with(Collection<IdentifiableElement> elements) {
 
-		return with(expressions.toArray(new Expression[] {}));
+		return Statement.builder().with(elements);
 	}
 
 	/**
@@ -810,7 +763,7 @@ public final class Cypher {
 	/**
 	 * A {@literal RETURN} statement without a previous match.
 	 *
-	 * @param expressions The expressions to return
+	 * @param expressions The elements to return
 	 * @return A buildable statement
 	 * @since 1.0.1
 	 */
@@ -828,7 +781,7 @@ public final class Cypher {
 	 */
 	@NotNull @Contract(pure = true)
 	public static StatementBuilder.OngoingReadingAndReturn returning(Collection<Expression> expressions) {
-		return returning(expressions.toArray(new Expression[] {}));
+		return Statement.builder().returning(expressions);
 	}
 
 	/**

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DefaultLoadCSVStatementBuilder.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DefaultLoadCSVStatementBuilder.java
@@ -37,7 +37,7 @@ import org.neo4j.cypherdsl.core.internal.UsingPeriodicCommit;
 @API(status = INTERNAL, since = "2021.2.1")
 final class DefaultLoadCSVStatementBuilder extends DefaultStatementBuilder implements LoadCSVStatementBuilder {
 
-	static class PrepareLoadCSVStatementImpl implements ExposesLoadCSV, OngoingLoadCSV {
+	static final class PrepareLoadCSVStatementImpl implements ExposesLoadCSV, OngoingLoadCSV {
 
 		private final UsingPeriodicCommit usingPeriodicCommit;
 		private final DefaultStatementBuilder source;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesReturning.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesReturning.java
@@ -24,6 +24,7 @@ import org.apiguardian.api.API;
 import org.jetbrains.annotations.NotNull;
 import org.neo4j.cypherdsl.core.annotations.CheckReturnValue;
 
+import java.util.Arrays;
 import java.util.Collection;
 
 /**
@@ -65,7 +66,9 @@ public interface ExposesReturning {
 	 * @return A match that can be build now
 	 */
 	@NotNull @CheckReturnValue
-	StatementBuilder.OngoingReadingAndReturn returning(Expression... expressions);
+	default StatementBuilder.OngoingReadingAndReturn returning(Expression... expressions) {
+		return returning(expressions == null ? null : Arrays.asList(expressions));
+	}
 
 	/**
 	 * Create a match that returns one or more expressions.
@@ -81,7 +84,7 @@ public interface ExposesReturning {
 	 * must be valid {@link SymbolicName symbolic names}. {@link Expression#property(String...)} must be used to return
 	 * single properties.
 	 *
-	 * @param variables The named things to return
+	 * @param variables The variables to return
 	 * @return A build step with a defined list of things to return.
 	 */
 	@NotNull @CheckReturnValue
@@ -107,7 +110,9 @@ public interface ExposesReturning {
 	 * @return A match that can be build now
 	 */
 	@NotNull @CheckReturnValue
-	StatementBuilder.OngoingReadingAndReturn returningDistinct(Expression... expressions);
+	default StatementBuilder.OngoingReadingAndReturn returningDistinct(Expression... expressions) {
+		return returningDistinct(expressions == null ? null : Arrays.asList(expressions));
+	}
 
 	/**
 	 * Creates a {@code RETURN} clause returning the distinct set of one or more expressions.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesWith.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesWith.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2019-2023 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.core;
+
+import static org.apiguardian.api.API.Status.STABLE;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.apiguardian.api.API;
+import org.jetbrains.annotations.NotNull;
+import org.neo4j.cypherdsl.core.StatementBuilder.OrderableOngoingReadingAndWithWithoutWhere;
+import org.neo4j.cypherdsl.core.annotations.CheckReturnValue;
+
+/**
+ * A step that exposes the {@code WITH} clause. This interface used to be part of the {@link StatementBuilder} and moved
+ * out of it to unify the {@literal WITH} clause taking in {@link IdentifiableElement identifable elements}.
+ *
+ * @author Michael J. Simons
+ * @since 2023.0.0
+ */
+@API(status = STABLE, since = "2023.0.0")
+public interface ExposesWith {
+
+	/**
+	 * Pipes all known variables into the next step of the pipeline
+	 * @param asterisk the asterisk
+	 * @return A match that can be build now
+	 */
+	default OrderableOngoingReadingAndWithWithoutWhere with(@SuppressWarnings("unused") Asterisk asterisk) {
+		return with(Asterisk.IdentifiableAsterisk.INSTANCE);
+	}
+
+	/**
+	 * Starts a with clause by passing variables to it.
+	 *
+	 * @param variables The variables to pass on to the next part
+	 * @return A match that can be build now
+	 */
+	@NotNull
+	@CheckReturnValue
+	default OrderableOngoingReadingAndWithWithoutWhere with(String... variables) {
+		return with(Expressions.createSymbolicNames(variables));
+	}
+
+	/**
+	 * Create a match that returns one or more identifiable elements.
+	 *
+	 * @param elements The variables to pass on to the next part
+	 * @return A match that can be build now
+	 */
+	@NotNull
+	@CheckReturnValue
+	default OrderableOngoingReadingAndWithWithoutWhere with(IdentifiableElement... elements) {
+		return with(Arrays.asList(elements));
+	}
+
+	/**
+	 * Create a match that returns one or more identifiable elements.
+	 *
+	 * @param elements The expressions to be returned. Must not be null and be at least one expression.
+	 * @return A match that can be build now
+	 */
+	@NotNull
+	@CheckReturnValue
+	OrderableOngoingReadingAndWithWithoutWhere with(Collection<IdentifiableElement> elements);
+
+	/**
+	 * Create a match that returns the distinct set of one or more identifiable elements.
+	 *
+	 * @param variables The variables to pass on to the next part
+	 * @return A match that can be build now
+	 * @see #withDistinct(IdentifiableElement...)
+	 */
+	@NotNull
+	@CheckReturnValue
+	default OrderableOngoingReadingAndWithWithoutWhere withDistinct(String... variables) {
+		return withDistinct(Expressions.createSymbolicNames(variables));
+	}
+
+	/**
+	 * Create a match that returns the distinct set of one or more identifiable elements.
+	 *
+	 * @param elements The variables to pass on to the next part
+	 * @return A match that can be build now
+	 * @see #withDistinct(IdentifiableElement...)
+	 */
+	@NotNull
+	@CheckReturnValue
+	default OrderableOngoingReadingAndWithWithoutWhere withDistinct(IdentifiableElement... elements) {
+		return withDistinct(Arrays.asList(elements));
+	}
+
+	/**
+	 * Create a match that returns the distinct set of one or more expressions.
+	 *
+	 * @param expressions The expressions to be returned. Must not be null and be at least one expression.
+	 * @return A match that can be build now
+	 */
+	@NotNull
+	@CheckReturnValue
+	OrderableOngoingReadingAndWithWithoutWhere withDistinct(Collection<IdentifiableElement> expressions);
+}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Expressions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Expressions.java
@@ -138,17 +138,13 @@ public final class Expressions {
 		}
 	}
 
-	static Expression[] createSymbolicNames(String[] variables) {
-		return Arrays.stream(variables).map(SymbolicName::of).toArray(Expression[]::new);
+	static SymbolicName[] createSymbolicNames(String[] variables) {
+		return Arrays.stream(variables).map(SymbolicName::of).toArray(SymbolicName[]::new);
 	}
 
-	static Expression[] createSymbolicNames(Named[] variables) {
+	static SymbolicName[] createSymbolicNames(Named[] variables) {
 		return Arrays.stream(variables).map(Named::getRequiredSymbolicName)
-			.toArray(Expression[]::new);
-	}
-
-	static Expression[] createSymbolicNames(IdentifiableElement[] variables) {
-		return Arrays.stream(variables).map(IdentifiableElement::asExpression).toArray(Expression[]::new);
+			.toArray(SymbolicName[]::new);
 	}
 
 	static String format(Expression expression) {

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/IdentifiableElement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/IdentifiableElement.java
@@ -24,8 +24,9 @@ import org.jetbrains.annotations.NotNull;
 /**
  * This interface represents an element that can be for example an identifiable part of the {@code WITH} clause.
  * It has been introduced to circumvent the absence of union types in Java
- * and to avoid an overload of {@link StatementBuilder#with(Expression...)} with an {@code Object...} parameter
- * to allow passing {@link Named named things} or {@link AliasedExpression aliased expression} into a pipeline.
+ * and to avoid an overload of {@link StatementBuilder#with(String...)} or other expressions with an {@code Object...}
+ * parameter. This type here allows passing {@link Named named things}. {@link AliasedExpression aliased expression},
+ * {@link SymbolicName symobolic names} into a pipeline.
  * <p>
  * There should be no need to implement this on your own.
  *
@@ -33,7 +34,7 @@ import org.jetbrains.annotations.NotNull;
  * @soundtrack Fatoni &amp; Edgar Wasser - Delirium
  * @since 2021.2.2
  */
-public interface IdentifiableElement {
+public sealed interface IdentifiableElement permits AliasedExpression, Asterisk.IdentifiableAsterisk, Named, Property, SymbolicName {
 
 	/**
 	 * Transform this element into an expression

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Named.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Named.java
@@ -33,7 +33,7 @@ import org.jetbrains.annotations.NotNull;
  * @since 1.0
  */
 @API(status = STABLE, since = "1.0")
-public interface Named extends IdentifiableElement {
+public non-sealed interface Named extends IdentifiableElement {
 
 	/**
 	 * @return An optional symbolic name.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Property.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Property.java
@@ -37,7 +37,7 @@ import org.jetbrains.annotations.NotNull;
  * @since 1.0
  */
 @API(status = STABLE, since = "1.0")
-public interface Property extends Expression, IdentifiableElement {
+public non-sealed interface Property extends Expression, IdentifiableElement {
 
 	/**
 	 * Returns the concatenated names of the property or the external reference (See {@link #referencedAs(String)}) if set.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementBuilder.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementBuilder.java
@@ -25,9 +25,9 @@ import java.util.Collection;
 import org.apiguardian.api.API;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import org.neo4j.cypherdsl.core.annotations.CheckReturnValue;
 import org.neo4j.cypherdsl.core.internal.RelationshipPatternCondition;
 import org.neo4j.cypherdsl.core.utils.Assertions;
-import org.neo4j.cypherdsl.core.annotations.CheckReturnValue;
 
 /**
  * @author Michael J. Simons
@@ -37,76 +37,7 @@ import org.neo4j.cypherdsl.core.annotations.CheckReturnValue;
  */
 @API(status = STABLE, since = "1.0")
 public interface StatementBuilder
-	extends ExposesMatch, ExposesCreate, ExposesMerge, ExposesUnwind, ExposesReturning, ExposesSubqueryCall {
-
-	/**
-	 * Starts a with clause by passing variables to it.
-	 *
-	 * @param variables The variables to start the query with
-	 * @return An ongoing read, exposing return and further matches.
-	 * @since 2020.1.2
-	 */
-	@NotNull @CheckReturnValue
-	OrderableOngoingReadingAndWithWithoutWhere with(String... variables);
-
-	/**
-	 * Starts a with clause by passing variables to it.
-	 *
-	 * @param variables The variables to start the query with
-	 * @return An ongoing read, exposing return and further matches.
-	 * @since 2020.1.2
-	 */
-	@NotNull @CheckReturnValue
-	OrderableOngoingReadingAndWithWithoutWhere with(SymbolicName... variables);
-
-	/**
-	 * Starts a with clause by passing named expressions to it.
-	 *
-	 * @param expressions The expressions to start the query with
-	 * @return An ongoing read, exposing return and further matches.
-	 * @since 2020.1.2
-	 */
-	@NotNull @CheckReturnValue
-	OrderableOngoingReadingAndWithWithoutWhere with(Named... expressions);
-
-	/**
-	 * Starts a with clause by passing named expressions to it.
-	 *
-	 * @param elements The expressions to start the query with
-	 * @return An ongoing read, exposing return and further matches.
-	 * @since 2020.2.2
-	 */
-	@NotNull @CheckReturnValue
-	OrderableOngoingReadingAndWithWithoutWhere with(IdentifiableElement... elements);
-
-	/**
-	 * Starts a with clause by passing named expressions to it.
-	 *
-	 * @param expressions The expressions to start the query with
-	 * @return An ongoing read, exposing return and further matches.
-	 * @since 2021.2.2
-	 */
-	@NotNull @CheckReturnValue
-	OrderableOngoingReadingAndWithWithoutWhere with(AliasedExpression... expressions);
-
-	/**
-	 * Allows for queries starting with {@code with range(1,10) as x return x} or similar.
-	 *
-	 * @param expressions The expressions to start the query with
-	 * @return An ongoing read, exposing return and further matches.
-	 */
-	@NotNull @CheckReturnValue
-	OrderableOngoingReadingAndWithWithoutWhere with(Expression... expressions);
-
-	/**
-	 * Allows for queries starting with {@code with range(1,10) as x return x} or similar.
-	 *
-	 * @param expressions The expressions to start the query with
-	 * @return An ongoing read, exposing return and further matches.
-	 * @since 2021.2.2
-	 */
-	@NotNull @CheckReturnValue
-	OrderableOngoingReadingAndWithWithoutWhere with(Collection<Expression> expressions);
+	extends ExposesMatch, ExposesCreate, ExposesMerge, ExposesUnwind, ExposesReturning, ExposesSubqueryCall, ExposesWith {
 
 	/**
 	 * An ongoing update statement that can be used to chain more update statements or add a with or return clause.
@@ -406,154 +337,6 @@ public interface StatementBuilder
 	}
 
 	/**
-	 * A step that exposes the {@code WITH} clause.
-	 *
-	 * @since 1.0
-	 */
-	interface ExposesWith {
-
-		/**
-		 * @param variables The variables to pass on to the next part
-		 * @return A match that can be build now
-		 * @see #with(Expression...)
-		 */
-		@NotNull @CheckReturnValue
-		default OrderableOngoingReadingAndWithWithoutWhere with(String... variables) {
-			return with(Expressions.createSymbolicNames(variables));
-		}
-
-		/**
-		 * @param variables The variables to pass on to the next part
-		 * @return A match that can be build now
-		 * @see #with(Expression...)
-		 */
-		@NotNull @CheckReturnValue
-		default OrderableOngoingReadingAndWithWithoutWhere with(SymbolicName... variables) {
-			return with((Expression[]) variables);
-		}
-
-		/**
-		 * @param variables The variables to pass on to the next part
-		 * @return A match that can be build now
-		 * @see #with(Expression...)
-		 */
-		@NotNull @CheckReturnValue
-		default OrderableOngoingReadingAndWithWithoutWhere with(Named... variables) {
-			return with(Expressions.createSymbolicNames(variables));
-		}
-
-		/**
-		 * @param elements The variables to pass on to the next part
-		 * @return A match that can be build now
-		 * @see #with(Expression...)
-		 */
-		@NotNull @CheckReturnValue
-		default OrderableOngoingReadingAndWithWithoutWhere with(IdentifiableElement... elements) {
-			return with(Expressions.createSymbolicNames(elements));
-		}
-
-		/**
-		 * Create a match that returns one or more expressions.
-		 *
-		 * @param expressions The expressions to be returned. Must not be null and be at least one expression.
-		 * @return A match that can be build now
-		 */
-		@NotNull @CheckReturnValue
-		default OrderableOngoingReadingAndWithWithoutWhere with(AliasedExpression... expressions) {
-			return with((Expression[]) expressions);
-		}
-
-		/**
-		 * Create a match that returns one or more expressions.
-		 *
-		 * @param expressions The expressions to be returned. Must not be null and be at least one expression.
-		 * @return A match that can be build now
-		 */
-		@NotNull @CheckReturnValue
-		OrderableOngoingReadingAndWithWithoutWhere with(Expression... expressions);
-
-		/**
-		 * Create a match that returns one or more expressions.
-		 *
-		 * @param expressions The expressions to be returned. Must not be null and be at least one expression.
-		 * @return A match that can be build now
-		 * @since 2021.2.2
-		 */
-		@NotNull @CheckReturnValue
-		OrderableOngoingReadingAndWithWithoutWhere with(Collection<Expression> expressions);
-
-		/**
-		 * @param variables The variables to pass on to the next part
-		 * @return A match that can be build now
-		 * @see #withDistinct(Expression...)
-		 */
-		@NotNull @CheckReturnValue
-		default OrderableOngoingReadingAndWithWithoutWhere withDistinct(String... variables) {
-			return withDistinct(Expressions.createSymbolicNames(variables));
-		}
-
-		/**
-		 * @param variables The variables to pass on to the next part
-		 * @return A match that can be build now
-		 * @see #withDistinct(Expression...)
-		 */
-		@NotNull @CheckReturnValue
-		default OrderableOngoingReadingAndWithWithoutWhere withDistinct(SymbolicName... variables) {
-			return withDistinct((Expression[]) variables);
-		}
-
-		/**
-		 * @param variables The variables to pass on to the next part
-		 * @return A match that can be build now
-		 * @see #withDistinct(Expression...)
-		 */
-		@NotNull @CheckReturnValue
-		default OrderableOngoingReadingAndWithWithoutWhere withDistinct(Named... variables) {
-			return withDistinct(Expressions.createSymbolicNames(variables));
-		}
-
-		/**
-		 * @param elements The variables to pass on to the next part
-		 * @return A match that can be build now
-		 * @see #withDistinct(Expression...)
-		 */
-		@NotNull @CheckReturnValue
-		default OrderableOngoingReadingAndWithWithoutWhere withDistinct(IdentifiableElement... elements) {
-			return withDistinct(Expressions.createSymbolicNames(elements));
-		}
-
-		/**
-		 * Create a match that returns the distinct set of one or more expressions.
-		 *
-		 * @param expressions The expressions to be returned. Must not be null and be at least one expression.
-		 * @return A match that can be build now
-		 */
-		@NotNull @CheckReturnValue
-		default OrderableOngoingReadingAndWithWithoutWhere withDistinct(AliasedExpression... expressions) {
-			return withDistinct((Expression[]) expressions);
-		}
-
-		/**
-		 * Create a match that returns the distinct set of one or more expressions.
-		 *
-		 * @param expressions The expressions to be returned. Must not be null and be at least one expression.
-		 * @return A match that can be build now
-		 */
-		@NotNull @CheckReturnValue
-		OrderableOngoingReadingAndWithWithoutWhere withDistinct(Expression... expressions);
-
-		/**
-		 * Create a match that returns the distinct set of one or more expressions.
-		 *
-		 * @param expressions The expressions to be returned. Must not be null and be at least one expression.
-		 * @return A match that can be build now
-		 * @since 2021.2.2
-		 */
-		@NotNull @CheckReturnValue
-		OrderableOngoingReadingAndWithWithoutWhere withDistinct(Collection<Expression> expressions);
-	}
-
-	/**
 	 * A step that exposes several methods to specify ordering. This is a terminal operation just before a statement
 	 * is buildable.
 	 *
@@ -766,7 +549,7 @@ public interface StatementBuilder
 		 * previously.
 		 *
 		 * @param variables Variables indicating the things to delete.
-		 * @return A match with a delete clause that can be build now
+		 * @return A match with a {@literal DELETE} clause that can be build now
 		 */
 		@NotNull @CheckReturnValue
 		default OngoingUpdate delete(String... variables) {
@@ -778,7 +561,7 @@ public interface StatementBuilder
 		 * previously.
 		 *
 		 * @param variables Variables indicating the things to delete.
-		 * @return A match with a delete clause that can be build now
+		 * @return A match with a {@literal DELETE} clause that can be build now
 		 */
 		@NotNull @CheckReturnValue
 		default OngoingUpdate delete(Named... variables) {
@@ -789,7 +572,7 @@ public interface StatementBuilder
 		 * Creates a delete step with one or more expressions to be deleted.
 		 *
 		 * @param expressions The expressions to be deleted.
-		 * @return A match with a delete clause that can be build now
+		 * @return A match with a {@literal DELETE} clause that can be build now
 		 */
 		@NotNull @CheckReturnValue
 		OngoingUpdate delete(Expression... expressions);
@@ -1162,9 +945,9 @@ public interface StatementBuilder
 	/**
 	 * A buildable statement exposing where and return clauses.
 	 */
-	interface OngoingStandaloneCallWithReturnFields extends
+	sealed interface OngoingStandaloneCallWithReturnFields extends
 		StatementBuilder.BuildableStatement<ResultStatement>,
-		ExposesMatch, ExposesWhere<StatementBuilder.OngoingReadingWithWhere>, ExposesReturning, StatementBuilder.ExposesWith, ExposesSubqueryCall {
+		ExposesMatch, ExposesWhere<StatementBuilder.OngoingReadingWithWhere>, ExposesReturning, ExposesWith, ExposesSubqueryCall permits DefaultStatementBuilder.YieldingStandaloneCallBuilder {
 	}
 
 	/**
@@ -1211,6 +994,6 @@ public interface StatementBuilder
 	 * An in-query call exposing where and return clauses.
 	 */
 	interface OngoingInQueryCallWithReturnFields extends
-		ExposesMatch, ExposesWhere<StatementBuilder.OngoingReadingWithWhere>, ExposesReturning, StatementBuilder.ExposesWith, ExposesSubqueryCall {
+		ExposesMatch, ExposesWhere<StatementBuilder.OngoingReadingWithWhere>, ExposesReturning, ExposesWith, ExposesSubqueryCall {
 	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/ScopingStrategy.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/ScopingStrategy.java
@@ -31,6 +31,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
+import org.neo4j.cypherdsl.core.Aliased;
 import org.neo4j.cypherdsl.core.AliasedExpression;
 import org.neo4j.cypherdsl.core.CountExpression;
 import org.neo4j.cypherdsl.core.Expression;
@@ -201,8 +202,8 @@ public final class ScopingStrategy {
 			.anyMatch(i -> {
 				if (i instanceof Named named) {
 					return named.getSymbolicName().equals(needle.getSymbolicName());
-				} else if (i instanceof AliasedExpression aliasedExpression) {
-					return aliasedExpression.getAlias().equals(needle.getRequiredSymbolicName().getValue());
+				} else if (i instanceof Aliased aliased) {
+					return aliased.getAlias().equals(needle.getRequiredSymbolicName().getValue());
 				}
 				return false;
 			});
@@ -235,8 +236,8 @@ public final class ScopingStrategy {
 					.filter(element -> {
 						if (element instanceof Named named) {
 							return named.getRequiredSymbolicName().equals(segment);
-						} else if (element instanceof AliasedExpression aliasedExpression) {
-							return aliasedExpression.getAlias().equals((symbolicName).getValue());
+						} else if (element instanceof Aliased aliased) {
+							return aliased.getAlias().equals((symbolicName).getValue());
 						}
 						return false;
 					})

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
@@ -4521,9 +4521,9 @@ class CypherIT {
 			Node li = Cypher.node("LineItem").named("li");
 			Relationship hasLineItems = o.relationshipTo(li).named("h");
 
-			Expression netAmount = Functions.sum(li.property("price").multiply(li.property("quantity")))
+			var netAmount = Functions.sum(li.property("price").multiply(li.property("quantity")))
 				.as("netAmount");
-			Expression totalAmount = netAmount.multiply(Cypher.literalOf(1).add(Cypher.parameter("taxRate")))
+			var totalAmount = netAmount.multiply(Cypher.literalOf(1).add(Cypher.parameter("taxRate")))
 				.as("totalAmount");
 			Statement statement = Cypher.match(hasLineItems)
 				.where(o.property("id").isEqualTo(Cypher.parameter("id")))
@@ -4544,9 +4544,9 @@ class CypherIT {
 			Node li = Cypher.node("LineItem").named("li");
 			Relationship hasLineItems = o.relationshipTo(li).named("h");
 
-			Expression netAmount = Functions.sum(li.property("price").multiply(li.property("quantity")))
+			var netAmount = Functions.sum(li.property("price").multiply(li.property("quantity")))
 				.as("netAmount");
-			Expression totalAmount = netAmount.multiply(Cypher.literalOf(1).add(Cypher.parameter("taxRate")))
+			var totalAmount = netAmount.multiply(Cypher.literalOf(1).add(Cypher.parameter("taxRate")))
 				.as("totalAmount");
 			Statement statement = Cypher.match(hasLineItems)
 				.where(o.property("id").isEqualTo(Cypher.parameter("id")))

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/DefaultStatementBuilderTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/DefaultStatementBuilderTest.java
@@ -50,7 +50,7 @@ class DefaultStatementBuilderTest {
 			assertThatIllegalArgumentException().isThrownBy(() -> builder.returning((Collection<Expression>) null))
 				.withMessage("Expressions to return are required.");
 
-			assertThatIllegalArgumentException().isThrownBy(() -> builder.with((Collection<Expression>) null))
+			assertThatIllegalArgumentException().isThrownBy(() -> builder.with((Collection<IdentifiableElement>) null))
 				.withMessage("Expressions to return are required.");
 
 			StatementBuilder.BuildableMatchAndUpdate update = builder.set(Cypher.node("N").named("n"), "x");
@@ -65,7 +65,7 @@ class DefaultStatementBuilderTest {
 			assertThatIllegalArgumentException().isThrownBy(() -> builder.returning((Expression) null))
 				.withMessage("At least one expressions to return is required.");
 
-			assertThatIllegalArgumentException().isThrownBy(() -> builder.with((Expression) null))
+			assertThatIllegalArgumentException().isThrownBy(() -> builder.with((IdentifiableElement) null))
 				.withMessage("At least one expressions to return is required.");
 
 			StatementBuilder.BuildableMatchAndUpdate update = builder.set(Cypher.node("N").named("n"), "x");

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/IdentifiableExpressionsIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/IdentifiableExpressionsIT.java
@@ -113,7 +113,7 @@ class IdentifiableExpressionsIT {
 		Node b = Cypher.anyNode("b");
 		Node a = Cypher.node("Label").named("a");
 		Collection<Expression> variables = Cypher.match(a.relationshipTo(b))
-			.with(Cypher.literalOf(1), b.as("007"))
+			.with(b.as("007"))
 			.getIdentifiableExpressions();
 
 		assertThat(variables.stream().map(Cypher::format))

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/IssueRelatedIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/IssueRelatedIT.java
@@ -411,7 +411,7 @@ class IssueRelatedIT {
 		SymbolicName nn = Cypher.name("nn");
 
 		Node rnNode = Cypher.node("SomeLabel").named(rn);
-		Expression rnAliasedAsNN = rnNode.as("nn");
+		var rnAliasedAsNN = rnNode.as("nn");
 		Statement statement = Cypher.match(Cypher.node("User").named(u), rnNode, Cypher.node("SomeLabel").named(nn))
 			.withDistinct(u, rn, rnAliasedAsNN)
 			.returning(u, rn, rnAliasedAsNN)
@@ -433,7 +433,7 @@ class IssueRelatedIT {
 	@Test // GH-123
 	void propertiesOfFunctionsInsideQuery() {
 
-		Expression collectedThings = Functions.collect(Cypher.name("n")).as("collectedThings");
+		var collectedThings = Functions.collect(Cypher.name("n")).as("collectedThings");
 		Statement statement = Cypher.match(Cypher.anyNode().named("n"))
 			.with(collectedThings)
 			.returning(Cypher.property(Functions.last(collectedThings), "name")).build();
@@ -767,7 +767,7 @@ class IssueRelatedIT {
 		Node node = Cypher.node("Node").named("node");
 		Expression someExpression = Cypher.literalFalse();
 
-		String cypher = Cypher.match(node).with((Expression) Cypher.name("n"), someExpression.as("f"), Functions.date().as("aDate"))
+		String cypher = Cypher.match(node).with(Cypher.name("n"), someExpression.as("f"), Functions.date().as("aDate"))
 			.returning(Cypher.asterisk()).build().getCypher();
 		assertThat(cypher).isEqualTo(
 			"MATCH (node:`Node`) WITH n, false AS f, date() AS aDate RETURN *");


### PR DESCRIPTION
This addresses and fixes #547 to some extend. The goal was to allow compilation of

```java
var cypher = Cypher.match(person)
    .returning(
        person,
        Expressions.count(person.relationshipTo(person, "ACTED_IN")).as("acted_in_rel_count")
    ).build();
```

without aliasing the `person` node with `as`.

This could be achieved by allowing `IdentifiableElement` on the `returning` methods the same way this PR does with the `with` methods. However, in contrast to `with`, `return` does allow non-aliased expressions, so the overload taking in `Expression` must continue to exists. That will rule out to add another overload with a `Collection<SomethingElse>`, as they will have the same type erasure as existing methods. Adding a varg of `IdentifiableElement` will break a gazillion lines of code, even in our tests, as the method will then be ambiguous. 

I think the original sin was having `Node` and `Relationship` indirectly implement `Named` through `PropertyContainer`. If that wasn't the case, `Named` could become an expression and things will resolve nicely without additional overloads.

That change however would take several engineering weeks and turn the DSL inside out and can't be part of this change.

We created #550 for the next major release after `2023.0.0` to track this issue.

This change here will require some changes to calling code of `with`, but getting rid of about 250 LoC is worth the change, in addition, `with` will actually be nicer.