### PR TITLE
feat: Allow direct rendering of `Visitable` objects.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,7 @@
 :artifactId: neo4j-cypher-dsl
 
 // This will be next version and also the one that will be put into the manual for the main branch
-:neo4j-cypher-dsl-version: 2023.0.1-SNAPSHOT
+:neo4j-cypher-dsl-version: 2023.1.0-SNAPSHOT
 // This is the latest released version, used only in the readme
 :neo4j-cypher-dsl-version-latest: 2023.0.0
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractCase.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractCase.java
@@ -48,15 +48,16 @@ abstract class AbstractCase implements Case {
 		return expression == null ? new GenericCaseImpl() : new SimpleCaseImpl(expression);
 	}
 
-	AbstractCase() {
-		this(Collections.emptyList());
-	}
-
 	AbstractCase(List<CaseWhenThen> caseWhenThens) {
 		this.caseWhenThens = new ArrayList<>(caseWhenThens);
 	}
 
 	abstract Expression getCaseExpression();
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 
 	void setCaseElse(CaseElse caseElse) {
 		this.caseElse = caseElse;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractClause.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractClause.java
@@ -18,31 +18,10 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.STABLE;
-
-import org.apiguardian.api.API;
-import org.neo4j.cypherdsl.core.ast.Visitor;
-
-/**
- * See <a href="https://s3.amazonaws.com/artifacts.opencypher.org/M15/railroad/Set.html">Set</a>.
- *
- * @author Michael J. Simons
- * @since 1.0
- */
-@API(status = STABLE, since = "1.0")
-public final class Set extends AbstractClause implements UpdatingClause {
-
-	private final ExpressionList setItems;
-
-	Set(ExpressionList setItems) {
-		this.setItems = setItems;
-	}
+abstract class AbstractClause implements Clause {
 
 	@Override
-	public void accept(Visitor visitor) {
-
-		visitor.enter(this);
-		setItems.accept(visitor);
-		visitor.leave(this);
+	public final String toString() {
+		return RendererBridge.render(this);
 	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractNode.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractNode.java
@@ -120,4 +120,9 @@ abstract class AbstractNode extends AbstractPropertyContainer implements Node {
 	public final Relationship relationshipBetween(Node other, String... types) {
 		return new InternalRelationshipImpl(null, this, Relationship.Direction.UNI, other, types);
 	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AliasedExpression.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AliasedExpression.java
@@ -81,4 +81,9 @@ public final class AliasedExpression implements Aliased, Expression, Identifiabl
 	public Expression asExpression() {
 		return this;
 	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Arguments.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Arguments.java
@@ -55,4 +55,9 @@ final class Arguments extends TypedSubtree<Expression> implements ProvidesAffixe
 	public Optional<String> getSuffix() {
 		return Optional.of(")");
 	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Comparison.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Comparison.java
@@ -99,5 +99,10 @@ public final class Comparison implements Condition {
 		}
 		return Condition.super.not();
 	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Create.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Create.java
@@ -31,7 +31,7 @@ import org.neo4j.cypherdsl.core.ast.Visitor;
  * @since 1.0
  */
 @API(status = STABLE, since = "1.0")
-public final class Create implements UpdatingClause {
+public final class Create extends AbstractClause implements UpdatingClause {
 
 	private final Pattern pattern;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DecoratedQuery.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DecoratedQuery.java
@@ -36,7 +36,12 @@ sealed class DecoratedQuery extends AbstractStatement implements UseStatement {
 
 	private enum Decoration implements Visitable {
 
-		EXPLAIN, PROFILE
+		EXPLAIN, PROFILE;
+
+		@Override
+		public String toString() {
+			return RendererBridge.render(this);
+		}
 	}
 
 	private final Visitable decoration;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Delete.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Delete.java
@@ -31,7 +31,7 @@ import org.neo4j.cypherdsl.core.ast.Visitor;
  * @since 1.0
  */
 @API(status = STABLE, since = "1.0")
-public final class Delete implements UpdatingClause {
+public final class Delete extends AbstractClause implements UpdatingClause {
 
 	private final ExpressionList deleteItems;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExpressionList.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExpressionList.java
@@ -50,4 +50,9 @@ class ExpressionList extends TypedSubtree<Expression> {
 	boolean isEmpty() {
 		return super.children.isEmpty();
 	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Foreach.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Foreach.java
@@ -32,7 +32,7 @@ import org.neo4j.cypherdsl.core.ast.Visitor;
  * @since 2021.3.0
  */
 @API(status = STABLE, since = "2021.3.0")
-public final class Foreach implements UpdatingClause {
+public final class Foreach extends AbstractClause implements UpdatingClause {
 
 	private final SymbolicName variable;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/FunctionInvocation.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/FunctionInvocation.java
@@ -181,9 +181,8 @@ public final class FunctionInvocation implements Expression {
 		visitor.leave(this);
 	}
 
-	@Override public String toString() {
-		return "FunctionInvocation{" +
-			"functionName='" + functionName + '\'' +
-			'}';
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
 	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Hint.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Hint.java
@@ -40,9 +40,19 @@ import org.neo4j.cypherdsl.core.utils.Assertions;
  */
 public final class Hint implements Visitable {
 
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
+
 	private enum Type implements Visitable {
 
-		INDEX, INDEX_SEEK, SCAN, JOIN_ON
+		INDEX, INDEX_SEEK, SCAN, JOIN_ON;
+
+		@Override
+		public String toString() {
+			return RendererBridge.render(this);
+		}
 	}
 
 	private static final class IndexReference implements Visitable {
@@ -70,6 +80,11 @@ public final class Hint implements Visitable {
 			this.symbolicName.accept(visitor);
 			Visitable.visitIfNotNull(this.optionalLabel, visitor);
 			visitor.leave(this);
+		}
+
+		@Override
+		public String toString() {
+			return RendererBridge.render(this);
 		}
 	}
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/InTransactions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/InTransactions.java
@@ -62,4 +62,9 @@ public final class InTransactions implements Visitable {
 		subquery.accept(visitor);
 		visitor.leave(this);
 	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/InternalPropertyImpl.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/InternalPropertyImpl.java
@@ -165,4 +165,9 @@ final class InternalPropertyImpl implements Property {
 	public Expression asExpression() {
 		return this;
 	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/KeyValueMapEntry.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/KeyValueMapEntry.java
@@ -79,4 +79,9 @@ public final class KeyValueMapEntry implements Expression {
 		value.accept(visitor);
 		visitor.leave(this);
 	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Limit.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Limit.java
@@ -52,4 +52,9 @@ public final class Limit implements Visitable {
 		limitExpression.accept(visitor);
 		visitor.leave(this);
 	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListExpression.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListExpression.java
@@ -64,4 +64,9 @@ public final class ListExpression implements Expression {
 		this.content.accept(visitor);
 		visitor.leave(this);
 	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListOperator.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListOperator.java
@@ -37,7 +37,7 @@ import org.neo4j.cypherdsl.core.utils.Assertions;
  * @since 2020.1.0
  */
 @API(status = API.Status.EXPERIMENTAL, since = "2020.1.0")
-public final class ListOperator implements Expression {
+public final class ListOperator implements Expression, Visitable {
 
 	/**
 	 * A literal for the dots.
@@ -92,6 +92,11 @@ public final class ListOperator implements Expression {
 		@Override
 		public Optional<String> getSuffix() {
 			return Optional.of("]");
+		}
+
+		@Override
+		public String toString() {
+			return RendererBridge.render(this);
 		}
 	}
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListPredicate.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ListPredicate.java
@@ -65,4 +65,9 @@ final class ListPredicate implements Expression {
 		this.where.accept(visitor);
 		visitor.leave(this);
 	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/LiteralBase.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/LiteralBase.java
@@ -51,5 +51,10 @@ abstract class LiteralBase<T> implements Literal<T> {
 	public final T getContent() {
 		return content;
 	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MapExpression.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MapExpression.java
@@ -106,4 +106,9 @@ public final class MapExpression extends TypedSubtree<Expression> implements Exp
 	protected Visitable prepareVisit(Expression child) {
 		return Expressions.nameOrExpression(child);
 	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MapProjection.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MapProjection.java
@@ -130,14 +130,13 @@ public final class MapProjection implements Expression {
 				knownKeys.add(lastKey);
 			} else if (lastExpression instanceof SymbolicName || lastExpression instanceof PropertyLookup) {
 				newContent.add(lastExpression);
-			} else if (lastExpression instanceof Property) {
-				List<PropertyLookup> names = ((Property) lastExpression).getNames();
+			} else if (lastExpression instanceof Property property) {
+				List<PropertyLookup> names = property.getNames();
 				if (names.size() > 1) {
 					throw new IllegalArgumentException("Cannot project nested properties!");
 				}
 				newContent.addAll(names);
-			} else if (lastExpression instanceof AliasedExpression) {
-				AliasedExpression aliasedExpression = (AliasedExpression) lastExpression;
+			} else if (lastExpression instanceof AliasedExpression aliasedExpression) {
 				newContent.add(KeyValueMapEntry.create(aliasedExpression.getAlias(), aliasedExpression));
 			} else if (lastExpression instanceof KeyValueMapEntry) {
 				newContent.add(lastExpression);
@@ -152,5 +151,10 @@ public final class MapProjection implements Expression {
 			lastExpression = null;
 		}
 		return newContent;
+	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
 	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Match.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Match.java
@@ -37,7 +37,7 @@ import org.neo4j.cypherdsl.core.ast.Visitor;
  * @since 1.0
  */
 @API(status = STABLE, since = "1.0")
-public final class Match implements ReadingClause {
+public final class Match extends AbstractClause implements ReadingClause {
 
 	private final boolean optional;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Merge.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Merge.java
@@ -37,7 +37,7 @@ import org.neo4j.cypherdsl.core.ast.Visitor;
  * @since 1.0
  */
 @API(status = STABLE, since = "1.0")
-public final class Merge implements UpdatingClause {
+public final class Merge extends AbstractClause implements UpdatingClause {
 
 	/**
 	 * A literal for the blank.
@@ -81,4 +81,3 @@ public final class Merge implements UpdatingClause {
 		visitor.leave(this);
 	}
 }
-

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MergeAction.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MergeAction.java
@@ -41,6 +41,11 @@ import org.neo4j.cypherdsl.core.ast.Visitor;
 @API(status = STABLE, since = "2020.1.2")
 public final class MergeAction implements Visitable {
 
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
+
 	/**
 	 * The type of the action.
 	 */

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MultiPartElement.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/MultiPartElement.java
@@ -54,4 +54,9 @@ class MultiPartElement implements Visitable {
 		with.accept(visitor);
 		visitor.leave(this);
 	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NestedExpression.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NestedExpression.java
@@ -43,4 +43,9 @@ public final class NestedExpression implements Expression {
 		Expressions.nameOrExpression(this.delegate).accept(visitor);
 		visitor.leave(this);
 	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NodeLabels.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NodeLabels.java
@@ -47,4 +47,8 @@ final class NodeLabels implements Visitable {
 		values.forEach(value -> value.accept(visitor));
 		visitor.leave(this);
 	}
+
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Operation.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Operation.java
@@ -129,4 +129,9 @@ public final class Operation implements Expression {
 	Operator getOperator() {
 		return operator;
 	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Operator.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Operator.java
@@ -218,6 +218,11 @@ public enum Operator implements Visitable {
 		return type;
 	}
 
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
+
 	/**
 	 * {@link Operator} type.
 	 *

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Parameter.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Parameter.java
@@ -111,4 +111,9 @@ public final class Parameter<T> implements Expression {
 	boolean hasValue() {
 		return !Objects.equals(value, NO_VALUE);
 	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Pattern.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Pattern.java
@@ -58,4 +58,9 @@ final class Pattern extends TypedSubtree<PatternElement> {
 	private Pattern(List<PatternElement> patternElements) {
 		super(patternElements);
 	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Properties.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Properties.java
@@ -60,4 +60,8 @@ public final class Properties implements Visitable {
 		this.value.accept(visitor);
 		visitor.leave(this);
 	}
+
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PropertyLookup.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PropertyLookup.java
@@ -94,4 +94,9 @@ public final class PropertyLookup implements Expression {
 		propertyKeyName.accept(visitor);
 		visitor.leave(this);
 	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Reduction.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Reduction.java
@@ -178,5 +178,10 @@ public final class Reduction extends TypedSubtree<Visitable> {
 			this.expression.accept(visitor);
 			visitor.leave(this);
 		}
+
+		@Override
+		public String toString() {
+			return RendererBridge.render(this);
+		}
 	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Relationship.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Relationship.java
@@ -250,6 +250,11 @@ public interface Relationship extends RelationshipPattern, PropertyContainer, Ex
 			Visitable.visitIfNotNull(this.properties, visitor);
 			visitor.leave(this);
 		}
+
+		@Override
+		public String toString() {
+			return RendererBridge.render(this);
+		}
 	}
 
 	/**

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipBase.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipBase.java
@@ -284,4 +284,9 @@ public abstract class RelationshipBase<S extends NodeBase<?>, E extends NodeBase
 
 		visitor.leave(this);
 	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipChain.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipChain.java
@@ -231,4 +231,9 @@ public final class RelationshipChain implements RelationshipPattern, ExposesPatt
 
 		visitor.leave(this);
 	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Remove.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Remove.java
@@ -30,7 +30,7 @@ import org.neo4j.cypherdsl.core.ast.Visitor;
  * @since 1.0
  */
 @API(status = STABLE, since = "1.0")
-public final class Remove implements UpdatingClause {
+public final class Remove extends AbstractClause implements UpdatingClause {
 
 	private final ExpressionList setItems;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RendererBridge.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RendererBridge.java
@@ -18,31 +18,31 @@
  */
 package org.neo4j.cypherdsl.core;
 
-import static org.apiguardian.api.API.Status.STABLE;
-
-import org.apiguardian.api.API;
-import org.neo4j.cypherdsl.core.ast.Visitor;
+import org.neo4j.cypherdsl.core.ast.Visitable;
+import org.neo4j.cypherdsl.core.renderer.Configuration;
+import org.neo4j.cypherdsl.core.renderer.Renderer;
 
 /**
- * See <a href="https://s3.amazonaws.com/artifacts.opencypher.org/M15/railroad/Set.html">Set</a>.
+ * A bridge to the renderer as a single entry point from core to the renderer infrastructure.
  *
  * @author Michael J. Simons
- * @since 1.0
+ * @since 2023.0.1
  */
-@API(status = STABLE, since = "1.0")
-public final class Set extends AbstractClause implements UpdatingClause {
+class RendererBridge {
 
-	private final ExpressionList setItems;
+	private static final Configuration CONFIGURATION = Configuration.newConfig().alwaysEscapeNames(false).build();
 
-	Set(ExpressionList setItems) {
-		this.setItems = setItems;
+	static String render(Visitable visitable) {
+		String name;
+		Class<? extends Visitable> clazz = visitable.getClass();
+		if (clazz.isAnonymousClass()) {
+			name = clazz.getName();
+		} else {
+			name = clazz.getSimpleName();
+		}
+		return "%s{cypher=%s}".formatted(name, Renderer.getRenderer(CONFIGURATION).render(visitable));
 	}
 
-	@Override
-	public void accept(Visitor visitor) {
-
-		visitor.enter(this);
-		setItems.accept(visitor);
-		visitor.leave(this);
+	private RendererBridge() {
 	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RendererBridge.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RendererBridge.java
@@ -26,7 +26,7 @@ import org.neo4j.cypherdsl.core.renderer.Renderer;
  * A bridge to the renderer as a single entry point from core to the renderer infrastructure.
  *
  * @author Michael J. Simons
- * @since 2023.0.1
+ * @since 2023.1.0
  */
 class RendererBridge {
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RendererBridge.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RendererBridge.java
@@ -20,6 +20,7 @@ package org.neo4j.cypherdsl.core;
 
 import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.renderer.Configuration;
+import org.neo4j.cypherdsl.core.renderer.GeneralizedRenderer;
 import org.neo4j.cypherdsl.core.renderer.Renderer;
 
 /**
@@ -40,7 +41,7 @@ class RendererBridge {
 		} else {
 			name = clazz.getSimpleName();
 		}
-		return "%s{cypher=%s}".formatted(name, Renderer.getRenderer(CONFIGURATION).render(visitable));
+		return "%s{cypher=%s}".formatted(name, Renderer.getRenderer(CONFIGURATION, GeneralizedRenderer.class).render(visitable));
 	}
 
 	private RendererBridge() {

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Return.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Return.java
@@ -94,4 +94,9 @@ public final class Return implements Clause {
 	ReturnBody getBody() {
 		return body;
 	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ReturnBody.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ReturnBody.java
@@ -55,4 +55,9 @@ public final class ReturnBody implements Visitable {
 		Visitable.visitIfNotNull(skip, visitor);
 		Visitable.visitIfNotNull(limit, visitor);
 	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Skip.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Skip.java
@@ -52,4 +52,9 @@ public final class Skip implements Visitable {
 		expression.accept(visitor);
 		visitor.leave(this);
 	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/SortItem.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/SortItem.java
@@ -83,6 +83,11 @@ public final class SortItem implements Visitable {
 		visitor.leave(this);
 	}
 
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
+
 	/**
 	 * Sort direction.
 	 * @since 1.0
@@ -107,6 +112,11 @@ public final class SortItem implements Visitable {
 		 */
 		public String getSymbol() {
 			return this.symbol;
+		}
+
+		@Override
+		public String toString() {
+			return RendererBridge.render(this);
 		}
 	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementContext.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementContext.java
@@ -38,7 +38,7 @@ public sealed interface StatementContext permits StatementContextImpl {
 	 *
 	 * @return A new default statement context.
 	 */
-	@API(status = INTERNAL, since = "2023.0.1")
+	@API(status = INTERNAL, since = "2023.1.0")
 	static StatementContext of() {
 		return new StatementContextImpl();
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementContext.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementContext.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.cypherdsl.core;
 
+import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
@@ -31,6 +32,16 @@ import org.apiguardian.api.API;
  */
 @API(status = STABLE, since = "2021.1.0")
 public sealed interface StatementContext permits StatementContextImpl {
+
+	/**
+	 * Utility method creating a new default context. Mainly internal use.
+	 *
+	 * @return A new default statement context.
+	 */
+	@API(status = INTERNAL, since = "2023.0.1")
+	static StatementContext of() {
+		return new StatementContextImpl();
+	}
 
 	/**
 	 * Gets or creates the name of a parameter

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Subquery.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Subquery.java
@@ -39,7 +39,7 @@ import org.neo4j.cypherdsl.core.ast.Visitor;
  */
 @API(status = STABLE, since = "2020.1.2")
 @Neo4jVersion(minimum = "4.0.0")
-public final class Subquery implements Clause {
+public final class Subquery extends AbstractClause implements Clause {
 
 	private final With imports;
 	private final With renames;

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/SymbolicName.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/SymbolicName.java
@@ -128,9 +128,7 @@ public final class SymbolicName implements Expression, IdentifiableElement {
 
 	@Override
 	public String toString() {
-		return value != null ? "SymbolicName{" +
-			"name='" + value + '\'' +
-			'}' : "Unresolved SymbolicName";
+		return value != null ? RendererBridge.render(this) : "Unresolved SymbolicName";
 	}
 
 	@Override

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/UnionPart.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/UnionPart.java
@@ -62,4 +62,9 @@ public final class UnionPart implements Visitable {
 		query.accept(visitor);
 		visitor.leave(this);
 	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Unwind.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Unwind.java
@@ -32,7 +32,7 @@ import org.neo4j.cypherdsl.core.ast.Visitor;
  * @since 1.0
  */
 @API(status = STABLE, since = "1.0")
-public final class Unwind implements ReadingClause {
+public final class Unwind extends AbstractClause implements ReadingClause {
 
 	private final Expression expressionToUnwind;
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Where.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Where.java
@@ -61,4 +61,9 @@ public final class Where implements Visitable {
 
 		visitor.leave(this);
 	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/With.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/With.java
@@ -62,4 +62,9 @@ public final class With implements Visitable, Clause {
 		Visitable.visitIfNotNull(where, visitor);
 		visitor.leave(this);
 	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ast/Visitable.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ast/Visitable.java
@@ -32,7 +32,7 @@ public interface Visitable {
 	 * Not meant to be overridden.
 	 *
 	 * @param visitable The visitable to visit if not null
-	 * @param visitor The visitor to use
+	 * @param visitor   The visitor to use
 	 */
 	static void visitIfNotNull(Visitable visitable, Visitor visitor) {
 
@@ -51,4 +51,16 @@ public interface Visitable {
 		visitor.enter(this);
 		visitor.leave(this);
 	}
+
+	/**
+	 * Most {@link Visitable visitables} will render themselves into a Cypher fragment preceded with the actual classname.
+	 * The representation however is not cached - in contrast to the ones for full statements. Using {@code toString}
+	 * is recommended for debugging purposes mainly, and not for production use.
+	 * <p>
+	 * The concrete classname has been prepended to help debugging and actually to discourage using fragments to build queries
+	 * without explicitly rendering them, either as statement or going through the renderer on purpose.
+	 *
+	 * @return A string representation of this visitable formatted as {@literal Classname{cypher=value}}
+	 */
+	String toString();
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ast/Visitable.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ast/Visitable.java
@@ -51,4 +51,8 @@ public interface Visitable {
 		visitor.enter(this);
 		visitor.leave(this);
 	}
+
+	default String toString() {
+		return "";
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ast/Visitable.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ast/Visitable.java
@@ -51,8 +51,4 @@ public interface Visitable {
 		visitor.enter(this);
 		visitor.leave(this);
 	}
-
-	default String toString() {
-		return "";
-	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ast/Visitor.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ast/Visitor.java
@@ -33,8 +33,8 @@ public interface Visitor {
 	void enter(Visitable segment);
 
 	/**
-	 * A method that is used to pass control to some extend from the visitor to the {@link Visitable}. Not all visitables
-	 * react to this and we don't give any guarantees about which will. This method has been mainly introduced in parallel
+	 * A method that is used to pass control to some extent from the visitor to the {@link Visitable}. Not all visitables
+	 * react to this, and we don't give any guarantees about which will. This method has been mainly introduced in parallel
 	 * to {@link #enter(Visitable)} so that existing external implementations of {@link Visitor visitors} won't break.
 	 *
 	 * @param segment the segment to visit.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/ConfigurableRenderer.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/ConfigurableRenderer.java
@@ -18,7 +18,6 @@
  */
 package org.neo4j.cypherdsl.core.renderer;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -52,7 +51,7 @@ final class ConfigurableRenderer implements GeneralizedRenderer, Renderer {
 		return CONFIGURATIONS.computeIfAbsent(configuration, ConfigurableRenderer::new);
 	}
 
-	private final LinkedHashMap<Integer, String> renderedStatementCache = new LRUCache<>(STATEMENT_CACHE_SIZE);
+	private final LRUCache<Integer, String> renderedStatementCache = new LRUCache<>(STATEMENT_CACHE_SIZE);
 
 	private final ReadWriteLock lock = new ReentrantReadWriteLock();
 	private final Lock read = lock.readLock();
@@ -70,6 +69,9 @@ final class ConfigurableRenderer implements GeneralizedRenderer, Renderer {
 	}
 
 	@Override
+	// This is about not using map.computeIfAbsent. This is done very much on purpose to keep this
+	// class thread safe. The LRUCache is basically LinkedHashMap and the method wouldn't be threadsafe.
+	@SuppressWarnings("squid:S3824")
 	public String render(Visitable visitable) {
 
 		BiFunction<StatementContext, Visitable, String> renderOp = (ctx, v) -> {

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/ConfigurableRenderer.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/ConfigurableRenderer.java
@@ -37,7 +37,7 @@ import org.neo4j.cypherdsl.core.StatementContext;
  * @author Gerrit Meier
  * @since 1.0
  */
-final class ConfigurableRenderer implements Renderer {
+final class ConfigurableRenderer implements GeneralizedRenderer, Renderer {
 
 	private static final Map<Configuration, ConfigurableRenderer> CONFIGURATIONS = new ConcurrentHashMap<>(8);
 	private static final int STATEMENT_CACHE_SIZE = 128;
@@ -62,6 +62,11 @@ final class ConfigurableRenderer implements Renderer {
 
 	ConfigurableRenderer(Configuration configuration) {
 		this.configuration = configuration;
+	}
+
+	@Override
+	public String render(Statement statement) {
+		return render((Visitable) statement);
 	}
 
 	@Override

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/ConfigurableRenderer.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/ConfigurableRenderer.java
@@ -25,8 +25,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.BiFunction;
 
 import org.neo4j.cypherdsl.core.Statement;
+import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.utils.LRUCache;
 import org.neo4j.cypherdsl.core.StatementContext;
 
@@ -35,7 +37,7 @@ import org.neo4j.cypherdsl.core.StatementContext;
  * @author Gerrit Meier
  * @since 1.0
  */
-class ConfigurableRenderer implements Renderer {
+final class ConfigurableRenderer implements Renderer {
 
 	private static final Map<Configuration, ConfigurableRenderer> CONFIGURATIONS = new ConcurrentHashMap<>(8);
 	private static final int STATEMENT_CACHE_SIZE = 128;
@@ -63,33 +65,38 @@ class ConfigurableRenderer implements Renderer {
 	}
 
 	@Override
-	public String render(Statement statement) {
+	public String render(Visitable visitable) {
 
-		int key = Objects.hash(statement, statement.isRenderConstantsAsParameters());
+		BiFunction<StatementContext, Visitable, String> renderOp = (ctx, v) -> {
+			var renderingVisitor = createVisitor(ctx);
+			v.accept(renderingVisitor);
+			return renderingVisitor.getRenderedContent().trim();
+		};
 
-		String renderedContent;
-		try {
-			read.lock();
-			renderedContent = renderedStatementCache.get(key);
-		} finally {
-			read.unlock();
-		}
+		if (visitable instanceof Statement statement) {
+			String renderedContent;
 
-		if (renderedContent == null) {
+			int key = Objects.hash(statement, statement.isRenderConstantsAsParameters());
 			try {
-				write.lock();
-
-				RenderingVisitor renderingVisitor = createVisitor(statement.getContext());
-				statement.accept(renderingVisitor);
-				renderedContent = renderingVisitor.getRenderedContent().trim();
-
-				renderedStatementCache.put(key, renderedContent);
+				read.lock();
+				renderedContent = renderedStatementCache.get(key);
 			} finally {
-				write.unlock();
+				read.unlock();
 			}
-		}
 
-		return renderedContent;
+			if (renderedContent == null) {
+				try {
+					write.lock();
+					renderedContent = renderOp.apply(statement.getContext(), statement);
+					renderedStatementCache.put(key, renderedContent);
+				} finally {
+					write.unlock();
+				}
+			}
+			return renderedContent;
+		} else {
+			return renderOp.apply(StatementContext.of(), visitable);
+		}
 	}
 
 	private RenderingVisitor createVisitor(StatementContext statementContext) {

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/DefaultVisitor.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/DefaultVisitor.java
@@ -103,11 +103,11 @@ import org.neo4j.cypherdsl.core.utils.Strings;
  * This is a simple (some would call it naive) implementation of a visitor to the Cypher AST created by the Cypher builder
  * based on the {@link ReflectiveVisitor reflective visitor}.
  * <p>
- * It takes care of separating elements of sub trees containing the element type with a separator and provides pairs of
+ * It takes care of separating elements of subtrees containing the element type with a separator and provides pairs of
  * {@code enter} / {@code leave} for the structuring elements of the Cypher AST as needed.
  * <p>
- * This rendering visitor is not meant to be used outside framework code and we don't give any guarantees on the format
- * being output apart from that it works within the constraints of SDN-RX.
+ * This rendering visitor is not meant to be used outside framework code, and we don't give any guarantees on the format
+ * being output apart from that it works within the constraints of SDN-RX respectively SDN 6 and later.
  *
  * @author Michael J. Simons
  * @author Gerrit Meier
@@ -393,7 +393,6 @@ class DefaultVisitor extends ReflectiveVisitor implements RenderingVisitor {
 	void leave(With with) {
 		builder.append(" ");
 	}
-
 
 	void enter(Delete delete) {
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/GeneralizedRenderer.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/GeneralizedRenderer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2019-2023 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.core.renderer;
+
+import static org.apiguardian.api.API.Status.STABLE;
+
+import org.apiguardian.api.API;
+import org.neo4j.cypherdsl.core.ast.Visitable;
+
+/**
+ * This is a more general renderer than {@link Renderer}. The generalized renderer will render any {@link Visitable}.
+ * This renderer will not cache rendered results for visitables.
+ *
+ * @author Michael J. Simons
+ * @since 2023.1.0
+ */
+@API(status = STABLE, since = "2023.1.0")
+public sealed interface GeneralizedRenderer extends Renderer permits ConfigurableRenderer {
+
+	/**
+	 * Renders any {@link Visitable}.
+	 *
+	 * @param visitable the visitable to render
+	 * @return a Cypher fragment (in case of arbitrary visitables), a full statement in case a {@link org.neo4j.cypherdsl.core.Statement} was passed to the renderer.
+	 */
+	String render(Visitable visitable);
+}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Renderer.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Renderer.java
@@ -21,7 +21,7 @@ package org.neo4j.cypherdsl.core.renderer;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.neo4j.cypherdsl.core.ast.Visitable;
+import org.neo4j.cypherdsl.core.Statement;
 
 /**
  * Instances of this class are supposed to be thread-safe. Please use {@link Renderer#getDefaultRenderer()} to get hold
@@ -31,15 +31,15 @@ import org.neo4j.cypherdsl.core.ast.Visitable;
  * @since 1.0
  */
 @API(status = STABLE, since = "1.0")
-public sealed interface Renderer permits ConfigurableRenderer {
+public sealed interface Renderer permits ConfigurableRenderer, GeneralizedRenderer {
 
 	/**
 	 * Renders a statement.
 	 *
-	 * @param visitable the statement to render
+	 * @param statement the statement to render
 	 * @return The rendered Cypher statement.
 	 */
-	String render(Visitable visitable);
+	String render(Statement statement);
 
 	/**
 	 * Provides the default renderer. This method may or may not provide shared instances of the renderer.
@@ -57,6 +57,16 @@ public sealed interface Renderer permits ConfigurableRenderer {
 	 * @return A new renderer (might be a shared instance).
 	 */
 	static Renderer getRenderer(Configuration configuration) {
-		return ConfigurableRenderer.create(configuration);
+		return getRenderer(configuration, Renderer.class);
+	}
+
+	/**
+	 * Creates a new renderer for the given configuration.
+	 *
+	 * @param configuration The configuration for this renderer
+	 * @return A new renderer (might be a shared instance).
+	 */
+	static <T extends Renderer> T getRenderer(Configuration configuration, Class<T> type) {
+		return type.cast(ConfigurableRenderer.create(configuration));
 	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Renderer.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/Renderer.java
@@ -21,7 +21,7 @@ package org.neo4j.cypherdsl.core.renderer;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.neo4j.cypherdsl.core.Statement;
+import org.neo4j.cypherdsl.core.ast.Visitable;
 
 /**
  * Instances of this class are supposed to be thread-safe. Please use {@link Renderer#getDefaultRenderer()} to get hold
@@ -31,15 +31,15 @@ import org.neo4j.cypherdsl.core.Statement;
  * @since 1.0
  */
 @API(status = STABLE, since = "1.0")
-public interface Renderer {
+public sealed interface Renderer permits ConfigurableRenderer {
 
 	/**
 	 * Renders a statement.
 	 *
-	 * @param statement the statement to render
+	 * @param visitable the statement to render
 	 * @return The rendered Cypher statement.
 	 */
-	String render(Statement statement);
+	String render(Visitable visitable);
 
 	/**
 	 * Provides the default renderer. This method may or may not provide shared instances of the renderer.

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
@@ -3873,7 +3873,7 @@ class CypherIT {
 		@SuppressWarnings("ResultOfMethodCallIgnored") @Test
 		void invalid() {
 
-			String expectedMessage = "FunctionInvocation{functionName='id'} of type class org.neo4j.cypherdsl.core.FunctionInvocation cannot be used with an implicit name as map entry.";
+			String expectedMessage = "FunctionInvocation{cypher=id(n)} of type class org.neo4j.cypherdsl.core.FunctionInvocation cannot be used with an implicit name as map entry.";
 			assertThatIllegalArgumentException().isThrownBy(() -> {
 				Node n = Cypher.anyNode("n");
 				n.project(Functions.id(n));

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/PackageAndAPIStructureTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/PackageAndAPIStructureTest.java
@@ -20,9 +20,9 @@ package org.neo4j.cypherdsl.core;
 
 import static com.tngtech.archunit.base.DescribedPredicate.not;
 import static com.tngtech.archunit.core.domain.JavaAccess.Predicates.targetOwner;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.assignableFrom;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.assignableTo;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage;
-import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleName;
 import static com.tngtech.archunit.core.domain.properties.HasModifiers.Predicates.modifier;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
@@ -101,7 +101,7 @@ class PackageAndAPIStructureTest {
 	void coreMostNotDependOnRendering() {
 		ArchRule rule = noClasses().that()
 			.resideInAPackage("..core")
-			.and(not(simpleName("AbstractStatement")))
+			.and(not(assignableFrom(AbstractStatement.class).or(assignableFrom(RendererBridge.class))))
 			.should().dependOnClassesThat(resideInAPackage("..renderer.."));
 		rule.check(coreClasses);
 	}

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/SymbolicNameTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/SymbolicNameTest.java
@@ -81,7 +81,7 @@ public class SymbolicNameTest {
 		void toStringShouldWork() {
 
 			SymbolicName name1 = SymbolicName.of("a");
-			assertThat(name1).hasToString("SymbolicName{name='a'}");
+			assertThat(name1).hasToString("SymbolicName{cypher=a}");
 		}
 	}
 

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/ToStringSmokeTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/ToStringSmokeTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2019-2023 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.neo4j.cypherdsl.core.ast.Visitable;
+
+/**
+ * @author Michael J. Simons
+ */
+class ToStringSmokeTest {
+
+	static Stream<Arguments> toStringShouldWork() {
+
+		return Stream.of(
+			Arguments.of(Cypher.node("Person").named("n"), "(n:Person)"),
+			Arguments.of(Cypher.node("Person").named("p").relationshipTo(Cypher.node("Movie").named("m"), "PLAYED_IN").named("r"), "(p:Person)-[r:PLAYED_IN]->(m:Movie)"),
+			Arguments.of(Cypher.node("Person").named("p").relationshipTo(Cypher.node("Movie").named("m"), "PLAYED_IN").named("r").relationshipFrom(Cypher.node("Person").named("d"), "DIRECTED"), "(p:Person)-[r:PLAYED_IN]->(m:Movie)<-[:DIRECTED]-(d:Person)"),
+			Arguments.of(Functions.id(Cypher.anyNode("n")), "id(n)"),
+			Arguments.of(Cypher.call("db.labels").asFunction(), "db.labels()"),
+			Arguments.of(Cypher.literalOf("aString"), "'aString'"),
+			Arguments.of(Cypher.literalOf(1), "1"),
+			Arguments.of(Cypher.parameter("p"), "$p"),
+			Arguments.of(Cypher.anyNode("n").property("prop"), "n.prop")
+		);
+	}
+
+	@ParameterizedTest
+	@MethodSource
+	void toStringShouldWork(Visitable visitable, String expected) {
+		assertThat(visitable).hasToString(visitable.getClass().getSimpleName() + "{cypher=" + expected + "}");
+	}
+
+	@Test
+	void mostConstructsShouldNotHaveDefaultToString() {
+		var statement = IssueRelatedIT.createSomewhatComplexStatement();
+
+		statement.accept(segment -> {
+			if (segment.getClass().getPackage().getName().equals("org.neo4j.cypherdsl.core.internal") || segment instanceof Statement) {
+				return;
+			}
+			try {
+				boolean hasOverwrittenToString = (segment.getClass().getMethod("toString").getDeclaringClass() != Object.class);
+				assertThat(hasOverwrittenToString).isTrue();
+				assertThatNoException().isThrownBy(segment::toString);
+			} catch (NoSuchMethodException e) {
+				throw new RuntimeException(e);
+			}
+		});
+	}
+}


### PR DESCRIPTION
This changes the `org.neo4j.cypherdsl.core.renderer.Renderer#render` method to accept any `Visitable` so that an intermediate representation can be retrieved.

Reluctant use is suggested, as the intermediate representation won't be cached in the renderer.

In addition, an overload of `toString` has been added to many `Visitable` types. While I would liked to have added this to the `Visitable` interface as suggested by @lukaseder, this is not possible as specified in the JLS 9.4.1.2. "Requirements in Overriding" (https://docs.oracle.com/javase/specs/jls/se17/html/jls-9.html#jls-9.4.1.2) (more background here https://mail.openjdk.org/pipermail/lambda-dev/2013-March/008435.html)

Closes #552.
