### PR TITLE
issue/backports 20230116

### DIFF
--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-driver/pom.xml
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-driver/pom.xml
@@ -42,7 +42,7 @@
 				<!-- Test containers can't decide. -->
 				<groupId>net.java.dev.jna</groupId>
 				<artifactId>jna</artifactId>
-				<version>5.12.1</version>
+				<version>5.13.0</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/pom.xml
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/pom.xml
@@ -39,7 +39,7 @@
 		<checkstyle.version>10.6.0</checkstyle.version>
 		<java-module-name>org.neo4j.cypherdsl.examples.sdn6</java-module-name>
 		<java.version>11</java.version>
-		<maven-checkstyle-plugin.version>3.2.0</maven-checkstyle-plugin.version>
+		<maven-checkstyle-plugin.version>3.2.1</maven-checkstyle-plugin.version>
 		<sortpom-maven-plugin.version>2.15.0</sortpom-maven-plugin.version>
 		<testcontainers.version>1.17.6</testcontainers.version>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
 		<jetbrains-annotations.version>24.0.0</jetbrains-annotations.version>
 		<joda-time.version>2.12.2</joda-time.version>
 		<jsr305.version>3.0.2</jsr305.version>
-		<junit-jupiter.version>5.9.1</junit-jupiter.version>
+		<junit-jupiter.version>5.9.2</junit-jupiter.version>
 		<maven-checkstyle-plugin.version>3.2.0</maven-checkstyle-plugin.version>
 		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
 		<maven-deploy-plugin.version>3.0.0</maven-deploy-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
 		<javapoet.version>1.13.0</javapoet.version>
 		<javax.annotation-api.version>1.3.2</javax.annotation-api.version>
 		<jaxb.version>2.3.1</jaxb.version>
-		<jetbrains-annotations.version>23.1.0</jetbrains-annotations.version>
+		<jetbrains-annotations.version>24.0.0</jetbrains-annotations.version>
 		<joda-time.version>2.12.2</joda-time.version>
 		<jsr305.version>3.0.2</jsr305.version>
 		<junit-jupiter.version>5.9.1</junit-jupiter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
 		<maven-source-plugin.version>3.2.1</maven-source-plugin.version>
 		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
 		<maven.version>3.8.4</maven.version>
-		<mockito.version>4.11.0</mockito.version>
+		<mockito.version>5.0.0</mockito.version>
 		<moditect-maven-plugin.version>1.0.0.RC2</moditect-maven-plugin.version>
 		<neo4j-java-driver.version>4.4.9</neo4j-java-driver.version>
 		<neo4j.version>4.4.12</neo4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
 		<joda-time.version>2.12.2</joda-time.version>
 		<jsr305.version>3.0.2</jsr305.version>
 		<junit-jupiter.version>5.9.2</junit-jupiter.version>
-		<maven-checkstyle-plugin.version>3.2.0</maven-checkstyle-plugin.version>
+		<maven-checkstyle-plugin.version>3.2.1</maven-checkstyle-plugin.version>
 		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
 		<maven-deploy-plugin.version>3.0.0</maven-deploy-plugin.version>
 		<maven-enforcer-plugin.version>3.1.0</maven-enforcer-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
 		<project.build.docs>${project.build.directory}/docs</project.build.docs>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<querydsl.version>5.0.0</querydsl.version>
-		<reactor.version>2022.0.1</reactor.version>
+		<reactor.version>2022.0.2</reactor.version>
 		<revision>9999</revision>
 		<sha1 />
 		<slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
- build(deps): Bump jna from 5.12.1 to 5.13.0 (#556)
- build(deps): Bump annotations from 23.1.0 to 24.0.0 (#557)
- build(deps): Bump mockito.version from 4.11.0 to 5.0.0 (#558)
- build(deps): Bump reactor-bom from 2022.0.1 to 2022.0.2 (#559)
- build(deps): Bump junit-bom from 5.9.1 to 5.9.2 (#563)
- build(deps): Bump maven-checkstyle-plugin from 3.2.0 to 3.2.1 (#564)
