### PR TITLE
refactor: Allow covariant collection overloads for `PatternElement` and `Expression` where sensible.

### DIFF
--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Clauses.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Clauses.java
@@ -21,6 +21,7 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.net.URI;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -54,7 +55,7 @@ public final class Clauses {
 	 * @since 2022.0.0
 	 */
 	@NotNull
-	public static Clause match(boolean optional, List<PatternElement> patternElements,
+	public static Clause match(boolean optional, Collection<? extends PatternElement> patternElements,
 		@Nullable Where optionalWhere,
 		@Nullable List<Hint> optionalHints) {
 
@@ -103,7 +104,7 @@ public final class Clauses {
 	 * @return an immutable create clause
 	 */
 	@NotNull
-	public static Clause create(List<PatternElement> patternElements) {
+	public static Clause create(Collection<? extends PatternElement> patternElements) {
 
 		return new Create(Pattern.of(patternElements));
 	}
@@ -116,7 +117,7 @@ public final class Clauses {
 	 * @return an immutable merge clause
 	 */
 	@NotNull
-	public static Clause merge(List<PatternElement> patternElements, @Nullable List<MergeAction> mergeActions) {
+	public static Clause merge(Collection<? extends PatternElement> patternElements, @Nullable List<MergeAction> mergeActions) {
 
 		return new Merge(Pattern.of(patternElements), mergeActions == null ? Collections.emptyList() : mergeActions);
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Clauses.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Clauses.java
@@ -21,7 +21,6 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.net.URI;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -55,7 +54,7 @@ public final class Clauses {
 	 * @since 2022.0.0
 	 */
 	@NotNull
-	public static Clause match(boolean optional, Collection<? extends PatternElement> patternElements,
+	public static Clause match(boolean optional, List<PatternElement> patternElements,
 		@Nullable Where optionalWhere,
 		@Nullable List<Hint> optionalHints) {
 
@@ -104,7 +103,7 @@ public final class Clauses {
 	 * @return an immutable create clause
 	 */
 	@NotNull
-	public static Clause create(Collection<? extends PatternElement> patternElements) {
+	public static Clause create(List<PatternElement> patternElements) {
 
 		return new Create(Pattern.of(patternElements));
 	}
@@ -117,7 +116,7 @@ public final class Clauses {
 	 * @return an immutable merge clause
 	 */
 	@NotNull
-	public static Clause merge(Collection<? extends PatternElement> patternElements, @Nullable List<MergeAction> mergeActions) {
+	public static Clause merge(List<PatternElement> patternElements, @Nullable List<MergeAction> mergeActions) {
 
 		return new Merge(Pattern.of(patternElements), mergeActions == null ? Collections.emptyList() : mergeActions);
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
@@ -354,7 +354,7 @@ public final class Cypher {
 	 * @since 2021.2.2
 	 */
 	@NotNull @Contract(pure = true)
-	public static StatementBuilder.OngoingReadingWithoutWhere optionalMatch(Collection<PatternElement> pattern) {
+	public static StatementBuilder.OngoingReadingWithoutWhere optionalMatch(Collection<? extends PatternElement> pattern) {
 
 		return optionalMatch(pattern.toArray(new PatternElement[] {}));
 	}
@@ -381,7 +381,7 @@ public final class Cypher {
 	 * @since 2021.2.2
 	 */
 	@NotNull @Contract(pure = true)
-	public static StatementBuilder.OngoingReadingWithoutWhere match(Collection<PatternElement> pattern) {
+	public static StatementBuilder.OngoingReadingWithoutWhere match(Collection<? extends PatternElement> pattern) {
 
 		return match(pattern.toArray(new PatternElement[] {}));
 	}
@@ -411,7 +411,7 @@ public final class Cypher {
 	 * @since 2021.2.2
 	 */
 	@NotNull @Contract(pure = true)
-	public static StatementBuilder.OngoingReadingWithoutWhere match(boolean optional, Collection<PatternElement> pattern) {
+	public static StatementBuilder.OngoingReadingWithoutWhere match(boolean optional, Collection<? extends PatternElement> pattern) {
 
 		return match(optional, pattern.toArray(new PatternElement[] {}));
 	}
@@ -436,7 +436,7 @@ public final class Cypher {
 	 * @since 2021.2.2
 	 */
 	@NotNull @Contract(pure = true)
-	public static StatementBuilder.OngoingUpdate create(Collection<PatternElement> pattern) {
+	public static StatementBuilder.OngoingUpdate create(Collection<? extends PatternElement> pattern) {
 
 		return create(pattern.toArray(new PatternElement[] {}));
 	}
@@ -509,7 +509,7 @@ public final class Cypher {
 	 * @since 2021.2.2
 	 */
 	@NotNull @Contract(pure = true)
-	public static StatementBuilder.OngoingMerge merge(Collection<PatternElement> pattern) {
+	public static StatementBuilder.OngoingMerge merge(Collection<? extends PatternElement> pattern) {
 
 		return merge(pattern.toArray(new PatternElement[] {}));
 	}
@@ -549,7 +549,7 @@ public final class Cypher {
 	 * @since 2021.2.2
 	 */
 	@NotNull @Contract(pure = true)
-	public static StatementBuilder.OngoingUnwind unwind(Collection<Expression> expressions) {
+	public static StatementBuilder.OngoingUnwind unwind(Collection<? extends Expression> expressions) {
 
 		return unwind(expressions.toArray(new Expression[] {}));
 	}
@@ -625,7 +625,7 @@ public final class Cypher {
 	 * @since 2021.2.2
 	 */
 	@NotNull @Contract(pure = true)
-	public static ListExpression listOf(Collection<Expression> expressions) {
+	public static ListExpression listOf(Collection<? extends Expression> expressions) {
 
 		return Cypher.listOf(expressions.toArray(new Expression[0]));
 	}
@@ -780,7 +780,7 @@ public final class Cypher {
 	 * @since 2021.2.2
 	 */
 	@NotNull @Contract(pure = true)
-	public static StatementBuilder.OngoingReadingAndReturn returning(Collection<Expression> expressions) {
+	public static StatementBuilder.OngoingReadingAndReturn returning(Collection<? extends Expression> expressions) {
 		return Statement.builder().returning(expressions);
 	}
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DefaultStatementBuilder.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DefaultStatementBuilder.java
@@ -133,7 +133,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 
 	@NotNull
 	@Override
-	public final OngoingUpdate create(Collection<PatternElement> pattern) {
+	public final OngoingUpdate create(Collection<? extends PatternElement> pattern) {
 
 		return create(pattern.toArray(new PatternElement[] {}));
 	}
@@ -182,7 +182,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 
 			@NotNull
 			@Override
-			public BuildableOngoingMergeAction set(Collection<Expression> expressions) {
+			public BuildableOngoingMergeAction set(Collection<? extends Expression> expressions) {
 				return set(expressions.toArray(new Expression[] {}));
 			}
 		};
@@ -215,14 +215,14 @@ class DefaultStatementBuilder implements StatementBuilder,
 
 	@NotNull
 	@Override
-	public final OngoingReadingAndReturn returning(Collection<Expression> elements) {
+	public final OngoingReadingAndReturn returning(Collection<? extends Expression> elements) {
 
 		return returning(false, false, elements);
 	}
 
 	@NotNull
 	@Override
-	public final OngoingReadingAndReturn returningDistinct(Collection<Expression> elements) {
+	public final OngoingReadingAndReturn returningDistinct(Collection<? extends Expression> elements) {
 
 		return returning(false, true, elements);
 	}
@@ -234,7 +234,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 		return new DefaultStatementWithReturnBuilder(rawExpression);
 	}
 
-	private OngoingReadingAndReturn returning(boolean raw, boolean distinct, Collection<Expression> elements) {
+	private OngoingReadingAndReturn returning(boolean raw, boolean distinct, Collection<? extends Expression> elements) {
 
 		DefaultStatementWithReturnBuilder ongoingMatchAndReturn = new DefaultStatementWithReturnBuilder(raw, distinct);
 		ongoingMatchAndReturn.addExpressions(elements);
@@ -269,7 +269,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 
 	@NotNull
 	@Override
-	public final OngoingUpdate delete(Collection<Expression> expressions) {
+	public final OngoingUpdate delete(Collection<? extends Expression> expressions) {
 
 		return delete(expressions.toArray(new Expression[] {}));
 	}
@@ -283,7 +283,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 
 	@NotNull
 	@Override
-	public final OngoingUpdate detachDelete(Collection<Expression> expressions) {
+	public final OngoingUpdate detachDelete(Collection<? extends Expression> expressions) {
 
 		return detachDelete(expressions.toArray(new Expression[] {}));
 	}
@@ -299,7 +299,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 
 	@NotNull
 	@Override
-	public final BuildableMatchAndUpdate set(Collection<Expression> expressions) {
+	public final BuildableMatchAndUpdate set(Collection<? extends Expression> expressions) {
 
 		return set(expressions.toArray(new Expression[] {}));
 	}
@@ -530,7 +530,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 			this.returnList.addAll(filteredElements);
 		}
 
-		protected final void addExpressions(Collection<Expression> expressions) {
+		protected final void addExpressions(Collection<? extends Expression> expressions) {
 
 			Assertions.notNull(expressions, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_EXPRESSIONS_REQUIRED));
 			Assertions.isTrue(!expressions.isEmpty() && expressions.stream().noneMatch(Objects::isNull), Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_AT_LEAST_ONE_EXPRESSION_REQUIRED));
@@ -678,7 +678,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 
 		@NotNull
 		@Override
-		public OngoingReadingAndReturn returning(Collection<Expression> expressions) {
+		public OngoingReadingAndReturn returning(Collection<? extends Expression> expressions) {
 
 			return DefaultStatementBuilder.this
 				.addWith(buildWith())
@@ -687,7 +687,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 
 		@NotNull
 		@Override
-		public OngoingReadingAndReturn returningDistinct(Collection<Expression> expressions) {
+		public OngoingReadingAndReturn returningDistinct(Collection<? extends Expression> expressions) {
 
 			return DefaultStatementBuilder.this
 				.addWith(buildWith())
@@ -713,7 +713,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 
 		@NotNull
 		@Override
-		public OngoingUpdate delete(Collection<Expression> expressions) {
+		public OngoingUpdate delete(Collection<? extends Expression> expressions) {
 
 			return delete(expressions.toArray(new Expression[] {}));
 		}
@@ -729,7 +729,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 
 		@NotNull
 		@Override
-		public OngoingUpdate detachDelete(Collection<Expression> expressions) {
+		public OngoingUpdate detachDelete(Collection<? extends Expression> expressions) {
 
 			return detachDelete(expressions.toArray(new Expression[] {}));
 		}
@@ -745,7 +745,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 
 		@NotNull
 		@Override
-		public BuildableMatchAndUpdate set(Collection<Expression> expressions) {
+		public BuildableMatchAndUpdate set(Collection<? extends Expression> expressions) {
 
 			return set(expressions.toArray(new Expression[] {}));
 		}
@@ -869,7 +869,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 
 		@NotNull
 		@Override
-		public OngoingUpdate create(Collection<PatternElement> pattern) {
+		public OngoingUpdate create(Collection<? extends PatternElement> pattern) {
 
 			return create(pattern.toArray(new PatternElement[]{}));
 		}
@@ -1207,7 +1207,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 
 		@NotNull
 		@Override
-		public OngoingReadingAndReturn returning(Collection<Expression> expressions) {
+		public OngoingReadingAndReturn returning(Collection<? extends Expression> expressions) {
 
 			DefaultStatementBuilder.this.addUpdatingClause(builder.build());
 
@@ -1218,7 +1218,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 
 		@NotNull
 		@Override
-		public OngoingReadingAndReturn returningDistinct(Collection<Expression> elements) {
+		public OngoingReadingAndReturn returningDistinct(Collection<? extends Expression> elements) {
 
 			DefaultStatementWithReturnBuilder delegate = (DefaultStatementWithReturnBuilder) returning(elements);
 			delegate.distinct = true;
@@ -1241,7 +1241,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 
 		@NotNull
 		@Override
-		public OngoingUpdate delete(Collection<Expression> deletedExpressions) {
+		public OngoingUpdate delete(Collection<? extends Expression> deletedExpressions) {
 			return delete(deletedExpressions.toArray(new Expression[] {}));
 		}
 
@@ -1253,7 +1253,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 
 		@NotNull
 		@Override
-		public OngoingUpdate detachDelete(Collection<Expression> deletedExpressions) {
+		public OngoingUpdate detachDelete(Collection<? extends Expression> deletedExpressions) {
 			return detachDelete(deletedExpressions.toArray(new Expression[] {}));
 		}
 
@@ -1281,7 +1281,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 
 		@NotNull
 		@Override
-		public BuildableMatchAndUpdate set(Collection<Expression> keyValuePairs) {
+		public BuildableMatchAndUpdate set(Collection<? extends Expression> keyValuePairs) {
 
 			return set(keyValuePairs.toArray(new Expression[] {}));
 		}
@@ -1367,7 +1367,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 
 		@NotNull
 		@Override
-		public OngoingUpdate create(Collection<PatternElement> pattern) {
+		public OngoingUpdate create(Collection<? extends PatternElement> pattern) {
 			return create(pattern.toArray(new PatternElement[] {}));
 		}
 
@@ -1546,14 +1546,14 @@ class DefaultStatementBuilder implements StatementBuilder,
 
 		@NotNull
 		@Override
-		public StatementBuilder.OngoingReadingAndReturn returning(Collection<Expression> expressions) {
+		public StatementBuilder.OngoingReadingAndReturn returning(Collection<? extends Expression> expressions) {
 
 			return new DefaultStatementBuilder(this.buildCall()).returning(expressions);
 		}
 
 		@NotNull
 		@Override
-		public StatementBuilder.OngoingReadingAndReturn returningDistinct(Collection<Expression> expressions) {
+		public StatementBuilder.OngoingReadingAndReturn returningDistinct(Collection<? extends Expression> expressions) {
 
 			return new DefaultStatementBuilder(this.buildCall()).returningDistinct(expressions);
 		}
@@ -1668,7 +1668,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 
 		@NotNull
 		@Override
-		public OngoingReadingAndReturn returning(Collection<Expression> expressions) {
+		public OngoingReadingAndReturn returning(Collection<? extends Expression> expressions) {
 
 			DefaultStatementBuilder.this.currentSinglePartElements.add(this.buildCall());
 			return DefaultStatementBuilder.this.returning(expressions);
@@ -1676,7 +1676,7 @@ class DefaultStatementBuilder implements StatementBuilder,
 
 		@NotNull
 		@Override
-		public OngoingReadingAndReturn returningDistinct(Collection<Expression> expressions) {
+		public OngoingReadingAndReturn returningDistinct(Collection<? extends Expression> expressions) {
 
 			DefaultStatementBuilder.this.currentSinglePartElements.add(this.buildCall());
 			return DefaultStatementBuilder.this.returningDistinct(expressions);

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesCreate.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesCreate.java
@@ -50,5 +50,5 @@ public interface ExposesCreate {
 	 * @since 2021.2.2
 	 */
 	@NotNull @CheckReturnValue
-	StatementBuilder.OngoingUpdate create(Collection<PatternElement> pattern);
+	StatementBuilder.OngoingUpdate create(Collection<? extends PatternElement> pattern);
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesMatch.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesMatch.java
@@ -53,7 +53,7 @@ public interface ExposesMatch {
 	 * @since 2021.2.2
 	 */
 	@NotNull @CheckReturnValue
-	default StatementBuilder.OngoingReadingWithoutWhere match(Collection<PatternElement> pattern) {
+	default StatementBuilder.OngoingReadingWithoutWhere match(Collection<? extends PatternElement> pattern) {
 		return this.match(pattern.toArray(new PatternElement[] {}));
 	}
 
@@ -76,7 +76,7 @@ public interface ExposesMatch {
 	 * @since 2021.2.2
 	 */
 	@NotNull @CheckReturnValue
-	default StatementBuilder.OngoingReadingWithoutWhere optionalMatch(Collection<PatternElement> pattern) {
+	default StatementBuilder.OngoingReadingWithoutWhere optionalMatch(Collection<? extends PatternElement> pattern) {
 		return this.optionalMatch(pattern.toArray(pattern.toArray(new PatternElement[] {})));
 	}
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesReturning.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesReturning.java
@@ -77,7 +77,7 @@ public interface ExposesReturning {
 	 * @return A match that can be build now
 	 */
 	@NotNull @CheckReturnValue
-	StatementBuilder.OngoingReadingAndReturn returning(Collection<Expression> expressions);
+	StatementBuilder.OngoingReadingAndReturn returning(Collection<? extends Expression> expressions);
 
 	/**
 	 * Creates a {@code RETURN} clause containing the {@code DISTINCT} keyword. All variables passed via {@code variables}
@@ -121,7 +121,7 @@ public interface ExposesReturning {
 	 * @return A match that can be build now
 	 */
 	@NotNull @CheckReturnValue
-	StatementBuilder.OngoingReadingAndReturn returningDistinct(Collection<Expression> expressions);
+	StatementBuilder.OngoingReadingAndReturn returningDistinct(Collection<? extends Expression> expressions);
 
 	/**
 	 * Creates a {@code RETURN} clause from a raw Cypher expression created via {@link Cypher#raw(String, Object...)}.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Pattern.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Pattern.java
@@ -22,6 +22,7 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import org.apiguardian.api.API;
@@ -51,8 +52,8 @@ final class Pattern extends TypedSubtree<PatternElement> {
 		return Pattern.of(elements);
 	}
 
-	static Pattern of(List<PatternElement> elements) {
-		return new Pattern(elements);
+	static Pattern of(Collection<? extends PatternElement> elements) {
+		return new Pattern(elements.stream().map(PatternElement.class::cast).toList());
 	}
 
 	private Pattern(List<PatternElement> patternElements) {

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementBuilder.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementBuilder.java
@@ -581,18 +581,18 @@ public interface StatementBuilder
 		 * Creates a delete step with one or more expressions to be deleted.
 		 *
 		 * @param expressions The expressions to be deleted.
-		 * @return A match with a delete clause that can be build now
+		 * @return A match with a {@literal DELETE} clause that can be build now
 		 * @since 2021.2.2
 		 */
 		@NotNull @CheckReturnValue
-		OngoingUpdate delete(Collection<Expression> expressions);
+		OngoingUpdate delete(Collection<? extends Expression> expressions);
 
 		/**
 		 * Renders a {@code DETACH DELETE} clause targeting the given variables. NO checks are done whether they have
 		 * been matched previously.
 		 *
 		 * @param variables Variables indicating the things to delete.
-		 * @return A match with a detach delete clause that can be build now
+		 * @return A match with a {@literal DETACH DELETE} clause that can be build now
 		 */
 		@NotNull @CheckReturnValue
 		default OngoingUpdate detachDelete(String... variables) {
@@ -604,7 +604,7 @@ public interface StatementBuilder
 		 * been matched previously.
 		 *
 		 * @param variables Variables indicating the things to delete.
-		 * @return A match with a detach delete clause that can be build now
+		 * @return A match with a {@literal DETACH DELETE} clause that can be build now
 		 */
 		@NotNull @CheckReturnValue
 		default OngoingUpdate detachDelete(Named... variables) {
@@ -615,7 +615,7 @@ public interface StatementBuilder
 		 * Starts building a delete step that will use {@code DETACH} to remove relationships.
 		 *
 		 * @param expressions The expressions to be deleted.
-		 * @return A match with a delete clause that can be build now
+		 * @return A match with {@literal DETACH DELETE} clause that can be build now
 		 */
 		@NotNull @CheckReturnValue
 		OngoingUpdate detachDelete(Expression... expressions);
@@ -624,11 +624,11 @@ public interface StatementBuilder
 		 * Starts building a delete step that will use {@code DETACH} to remove relationships.
 		 *
 		 * @param expressions The expressions to be deleted.
-		 * @return A match with a delete clause that can be build now
+		 * @return A match with {@literal DETACH DELETE} clause that can be build now
 		 * @since 2021.2.2
 		 */
 		@NotNull @CheckReturnValue
-		OngoingUpdate detachDelete(Collection<Expression> expressions);
+		OngoingUpdate detachDelete(Collection<? extends Expression> expressions);
 	}
 
 	/**
@@ -657,7 +657,7 @@ public interface StatementBuilder
 		 * @since 2021.2.2
 		 */
 		@NotNull @CheckReturnValue
-		BuildableMatchAndUpdate set(Collection<Expression> expressions);
+		BuildableMatchAndUpdate set(Collection<? extends Expression> expressions);
 
 		/**
 		 * Adds a {@code SET} clause to the statement, modifying the given named thing with an expression.
@@ -841,7 +841,7 @@ public interface StatementBuilder
 		 * @since 2021.2.2
 		 */
 		@NotNull @CheckReturnValue
-		BuildableOngoingMergeAction set(Collection<Expression> expressions);
+		BuildableOngoingMergeAction set(Collection<? extends Expression> expressions);
 
 		/**
 		 * Adds a {@code SET} clause to the statement, modifying the given named thing with an expression.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ast/TypedSubtree.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ast/TypedSubtree.java
@@ -22,6 +22,7 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import org.apiguardian.api.API;
@@ -59,7 +60,7 @@ public abstract class TypedSubtree<T extends Visitable> implements Visitable {
 	 *
 	 * @param children The content of this subtree.
 	 */
-	protected TypedSubtree(List<T> children) {
+	protected TypedSubtree(Collection<T> children) {
 
 		this.children = new ArrayList<>(children);
 	}

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/IssueRelatedIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/IssueRelatedIT.java
@@ -1443,4 +1443,12 @@ class IssueRelatedIT {
 			.build().getCypher();
 		assertThat(cypher).isEqualTo("MATCH (person:`Person`) WITH person, COUNT { (person)-[:`ACTED_IN`]->() } AS actedInDegree RETURN *");
 	}
+
+	@Test // GH-553
+	void allowCovariantForMakingDynamicCypherCreationEasier() {
+
+		var patterns = List.of(Cypher.node("A").named("a"), Cypher.node("B").relationshipTo(Cypher.node("C"), "IS_RELATED").named("r"));
+		var cypher = Cypher.match(patterns.stream().toList()).returning(Cypher.asterisk()).build().getCypher();
+		assertThat(cypher).isEqualTo("MATCH (a:`A`), (:`B`)-[r:`IS_RELATED`]->(:`C`) RETURN *");
+	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -632,16 +632,14 @@
 								</overrideCompatibilityChangeParameter>
 							</overrideCompatibilityChangeParameters>
 							<excludes>
-								<!--
-								 | Internal packages, protected by Java Module system on module path.
-								 -->
+								<!-- Internal packages, protected by Java Module system on module path. -->
 								<exclude>org.neo4j.cypherdsl.core.internal</exclude>
+								<!-- 2023.1.0, changed for #553. It's safely marked as internal -->
+								<exclude>org.neo4j.cypherdsl.core.ast.TypedSubtree</exclude>
 								<!-- Not exported either, but let's be a more lenient. -->
 								<exclude>org.neo4j.cypherdsl.core.utils.Strings#isValidJavaIdentifierPartAt(int,int)</exclude>
 								<exclude>org.neo4j.cypherdsl.core.utils.Strings#isIdentifier(java.lang.CharSequence)</exclude>
-								<!--
-								 | Those are shaded classes from Neo4j and we work around their changes.
-								 -->
+								<!-- Those are shaded classes from Neo4j, and we work around their changes. -->
 								<exclude>org.neo4j.cypherdsl.parser.internal</exclude>
 							</excludes>
 						</parameter>


### PR DESCRIPTION
Closes #553.
