### PR TITLE
fix: Move resolved symbolic names into `StatementContext`.

### DIFF
--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementContext.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementContext.java
@@ -58,4 +58,24 @@ public sealed interface StatementContext permits StatementContextImpl {
 	 * constants rather than actual Cypher parameters.
 	 */
 	boolean isRenderConstantsAsParameters();
+
+	/**
+	 * Resolves a {@link SymbolicName symbolic name} into a string: A symbolic name can be a placeholder without an actual
+	 * value. In such cases a value is randomly generated and will stay constant for that name as long as the statement exists.
+	 * In case the {@code symbolicName} has a constant value it will be returned,
+	 *
+	 * @param symbolicName the symbolic name to resolve
+	 * @return a value for the given name
+	 * @since 2023.0.3
+	 */
+	String resolve(SymbolicName symbolicName);
+
+	/**
+	 * Checks whether a given {@link SymbolicName symbolic name} has been resolved in this {@link StatementContext context}.
+	 *
+	 * @param symbolicName the symbolic name to check
+	 * @return true if the given name has already been resolved in this context
+	 * @since 2023.0.3
+	 */
+	boolean isResolved(SymbolicName symbolicName);
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/DefaultVisitor.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/DefaultVisitor.java
@@ -154,11 +154,6 @@ class DefaultVisitor extends ReflectiveVisitor implements RenderingVisitor {
 	private boolean skipAliasing = false;
 
 	/**
-	 * Keeps track of unresolved symbolic names.
-	 */
-	private final Map<SymbolicName, String> resolvedSymbolicNames = new ConcurrentHashMap<>();
-
-	/**
 	 * A cache of delegates, avoiding unnecessary object creation.
 	 */
 	private final Map<Class<? extends Visitor>, Visitor> delegateCache = new ConcurrentHashMap<>();
@@ -217,17 +212,6 @@ class DefaultVisitor extends ReflectiveVisitor implements RenderingVisitor {
 	private Optional<AtomicReference<String>> separatorOnCurrentLevel() {
 
 		return Optional.ofNullable(separatorOnLevel.get(currentLevel));
-	}
-
-	private String resolve(SymbolicName symbolicName) {
-
-		return this.resolvedSymbolicNames.computeIfAbsent(symbolicName, k -> {
-			String value = k.getValue();
-			if (Strings.hasText(value)) {
-				return escapeIfNecessary(symbolicName.getValue());
-			}
-			return String.format("%s%03d", Strings.randomIdentifier(8), resolvedSymbolicNames.size());
-		});
 	}
 
 	@Override
@@ -527,7 +511,7 @@ class DefaultVisitor extends ReflectiveVisitor implements RenderingVisitor {
 
 		if (skipNodeContent) {
 			String symbolicName = node.getSymbolicName()
-				.map(SymbolicName::getValue).orElseGet(() -> resolve(node.getRequiredSymbolicName()));
+				.map(SymbolicName::getValue).orElseGet(() -> statementContext.resolve(node.getRequiredSymbolicName()));
 			builder.append(symbolicName);
 		}
 
@@ -594,11 +578,11 @@ class DefaultVisitor extends ReflectiveVisitor implements RenderingVisitor {
 
 		if (inRelationshipCondition) {
 			String value = symbolicName.getValue();
-			if (Strings.hasText(value) && resolvedSymbolicNames.containsKey(symbolicName)) {
+			if (Strings.hasText(value) && statementContext.isResolved(symbolicName)) {
 				builder.append(escapeIfNecessary(symbolicName.getValue()));
 			}
 		} else {
-			builder.append(resolve(symbolicName));
+			builder.append(statementContext.resolve(symbolicName));
 		}
 	}
 

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/IssueRelatedIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/IssueRelatedIT.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -1450,5 +1451,25 @@ class IssueRelatedIT {
 		var patterns = List.of(Cypher.node("A").named("a"), Cypher.node("B").relationshipTo(Cypher.node("C"), "IS_RELATED").named("r"));
 		var cypher = Cypher.match(patterns.stream().toList()).returning(Cypher.asterisk()).build().getCypher();
 		assertThat(cypher).isEqualTo("MATCH (a:`A`), (:`B`)-[r:`IS_RELATED`]->(:`C`) RETURN *");
+	}
+
+	@Test // GH-585
+	void rerenderShouldYieldSameResultOnSameRenderer() throws NoSuchFieldException, IllegalAccessException {
+
+		var anonymous = Cypher.node("Person");
+		var statement = Cypher.match(anonymous).delete(anonymous).build();
+		var s1 = statement.getCypher();
+		var s2 = statement.getCypher();
+		var defaultRenderer = Renderer.getDefaultRenderer();
+		var s3 = defaultRenderer.render(statement);
+		assertThat(s1).isEqualTo(s2);
+		assertThat(s2).isEqualTo(s3);
+
+		// Nuke the cache
+		var renderedStatementCache = defaultRenderer.getClass().getDeclaredField("renderedStatementCache");
+		renderedStatementCache.setAccessible(true);
+		((Map<?, ?>) renderedStatementCache.get(defaultRenderer)).clear();
+		var s4 = defaultRenderer.render(statement);
+		assertThat(s3).isEqualTo(s4);
 	}
 }


### PR DESCRIPTION
This is necessary to keep the generated values constant for the lifetime of a statement.
Otherwise they would be re-resolved by the rendering when the cache overflew. This is probably
not what happened in #585, but what I realised while adding a test for the desired behaviour.

Having an API to access the resolved values might be useful in the future, too.

Fixes #585.
