### PR TITLE
fix: Open implicit scope when entering a `UNION` clause.

### DIFF
--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/ScopingStrategy.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/ScopingStrategy.java
@@ -111,7 +111,7 @@ public final class ScopingStrategy {
 				new HashSet<>(dequeOfVisitedNamed.isEmpty() ? Collections.emptySet() : dequeOfVisitedNamed.peek()));
 		}
 
-		if (visitable instanceof CountExpression) {
+		if (hasImplicitScope(visitable)) {
 			implicitScope.push(
 				new HashSet<>(dequeOfVisitedNamed.isEmpty() ? Collections.emptySet() : dequeOfVisitedNamed.peek()));
 		}
@@ -163,11 +163,15 @@ public final class ScopingStrategy {
 			this.inProperty = false;
 		}
 
-		if (visitable instanceof CountExpression) {
+		if (hasImplicitScope(visitable)) {
 			this.implicitScope.pop();
 		}
 
 		previous = visitable;
+	}
+
+	private boolean hasImplicitScope(Visitable visitable) {
+		return visitable instanceof CountExpression || visitable instanceof Statement.UnionQuery;
 	}
 
 	private void leaveStatement(Visitable visitable) {


### PR DESCRIPTION
Fixes #589.