### PR TITLE
fix: Apply prefixes after potential separator.

### DIFF
--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/DefaultVisitor.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/DefaultVisitor.java
@@ -234,10 +234,6 @@ class DefaultVisitor extends ReflectiveVisitor implements RenderingVisitor {
 			return false;
 		}
 
-		if (visitable instanceof ProvidesAffixes) {
-			((ProvidesAffixes) visitable).getPrefix().ifPresent(this::doWithPrefix);
-		}
-
 		if (visitable instanceof AliasedExpression) {
 			currentAliasedElements.push((AliasedExpression) visitable);
 		}
@@ -252,6 +248,10 @@ class DefaultVisitor extends ReflectiveVisitor implements RenderingVisitor {
 		}
 
 		separatorOnCurrentLevel().ifPresent(ref -> builder.append(ref.getAndSet("")));
+
+		if (visitable instanceof ProvidesAffixes) {
+			((ProvidesAffixes) visitable).getPrefix().ifPresent(this::doWithPrefix);
+		}
 
 		boolean doEnter = !skipNodeContent;
 		if (doEnter) {

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/IssueRelatedIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/IssueRelatedIT.java
@@ -1430,4 +1430,19 @@ class IssueRelatedIT {
 			.build();
 		assertThat(renderer.render(statement)).isEqualTo("UNWIND $ids AS id MATCH (n:`Person`) WHERE elementId(n) = id RETURN n");
 	}
+
+	static Stream<Arguments> conditionExpressionShouldWorkInReturn() {
+		return Stream.of(
+			Arguments.of(Cypher.returning(Cypher.literalOf(1), Cypher.literalTrue().asCondition()).build(), "RETURN 1, true"),
+			Arguments.of(Cypher.returning(Cypher.literalOf(1), Cypher.literalTrue().asCondition().and(Cypher.literalFalse().asCondition())).build(), "RETURN 1, (true AND false)"),
+			Arguments.of(Cypher.returning(Cypher.literalOf(1), Cypher.literalTrue().asCondition().or(Cypher.literalFalse().asCondition())).build(), "RETURN 1, (true OR false)")
+		);
+	}
+
+	@ParameterizedTest(name = "{1}") // GH-605
+	@MethodSource
+	void conditionExpressionShouldWorkInReturn(Statement statement, String expected) {
+		String cypher = statement.getCypher();
+		assertThat(cypher).isEqualTo(expected);
+	}
 }


### PR DESCRIPTION
This fixes #605. Thanks to @GregoryEssertel for spotting this.
