### PR TITLE
feat: Add label existences conditions to catalog.

### DIFF
--- a/neo4j-cypher-dsl-native-tests/src/main/java/org/neo4j/cypherdsl/graalvm/Application.java
+++ b/neo4j-cypher-dsl-native-tests/src/main/java/org/neo4j/cypherdsl/graalvm/Application.java
@@ -67,7 +67,7 @@ public class Application {
 			.map(SymbolicName::getValue)
 			.sorted()
 			.forEach(System.out::println);
-		catalog.getAllConditions()
+		catalog.getAllPropertyFilters()
 			.entrySet()
 			.stream().sorted(Comparator.comparing(o -> o.getKey().name()))
 			.forEach(e -> System.out.println(e.getKey().name() + ": " + e.getValue().stream().limit(1).map(cc -> cc.right().toString()).collect(Collectors.joining())));

--- a/neo4j-cypher-dsl-parser/src/test/java/org/neo4j/cypherdsl/parser/ExtractionIT.java
+++ b/neo4j-cypher-dsl-parser/src/test/java/org/neo4j/cypherdsl/parser/ExtractionIT.java
@@ -32,7 +32,7 @@ import org.neo4j.cypherdsl.core.Cypher;
 import org.neo4j.cypherdsl.core.Operator;
 import org.neo4j.cypherdsl.core.Statement;
 import org.neo4j.cypherdsl.core.StatementCatalog.Property;
-import org.neo4j.cypherdsl.core.StatementCatalog.Condition.Clause;
+import org.neo4j.cypherdsl.core.StatementCatalog.Clause;
 import org.neo4j.cypherdsl.core.StatementCatalog.Token;
 import org.neo4j.cypherdsl.core.renderer.Configuration;
 import org.neo4j.cypherdsl.core.renderer.GeneralizedRenderer;
@@ -67,7 +67,7 @@ class ExtractionIT {
 		assertThat(catalog.getProperties()).containsExactlyInAnyOrderElementsOf(testData.expectedProperties());
 		if (testData.expectedComparisons != null) {
 			for (TestDataComparison expectedComparison : testData.expectedComparisons()) {
-				assertThat(catalog.getConditions(expectedComparison.property())).allMatch(v -> testData.expectedComparisons().contains(
+				assertThat(catalog.getFilters(expectedComparison.property())).allMatch(v -> testData.expectedComparisons().contains(
 					new TestDataComparison(v.clause(), expectedComparison.property, v.left() == null ? null : RENDERER.render(v.left()), v.operator(), v.right() == null ? null : RENDERER.render(v.right()), v.parameterNames())
 				));
 			}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementCatalog.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementCatalog.java
@@ -129,7 +129,7 @@ public sealed interface StatementCatalog permits StatementCatalogBuildingVisitor
 	 *
 	 * @return A map of all filters.
 	 */
-	default Collection<? extends Filter> getAllFilters() {
+	default Collection<Filter> getAllFilters() {
 		Set<Filter> result = new HashSet<>(this.getAllLabelFilters());
 		this.getAllPropertyFilters().forEach((p, f) -> result.addAll(f));
 		return result;


### PR DESCRIPTION
This changes implements #618. The Neo4j documentation speaks about filters and we think it’s a better name to be used in our catalog too. So to unify the access to both property based filters (which filter by conditions) and label existence based filters, the `Condition` type has been renamed `PropertyFilter` and an interface `Filter` has been introduced, together with all required accessors for the label filters.

This closes #618.
