### PR TITLE
feat: Add overloads for `count` and `exists` taking in a statement and optional imports.

### DIFF
--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExistentialSubquery.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExistentialSubquery.java
@@ -21,11 +21,12 @@ package org.neo4j.cypherdsl.core;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
+import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.ast.Visitor;
 
 /**
- * An existential subquery can only be used in a where clause. The subquery must consisted only of a match statement
- * which may have a {@code WHERE} clause on its own but is not not allowed to return anything.
+ * An existential sub-query  can only be used in  a where clause. The  sub-query must consist only of  a match statement
+ * which may have a {@code WHERE} clause on its own but is not allowed to return anything.
  *
  * @author Michael J. Simons
  * @soundtrack Die Ärzte - Seitenhirsch
@@ -41,16 +42,28 @@ public final class ExistentialSubquery implements SubqueryExpression, Condition 
 		return new ExistentialSubquery(fragment);
 	}
 
-	private final Match fragment;
+	static Condition exists(Statement statement, IdentifiableElement... imports) {
+		return new ExistentialSubquery(statement, imports);
+	}
+
+	private final Visitable fragment;
+	private final ImportingWith importingWith;
 
 	ExistentialSubquery(Match fragment) {
 		this.fragment = fragment;
+		this.importingWith = new ImportingWith();
+	}
+
+	ExistentialSubquery(Statement statement, IdentifiableElement... imports) {
+		this.fragment = statement;
+		this.importingWith = ImportingWith.of(imports);
 	}
 
 	@Override
 	public void accept(Visitor visitor) {
 
 		visitor.enter(this);
+		importingWith.accept(visitor);
 		fragment.accept(visitor);
 		visitor.leave(this);
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesSubqueryCall.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesSubqueryCall.java
@@ -87,7 +87,7 @@ public interface ExposesSubqueryCall {
 	}
 
 	/**
-	 * The {@link Statement subquery} parameter must be a valid subquery.
+	 * The {@link Statement subquery} parameter must be a valid sub-query.
 	 * <ul>
 	 * <li>must end with a RETURN clause</li>
 	 * <li>cannot refer to variables from the enclosing query</li>
@@ -95,9 +95,10 @@ public interface ExposesSubqueryCall {
 	 * <li>All variables that are returned from a subquery are afterwards available in the enclosing query</li>
 	 * </ul>
 	 *
-	 * @param statement The statement representing the subquery.
-	 * @param imports   Additional things that should be imported into the subquery. {@link AliasedExpression aliased expressions}
-	 *                  will automatically imported twice (once as WITH a, then WITH a AS alias).
+	 * @param statement The statement representing the sub-query.
+	 * @param imports   Additional things that  should be imported into the sub-query.  {@link AliasedExpression aliased
+	 *                  expressions} will automatically be  importe twice (once as {@code WITH a}, then  {code WITH a AS
+	 *                  alias}).
 	 * @return An ongoing reading
 	 * @since 2021.3.0
 	 */

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Expressions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Expressions.java
@@ -73,7 +73,7 @@ public final class Expressions {
 	 */
 	@NotNull
 	public static CountExpression count(PatternElement requiredPattern, PatternElement... patternElement) {
-		return new CountExpression(null, Pattern.of(requiredPattern, patternElement), null);
+		return CountExpression.count(Pattern.of(requiredPattern, patternElement));
 	}
 
 	/**
@@ -85,7 +85,22 @@ public final class Expressions {
 	 */
 	@NotNull
 	public static CountExpression count(UnionQuery union) {
-		return new CountExpression(null, union, null);
+		return CountExpression.count(union);
+	}
+
+	/**
+	 * Creates a {@literal COUNT} from a full statement, including  its filters and conditions. The statement may or may
+	 * not have a {@literal RETURN} clause. It must however not contain any updates. While it would render syntactically
+	 * correct Cypher, Neo4j does not support updates inside counting sub-queries.
+	 *
+	 * @param statement The statement to be passed to {@code count{}}
+	 * @param imports   Optional imports to be used in the statement (will be imported with {@literal WITH})
+	 * @return A counting sub-query.
+	 * @since 2023.1.0
+	 */
+	@NotNull
+	public static CountExpression count(Statement statement, IdentifiableElement... imports) {
+		return CountExpression.count(statement, imports);
 	}
 
 	/**
@@ -114,12 +129,12 @@ public final class Expressions {
 		return new SubqueryExpressionBuilder() {
 			@Override @NotNull
 			public CountExpression count(PatternElement requiredPattern, PatternElement... patternElement) {
-				return new CountExpression(with, Pattern.of(requiredPattern, patternElement), null);
+				return CountExpression.count(with, Pattern.of(requiredPattern, patternElement));
 			}
 
 			@Override @NotNull
 			public CountExpression count(UnionQuery union) {
-				return new CountExpression(with, union, null);
+				return CountExpression.count(with, union);
 			}
 		};
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ImportingWith.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ImportingWith.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2019-2023 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.core;
+
+import static org.apiguardian.api.API.Status.INTERNAL;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import org.apiguardian.api.API;
+import org.jetbrains.annotations.Nullable;
+import org.neo4j.cypherdsl.core.ast.Visitable;
+import org.neo4j.cypherdsl.core.ast.Visitor;
+
+/**
+ * This type  is used  in sub-queries,  both for  sub-queries with  an implicit  scope such  as {@literal  EXISTS{}} and
+ * {@literal  COUNT{}} and  full  sub-queries. In  the latter  case,  it will  create  and visite  multiple {@link  With
+ * with-instances} so that the import actually shadows the outer scope.
+ *
+ * @author Michael J. Simons
+ * @param imports The imported expressions
+ * @param renames The renamed expressions, shadowing the outer scope
+ * @since 2023.1.0
+ */
+@API(status = INTERNAL, since = "2023.1.0")
+record ImportingWith(@Nullable With imports, @Nullable With renames) implements Visitable {
+
+	ImportingWith() {
+		this(null, null);
+	}
+
+	@Nullable
+	static ImportingWith of(IdentifiableElement... imports) {
+
+		With optionalImports;
+		With optionalRenames;
+
+		ExpressionList returnItems = new ExpressionList(Arrays.stream(imports)
+			.map(i -> {
+				if (i instanceof AliasedExpression aliasedExpression) {
+					var delegate = aliasedExpression.getDelegate();
+					if (delegate instanceof Literal<?>) {
+						return null;
+					}
+					return delegate;
+				} else {
+					return i.asExpression();
+				}
+			})
+			.filter(Objects::nonNull)
+			.toList());
+
+		optionalImports = returnItems.isEmpty() ? null : new With(false, returnItems, null, null, null, null);
+
+		returnItems = new ExpressionList(Arrays.stream(imports)
+			.filter(AliasedExpression.class::isInstance)
+			.map(Expression.class::cast)
+			.toList());
+
+		optionalRenames = returnItems.isEmpty() ? null : new With(false, returnItems, null, null, null, null);
+
+		return new ImportingWith(optionalImports, optionalRenames);
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+		Visitable.visitIfNotNull(this.imports, visitor);
+		Visitable.visitIfNotNull(this.renames, visitor);
+	}
+}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Predicates.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Predicates.java
@@ -63,6 +63,23 @@ public final class Predicates {
 	}
 
 	/**
+	 * Creates                  a                 new                  condition                 via                  an
+	 * <a     href="https://neo4j.com/docs/cypher-manual/current/syntax/expressions/#existential-subqueries">existential
+	 * sub-query</a>. The statement may or  may not have  a {@literal  RETURN} clause. It  must however not  contain any
+	 * updates. While it  would render syntactically correct  Cypher, Neo4j does not support  updates inside existential
+	 * sub-queries.
+	 *
+	 * @param statement The statement to be passed to {@code exists{}}
+	 * @param imports   Optional imports to be used in the statement (will be imported with {@literal WITH})
+	 * @return An existential sub-query.
+	 * @since 2023.1.0
+	 */
+	public static Condition exists(Statement statement, IdentifiableElement... imports) {
+
+		return ExistentialSubquery.exists(statement, imports);
+	}
+
+	/**
 	 * @param variable The variable referring to elements of a list
 	 * @return A builder for the {@code all()} predicate function
 	 * @see #all(SymbolicName)

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/ScopingStrategy.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/ScopingStrategy.java
@@ -40,6 +40,7 @@ import org.neo4j.cypherdsl.core.Aliased;
 import org.neo4j.cypherdsl.core.AliasedExpression;
 import org.neo4j.cypherdsl.core.CountExpression;
 import org.neo4j.cypherdsl.core.Cypher;
+import org.neo4j.cypherdsl.core.ExistentialSubquery;
 import org.neo4j.cypherdsl.core.Expression;
 import org.neo4j.cypherdsl.core.Foreach;
 import org.neo4j.cypherdsl.core.IdentifiableElement;
@@ -228,7 +229,7 @@ public final class ScopingStrategy {
 	}
 
 	private static boolean hasImplicitScope(Visitable visitable) {
-		return visitable instanceof CountExpression || visitable instanceof Statement.UnionQuery;
+		return visitable instanceof CountExpression || visitable instanceof ExistentialSubquery || visitable instanceof Statement.UnionQuery;
 	}
 
 	private void leaveStatement(Visitable visitable) {


### PR DESCRIPTION
This allows for easier composition of queries with those type of subqueries than using the builder throughout a pipeline. As we don’t do a full semantic analysis inside the statement, those overloads don’t do a semantical check whether the passed statements are read-only queries or not. Neither `count` nor `exists` do support updates. If such a query is used, syntactically correct Cypher will be rendered, but that cypher can’t be executed.

The API is argumentwise compatible with `org.neo4j.cypherdsl.core.ExposesSubqueryCall#call(org.neo4j.cypherdsl.core.Statement, org.neo4j.cypherdsl.core.IdentifiableElement…)`.

This closes #578.
