### PR TITLE
feat: Add `Cypher.withAll` to create a with clause importing all (`*`) variables.

### DIFF
--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
@@ -454,7 +454,7 @@ public final class Cypher {
 
 	/**
 	 * Starts a statement with a leading {@code WITH}. Those are useful for passing on lists of various type that
-	 * can be unwound later on etc. A leading {@code WITH} cannot be used with patterns obviously and needs its
+	 * can be unwound later on etc. A leading {@code WITH} obviously cannot be used with patterns and needs its
 	 * arguments to have an alias.
 	 *
 	 * @param variables One ore more variables.
@@ -465,6 +465,19 @@ public final class Cypher {
 	public static StatementBuilder.OrderableOngoingReadingAndWithWithoutWhere with(String... variables) {
 
 		return Statement.builder().with(variables);
+	}
+
+	/**
+	 * Starts a statement with a leading {@code WITH *}, meaning all outer variables are imported into the query.
+	 * The created statement is only semantically meaningful inside a {@code CALL{}} clause.
+	 *
+	 * @return An ongoing with clause.
+	 * @since 2023.2.0
+	 */
+	@NotNull @Contract(pure = true)
+	public static StatementBuilder.OrderableOngoingReadingAndWithWithoutWhere withAll() {
+
+		return Statement.builder().with(Cypher.asterisk());
 	}
 
 	/**

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/IssueRelatedIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/IssueRelatedIT.java
@@ -1629,4 +1629,18 @@ class IssueRelatedIT {
 			.returningDistinct(label).build().getCypher())
 			.isEqualTo("MATCH p = (:`Movie`)<-[r]-() WITH nodes(p) AS nodes UNWIND nodes AS node WITH labels(node) AS labels UNWIND labels AS label RETURN DISTINCT label");
 	}
+
+	@Test // GH-634
+	void withAllShouldWork() {
+
+		var this0 = Cypher.node("User").named("this");
+		var x = Cypher.name("x");
+		var stmt = Cypher.match(this0)
+			.call(Cypher.withAll().with(this0.as("x")).returning(Functions.count(Cypher.asterisk()).as(x)).build())
+			.returning(x, Functions.count(Cypher.asterisk()))
+			.build();
+
+		var expected = "MATCH (this:`User`) CALL {WITH * WITH this AS x RETURN count(*) AS x} RETURN x, count(*)";
+		assertThat(stmt.getCypher()).isEqualTo(expected);
+	}
 }


### PR DESCRIPTION
Closes #634
