### PR TITLE
refactor: Deprecate `Functions.id()` in favor of `elementId()`.

### DIFF
--- a/etc/recipes/rewrite.yml
+++ b/etc/recipes/rewrite.yml
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2019-2023 "Neo4j,"
+# Neo4j Sweden AB [https://neo4j.com]
+#
+# This file is part of Neo4j.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Run with
+# ./mvnw org.openrewrite.maven:rewrite-maven-plugin:run \
+#   -Drewrite.configLocation=/full/path/to/cypher-dsl/etc/recipes/rewrite.yml \
+#   -Drewrite.activeRecipes=cypher-dsl.rewriteIdCalls
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: cypher-dsl.rewriteIdCalls
+displayName: Change calls to Functions.id to Functions.elementId
+recipeList:
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.neo4j.cypherdsl.core.Functions id(..)
+      newMethodName: elementId
+      ignoreDefinition: true

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Functions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Functions.java
@@ -50,8 +50,11 @@ public final class Functions {
 	 *
 	 * @param node The node for which the internal id should be retrieved
 	 * @return A function call for {@code id()} on a node.
+	 * @deprecated see {@link #elementId(Node)} for a replacement. Neo4j the database will remove support for {@code id(n)}
+	 * at some point.
 	 */
 	@NotNull @Contract(pure = true)
+	@Deprecated(since = "2023.3.0")
 	public static FunctionInvocation id(@NotNull Node node) {
 
 		Assertions.notNull(node, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_NODE_REQUIRED));
@@ -65,8 +68,11 @@ public final class Functions {
 	 *
 	 * @param relationship The relationship for which the internal id should be retrieved
 	 * @return A function call for {@code id()} on a relationship.
+	 * @deprecated see {@link #elementId(Relationship)} for a replacement. Neo4j the database will remove support for
+	 * {@code id(n)} at some point.
 	 */
 	@NotNull @Contract(pure = true)
+	@Deprecated(since = "2023.3.0")
 	public static FunctionInvocation id(@NotNull Relationship relationship) {
 
 		Assertions.notNull(relationship, Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_RELATIONSHIP_REQUIRED));

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RendererBridge.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RendererBridge.java
@@ -20,6 +20,7 @@ package org.neo4j.cypherdsl.core;
 
 import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.renderer.Configuration;
+import org.neo4j.cypherdsl.core.renderer.Dialect;
 import org.neo4j.cypherdsl.core.renderer.GeneralizedRenderer;
 import org.neo4j.cypherdsl.core.renderer.Renderer;
 
@@ -31,7 +32,9 @@ import org.neo4j.cypherdsl.core.renderer.Renderer;
  */
 class RendererBridge {
 
-	private static final Configuration CONFIGURATION = Configuration.newConfig().alwaysEscapeNames(false).build();
+	private static final Configuration CONFIGURATION = Configuration.newConfig()
+		.withDialect(Dialect.NEO4J_5)
+		.alwaysEscapeNames(false).build();
 
 	static String render(Visitable visitable) {
 		String name;

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
@@ -3273,7 +3273,7 @@ class CypherIT {
 			Node node = Cypher.node("Person").named("p");
 			//noinspection ResultOfMethodCallIgnored
 			assertThatIllegalArgumentException().isThrownBy(() -> Cypher.match(node)
-				.returning(node.project("__internalNeo4jId__", Functions.id(node), "name")
+				.returning(node.project("__internalNeo4jId__", Functions.elementId(node), "name")
 					.and(node.property("home.location", "y"))
 				)
 				.build()).withMessage("Cannot project nested properties!");
@@ -3680,14 +3680,14 @@ class CypherIT {
 				Node n = Cypher.anyNode("n");
 
 				statement = Cypher.match(n)
-					.returning(n.project("__internalNeo4jId__", Functions.id(n), "name"))
+					.returning(n.project("__internalNeo4jId__", Functions.elementId(n), "name"))
 					.build();
 				assertThat(cypherRenderer.render(statement))
 					.isEqualTo(
 						"MATCH (n) RETURN n{__internalNeo4jId__: id(n), .name}");
 
 				statement = Cypher.match(n)
-					.returning(n.project("name", "__internalNeo4jId__", Functions.id(n)))
+					.returning(n.project("name", "__internalNeo4jId__", Functions.elementId(n)))
 					.build();
 				assertThat(cypherRenderer.render(statement))
 					.isEqualTo(
@@ -3739,8 +3739,8 @@ class CypherIT {
 				statement = Cypher.match(n.relationshipTo(m, "ACTED_IN"))
 					.returning(
 						n.project(
-							"__internalNeo4jId__", Functions.id(n), "name", "nested",
-							m.project("title", "__internalNeo4jId__", Functions.id(m))
+							"__internalNeo4jId__", Functions.elementId(n), "name", "nested",
+							m.project("title", "__internalNeo4jId__", Functions.elementId(m))
 						))
 					.build();
 				assertThat(cypherRenderer.render(statement))
@@ -3785,7 +3785,7 @@ class CypherIT {
 				Relationship rel = p.relationshipTo(m, "ACTED_IN").named("r");
 
 				statement = Cypher.match(rel)
-					.returning(p.project("__internalNeo4jId__", Functions.id(p), "name")
+					.returning(p.project("__internalNeo4jId__", Functions.elementId(p), "name")
 						.and(rel)
 						.and(m)
 						.and(p.property("foo"))
@@ -3812,7 +3812,7 @@ class CypherIT {
 				statement = Cypher.match(rel)
 					.returning(
 						rel.project(
-							"__internalNeo4jId__", Functions.id(rel), "roles"
+							"__internalNeo4jId__", Functions.elementId(rel), "roles"
 						))
 					.build();
 				assertThat(cypherRenderer.render(statement))
@@ -3833,7 +3833,7 @@ class CypherIT {
 						m.project(
 							"title", "roles",
 							rel.project(
-								"__internalNeo4jId__", Functions.id(rel), "roles"
+								"__internalNeo4jId__", Functions.elementId(rel), "roles"
 							)
 						)
 					)
@@ -3876,12 +3876,12 @@ class CypherIT {
 			String expectedMessage = "FunctionInvocation{cypher=id(n)} of type class org.neo4j.cypherdsl.core.FunctionInvocation cannot be used with an implicit name as map entry.";
 			assertThatIllegalArgumentException().isThrownBy(() -> {
 				Node n = Cypher.anyNode("n");
-				n.project(Functions.id(n));
+				n.project(Functions.elementId(n));
 			}).withMessage(expectedMessage);
 
 			assertThatIllegalArgumentException().isThrownBy(() -> {
 				Node n = Cypher.anyNode("n");
-				n.project("a", Cypher.mapOf("a", Cypher.literalOf("b")), Functions.id(n));
+				n.project("a", Cypher.mapOf("a", Cypher.literalOf("b")), Functions.elementId(n));
 			}).withMessage(expectedMessage);
 		}
 	}

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/FunctionsIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/FunctionsIT.java
@@ -240,6 +240,7 @@ class FunctionsIT {
 			.literalOf(4)));
 
 		// NOTE: Not all of those return valid Cypher statements. They are used only for integration testing the function calls so far.
+		@SuppressWarnings("deprecation") var idOfRel = Functions.id(r);
 		return Stream.of(
 			Arguments.of(Functions.left(null, null), "RETURN left(NULL, NULL)"),
 			Arguments.of(Functions.left(Cypher.literalOf("hello"), Cypher.literalOf(3)), "RETURN left('hello', 3)"),
@@ -252,8 +253,7 @@ class FunctionsIT {
 			Arguments.of(Functions.substring(Cypher.literalOf("hello"), Cypher.literalOf(1), Cypher.literalOf(3)), "RETURN substring('hello', 1, 3)"),
 			Arguments.of(Functions.substring(Cypher.literalOf("hello"), Cypher.literalOf(2), null), "RETURN substring('hello', 2)"),
 			Arguments.of(Functions.toStringOrNull(Cypher.literalOf("hello")), "RETURN toStringOrNull('hello')"),
-			Arguments.of(Functions.id(n), "RETURN id(n)"),
-			Arguments.of(Functions.id(r), "RETURN id(r)"),
+			Arguments.of(idOfRel, "RETURN id(r)"),
 			Arguments.of(Functions.elementId(n), "RETURN toString(id(n))"),
 			Arguments.of(Functions.elementId(r), "RETURN toString(id(r))"),
 			Arguments.of(Functions.keys(n), "RETURN keys(n)"),

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/IssueRelatedIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/IssueRelatedIT.java
@@ -109,7 +109,7 @@ class IssueRelatedIT {
 		final Relationship aFl = app.relationshipFrom(locStart, "PART_OF").length(0, 3);
 		final Relationship lFr = locStart.relationshipFrom(resume, "IN", "IN_ANALYTICS");
 
-		Statement statement = Cypher.match(aFl, lFr)
+		@SuppressWarnings("deprecation") Statement statement = Cypher.match(aFl, lFr)
 			.withDistinct(resume, locStart, app)
 			.match(resume
 				.relationshipTo(offer.withProperties("is_valid", Cypher.literalTrue()), "IN_COHORT_OF")
@@ -1396,7 +1396,7 @@ class IssueRelatedIT {
 
 		Operation removeOp = Operations.remove(node, "Drink");
 		List<Expression> propertyExpressions = Collections.singletonList(removeOp);
-		StatementBuilder.OngoingReadingWithWhere ongoingReadingWithWhere = Cypher.match(node)
+		@SuppressWarnings("deprecation") StatementBuilder.OngoingReadingWithWhere ongoingReadingWithWhere = Cypher.match(node)
 			.where(Functions.id(node).isEqualTo(Cypher.literalOf(1)));
 
 		String expectedMessage = "REMOVE operations are not supported in a SET clause";
@@ -1412,7 +1412,7 @@ class IssueRelatedIT {
 			.isThrownBy(() -> Cypher.match(node).set(removeOp))
 			.withMessage(expectedMessage);
 
-		String correctQuery = ongoingReadingWithWhere
+		@SuppressWarnings("deprecation") String correctQuery = ongoingReadingWithWhere
 			.remove(node, "Drink")
 			.returning(Functions.id(node).as("id"))
 			.build()

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/ToStringSmokeTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/ToStringSmokeTest.java
@@ -40,7 +40,7 @@ class ToStringSmokeTest {
 			Arguments.of(Cypher.node("Person").named("n"), "(n:Person)"),
 			Arguments.of(Cypher.node("Person").named("p").relationshipTo(Cypher.node("Movie").named("m"), "PLAYED_IN").named("r"), "(p:Person)-[r:PLAYED_IN]->(m:Movie)"),
 			Arguments.of(Cypher.node("Person").named("p").relationshipTo(Cypher.node("Movie").named("m"), "PLAYED_IN").named("r").relationshipFrom(Cypher.node("Person").named("d"), "DIRECTED"), "(p:Person)-[r:PLAYED_IN]->(m:Movie)<-[:DIRECTED]-(d:Person)"),
-			Arguments.of(Functions.id(Cypher.anyNode("n")), "id(n)"),
+			Arguments.of(Functions.elementId(Cypher.anyNode("n")), "elementId(n)"),
 			Arguments.of(Cypher.call("db.labels").asFunction(), "db.labels()"),
 			Arguments.of(Cypher.literalOf("aString"), "'aString'"),
 			Arguments.of(Cypher.literalOf(1), "1"),


### PR DESCRIPTION
While we don’t have any plans to remove it in 2023, deprecating it makes it easier for downstream projects to find usages. An OpenRewrite recipe for your applications to alloww easy rewriting of those calls has been made available in `etc/recipes/rewrite.yml`
