### PR TITLE
refactor: Use sorted sets everywhere to keep orders of identifiables in the catalog close to users expectations.

### DIFF
--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementCatalogBuildingVisitor.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementCatalogBuildingVisitor.java
@@ -24,6 +24,8 @@ import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -70,13 +72,13 @@ class StatementCatalogBuildingVisitor extends ReflectiveVisitor {
 	 */
 	private final Deque<PatternElement> currentPatternElement = new ArrayDeque<>();
 
-	private final Set<Token> tokens = new HashSet<>();
+	private final Set<Token> tokens = new LinkedHashSet<>();
 
-	private final Set<StatementCatalog.Property> properties = new HashSet<>();
+	private final Set<StatementCatalog.Property> properties = new LinkedHashSet<>();
 
-	private final Set<StatementCatalog.LabelFilter> labelFilters = new HashSet<>();
+	private final Set<StatementCatalog.LabelFilter> labelFilters = new LinkedHashSet<>();
 
-	private final Map<StatementCatalog.Property, Set<PropertyFilter>> propertyFilters = new HashMap<>();
+	private final Map<StatementCatalog.Property, Set<PropertyFilter>> propertyFilters = new LinkedHashMap<>();
 
 	/**
 	 * Scoped lookup tables from symbolic name to pattern elements (nodes or relationships).
@@ -557,18 +559,18 @@ class StatementCatalogBuildingVisitor extends ReflectiveVisitor {
 			ParameterInformation parameterInformation,
 			Map<Token, Relationships> relationships
 		) {
-			this.tokens = Set.copyOf(tokens);
-			this.labelFilters = Set.copyOf(labelFilters);
+			this.tokens = Collections.unmodifiableSet(tokens);
+			this.labelFilters = Collections.unmodifiableSet(labelFilters);
 
-			this.properties = Set.copyOf(properties);
+			this.properties = Collections.unmodifiableSet(properties);
 			this.propertyFilters = propertyFilters.entrySet().stream()
-				.collect(Collectors.collectingAndThen(Collectors.toMap(Map.Entry::getKey, e -> Set.copyOf(e.getValue())), Map::copyOf));
+				.collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> Collections.unmodifiableSet(e.getValue())));
 
-			this.identifiableExpressions = Set.copyOf(identifiableExpressions);
+			this.identifiableExpressions = identifiableExpressions instanceof Set<Expression> s ? Collections.unmodifiableSet(s) : Set.copyOf(identifiableExpressions);
 			this.parameterInformation = parameterInformation;
 
 			this.relationships = relationships.entrySet().stream()
-				.collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().copy()));
+				.collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> e.getValue().copy()));
 		}
 
 		@Override

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/ScopingStrategy.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/internal/ScopingStrategy.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -113,7 +114,7 @@ public final class ScopingStrategy {
 	private final List<BiConsumer<Visitable, Collection<IdentifiableElement>>> onScopeLeft = new ArrayList<>();
 
 	private ScopingStrategy() {
-		this.dequeOfVisitedNamed.push(new HashSet<>());
+		this.dequeOfVisitedNamed.push(new LinkedHashSet<>());
 	}
 
 	/**
@@ -150,12 +151,12 @@ public final class ScopingStrategy {
 		Set<IdentifiableElement> scopeSeed = dequeOfVisitedNamed.isEmpty() ? Collections.emptySet() : dequeOfVisitedNamed.peek();
 		if (hasLocalScope(visitable)) {
 			notify = true;
-			dequeOfVisitedNamed.push(new HashSet<>(scopeSeed));
+			dequeOfVisitedNamed.push(new LinkedHashSet<>(scopeSeed));
 		}
 
 		if (hasImplicitScope(visitable)) {
 			notify = true;
-			implicitScope.push(new HashSet<>(scopeSeed));
+			implicitScope.push(new LinkedHashSet<>(scopeSeed));
 		}
 
 		if (notify) {
@@ -238,9 +239,9 @@ public final class ScopingStrategy {
 		// We keep properties only around when they have been actually returned
 		if (!(previous instanceof Return || previous instanceof YieldItems)) {
 			this.afterStatement = lastScope.stream().filter(i -> !(i instanceof Property))
-				.collect(Collectors.toSet());
+				.collect(Collectors.toCollection(LinkedHashSet::new));
 		} else {
-			this.afterStatement = new HashSet<>(lastScope);
+			this.afterStatement = new LinkedHashSet<>(lastScope);
 		}
 
 		// A procedure call doesn't change scope.
@@ -395,7 +396,7 @@ public final class ScopingStrategy {
 			.stream()
 			.filter(allNamedElementsHaveResolvedNames)
 			.map(IdentifiableElement::asExpression)
-			.collect(Collectors.collectingAndThen(Collectors.toSet(), Collections::unmodifiableSet));
+			.collect(Collectors.collectingAndThen(Collectors.toCollection(LinkedHashSet::new), Collections::unmodifiableSet));
 	}
 
 	/**


### PR DESCRIPTION
Closes #731.
