### PR TITLE
feat: Provide all functions in the `graph.*` namespaces.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,7 @@
 :artifactId: neo4j-cypher-dsl
 
 // This will be next version and also the one that will be put into the manual for the main branch
-:neo4j-cypher-dsl-version: 2023.3.3-SNAPSHOT
+:neo4j-cypher-dsl-version: 2023.4.0-SNAPSHOT
 // This is the latest released version, used only in the readme
 :neo4j-cypher-dsl-version-latest: 2023.3.2
 

--- a/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/Options.java
+++ b/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/Options.java
@@ -223,7 +223,7 @@ public final class Options {
 		 *
 		 * @param newParameterValues A new lookup table. Use an empty map or {@literal null} to clear any lookups in the config
 		 * @return This builder
-		 * @since 2023.3.3
+		 * @since 2023.4.0
 		 */
 		public Builder withParameterValues(Map<String, Object> newParameterValues) {
 			this.parameterValues = newParameterValues == null ? Map.of() : Map.copyOf(newParameterValues);

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/BuiltInFunctions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/BuiltInFunctions.java
@@ -52,6 +52,24 @@ final class BuiltInFunctions {
 		}
 	}
 
+	enum Graph implements FunctionDefinition {
+
+		NAMES("names"),
+		PROPERTIES_BY_NAME("propertiesByName"),
+		BY_NAME("byName");
+
+		private final String implementationName;
+
+		Graph(String implementationName) {
+			this.implementationName = "graph." + implementationName;
+		}
+
+		@Override
+		public String getImplementationName() {
+			return implementationName;
+		}
+	}
+
 	enum Scalars implements FunctionDefinition {
 
 		COALESCE("coalesce"),

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
@@ -1264,14 +1264,15 @@ public final class Cypher {
 
 	/**
 	 * Decorates the given statement by prepending a dynamic {@literal USE} clause. A dynamic {@literal USE} clause will
-	 * utilize {@code graph.byName} to resolve the target database.
+	 * utilize {@code graph.byName} to resolve the target database unless {@link Functions#graphByName(Expression)} has
+	 * already been used.
 	 *
 	 * @param target    The name of a variable pointing to the graph or constituent
 	 * @param statement The statement to decorate
 	 * @return The new buildable statement
 	 * @since 2023.0.0
 	 */
-	public static UseStatement use(SymbolicName target, Statement statement) {
+	public static UseStatement use(Expression target, Statement statement) {
 		return DecoratedQuery.decorate(statement, UseClauseImpl.of(target));
 	}
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
@@ -1264,13 +1264,29 @@ public final class Cypher {
 
 	/**
 	 * Decorates the given statement by prepending a dynamic {@literal USE} clause. A dynamic {@literal USE} clause will
+	 * utilize {@code graph.byName} to resolve the target database.
+	 *
+	 * @param target    The name of a variable pointing to the graph or constituent
+	 * @param statement The statement to decorate
+	 * @return The new buildable statement
+	 * @since 2023.0.0
+	 * @deprecated Use {@link #use(Expression, Statement)}
+	 */
+	@Deprecated(forRemoval = true, since = "2023.3.3")
+	@SuppressWarnings({"squid:S1133"}) // Yes, I promise, this will be removed at some point, but not yet.
+	public static UseStatement use(SymbolicName target, Statement statement) {
+		return use((Expression) target, statement);
+	}
+
+	/**
+	 * Decorates the given statement by prepending a dynamic {@literal USE} clause. A dynamic {@literal USE} clause will
 	 * utilize {@code graph.byName} to resolve the target database unless {@link Functions#graphByName(Expression)} has
 	 * already been used.
 	 *
 	 * @param target    The name of a variable pointing to the graph or constituent
 	 * @param statement The statement to decorate
 	 * @return The new buildable statement
-	 * @since 2023.0.0
+	 * @since 2023.3.3
 	 */
 	public static UseStatement use(Expression target, Statement statement) {
 		return DecoratedQuery.decorate(statement, UseClauseImpl.of(target));

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
@@ -1272,7 +1272,7 @@ public final class Cypher {
 	 * @since 2023.0.0
 	 * @deprecated Use {@link #use(Expression, Statement)}
 	 */
-	@Deprecated(forRemoval = true, since = "2023.3.3")
+	@Deprecated(forRemoval = true, since = "2023.4.0")
 	@SuppressWarnings({"squid:S1133"}) // Yes, I promise, this will be removed at some point, but not yet.
 	public static UseStatement use(SymbolicName target, Statement statement) {
 		return use((Expression) target, statement);
@@ -1286,7 +1286,7 @@ public final class Cypher {
 	 * @param target    The name of a variable pointing to the graph or constituent
 	 * @param statement The statement to decorate
 	 * @return The new buildable statement
-	 * @since 2023.3.3
+	 * @since 2023.4.0
 	 */
 	public static UseStatement use(Expression target, Statement statement) {
 		return DecoratedQuery.decorate(statement, UseClauseImpl.of(target));

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Functions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Functions.java
@@ -2166,7 +2166,7 @@ public final class Functions {
 	}
 
 	/**
-	 * Creates a function invocation for {@code length{}}.
+	 * Creates a function invocation for {@code length()}.
 	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/scalar/#functions-length">length</a>.
 	 *
 	 * @param path The path for which the length should be retrieved
@@ -2180,6 +2180,54 @@ public final class Functions {
 		return FunctionInvocation.create(Scalars.LENGTH,
 			path.getSymbolicName().orElseThrow(() -> new IllegalArgumentException(Cypher.MESSAGES.getString(MessageKeys.ASSERTIONS_NAMED_PATH_REQUIRED))));
 	}
+
+	/**
+	 * Creates a function invocation for {@code graph.names()}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/graph/#functions-graph-names">graph.names</a>.
+	 *
+	 * @return A function call for {@code graph.names()}.
+	 * @since 2023.3.3
+	 */
+	@NotNull
+	@Contract(pure = true)
+	@Neo4jVersion(minimum = "5.0.0")
+	public static FunctionInvocation graphNames() {
+
+		return FunctionInvocation.create(BuiltInFunctions.Graph.NAMES);
+	}
+
+	/**
+	 * Creates a function invocation for {@code graph.propertiesByName()}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/graph/#functions-graph-propertiesByName">graph.propertiesByName</a>.
+	 *
+	 * @param name The name of the graph
+	 * @return A function call for {@code graph.propertiesByName()}.
+	 * @since 2023.3.3
+	 */
+	@NotNull
+	@Contract(pure = true)
+	@Neo4jVersion(minimum = "5.0.0")
+	public static FunctionInvocation graphPropertiesByName(Expression name) {
+
+		return FunctionInvocation.create(BuiltInFunctions.Graph.PROPERTIES_BY_NAME, name);
+	}
+
+	/**
+	 * Creates a function invocation for {@code graph.byName()}.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/graph/#functions-graph-byname">graph.byName</a>.
+	 *
+	 * @param name The name of the graph
+	 * @return A function call for {@code graph.byName()}.
+	 * @since 2023.3.3
+	 */
+	@NotNull
+	@Contract(pure = true)
+	@Neo4jVersion(minimum = "5.0.0")
+	public static FunctionInvocation graphByName(Expression name) {
+
+		return FunctionInvocation.create(BuiltInFunctions.Graph.BY_NAME, name);
+	}
+
 
 	private Functions() {
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Functions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Functions.java
@@ -2186,7 +2186,7 @@ public final class Functions {
 	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/graph/#functions-graph-names">graph.names</a>.
 	 *
 	 * @return A function call for {@code graph.names()}.
-	 * @since 2023.3.3
+	 * @since 2023.4.0
 	 */
 	@NotNull
 	@Contract(pure = true)
@@ -2202,7 +2202,7 @@ public final class Functions {
 	 *
 	 * @param name The name of the graph
 	 * @return A function call for {@code graph.propertiesByName()}.
-	 * @since 2023.3.3
+	 * @since 2023.4.0
 	 */
 	@NotNull
 	@Contract(pure = true)
@@ -2218,7 +2218,7 @@ public final class Functions {
 	 *
 	 * @param name The name of the graph
 	 * @return A function call for {@code graph.byName()}.
-	 * @since 2023.3.3
+	 * @since 2023.4.0
 	 */
 	@NotNull
 	@Contract(pure = true)

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/UseClauseImpl.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/UseClauseImpl.java
@@ -44,7 +44,7 @@ record UseClauseImpl(Expression target, boolean dynamic) implements Use {
 	}
 
 	static Use of(Expression target) {
-		return new UseClauseImpl(target, true);
+		return new UseClauseImpl(target, !(target instanceof FunctionInvocation fi) || !"graph.byName".equals(fi.getFunctionName()));
 	}
 
 	@Override

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/FunctionsTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/FunctionsTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import static org.mockito.Mockito.mock;
 
 import java.lang.reflect.Method;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Named;
@@ -94,9 +95,13 @@ class FunctionsTest {
 	@MethodSource("functionsToTest")
 	void functionInvocationsShouldBeCreated(Method method) {
 
+		var expectedValue = method.getName().replace("Distinct", "");
+		if (expectedValue.startsWith("graph")) {
+			expectedValue = "graph." + expectedValue.substring(5, 6).toLowerCase(Locale.ROOT) + expectedValue.substring(6);
+		}
+
 		FunctionInvocation invocation = (FunctionInvocation) TestUtils
 			.invokeMethod(method, null, mock(method.getParameterTypes()[0], Answers.RETURNS_DEEP_STUBS));
-		assertThat(invocation).hasFieldOrPropertyWithValue(FUNCTION_NAME_FIELD,
-			method.getName().replace("Distinct", ""));
+		assertThat(invocation).hasFieldOrPropertyWithValue(FUNCTION_NAME_FIELD, expectedValue);
 	}
 }

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/StatementCatalogBuildingVisitorTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/StatementCatalogBuildingVisitorTest.java
@@ -193,9 +193,8 @@ class StatementCatalogBuildingVisitorTest {
 			.build();
 
 		var graph_name = Cypher.name("__graph__name__");
-		var graphNames = Cypher.raw("graph.names()");
-		var statement = Cypher.unwind(graphNames).as(graph_name)
-			.call(Cypher.use(graph_name, innerStatement))
+		var statement = Cypher.unwind(Functions.graphNames()).as(graph_name)
+			.call(Cypher.use(Functions.graphByName(graph_name), innerStatement))
 			.returning(innerStatement.getCatalog().getIdentifiableExpressions())
 			.build();
 

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/UseIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/UseIT.java
@@ -96,7 +96,7 @@ class UseIT {
 		var innerStatement = Cypher.match(Cypher.node("Movie").named("movie")).returning("movie").build();
 		var cypher = Cypher.unwind(Cypher.literalOf(List.of("cineasts.latest", "cineasts.upcoming")))
 			.as("graphName")
-			.call(Cypher.use(Cypher.name("graphName"), innerStatement))
+			.call(Cypher.use((Expression) Cypher.name("graphName"), innerStatement))
 			.returning(Cypher.name("movie").property("title").as("title")).build().getCypher();
 		assertThat(cypher).isEqualTo(expected);
 	}


### PR DESCRIPTION
Also allow possible usecases of `graph.byName` in `Cypher.use`.

CLoses #728.
