### PR TITLE
fix: Use unmodifiable maps instead of copyOf to allow `null` parameters.

### DIFF
--- a/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/Options.java
+++ b/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/Options.java
@@ -23,7 +23,9 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -257,7 +259,7 @@ public final class Options {
 		 * @since 2023.4.0
 		 */
 		public Builder withParameterValues(Map<String, Object> newParameterValues) {
-			this.parameterValues = newParameterValues == null ? Map.of() : Map.copyOf(newParameterValues);
+			this.parameterValues = newParameterValues == null ? Map.of() : Collections.unmodifiableMap(new HashMap<>(newParameterValues));
 			return this;
 		}
 

--- a/neo4j-cypher-dsl-parser/src/test/java/org/neo4j/cypherdsl/parser/OptionsTest.java
+++ b/neo4j-cypher-dsl-parser/src/test/java/org/neo4j/cypherdsl/parser/OptionsTest.java
@@ -20,7 +20,10 @@
 package org.neo4j.cypherdsl.parser;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.UnaryOperator;
 
 import org.junit.jupiter.api.Test;
@@ -45,5 +48,13 @@ class OptionsTest {
 		assertThat(options.getOnNewPatternElementCallbacks())
 			.containsKey(PatternElementCreatedEventType.ON_CREATE);
 		assertThat(options.getOnNewPatternElementCallbacks().get(PatternElementCreatedEventType.ON_CREATE)).hasSize(2);
+	}
+
+	@Test // GH-785
+	void optionsMustAllowNullParameterValues() {
+		Map<String, Object> wurst = new HashMap<>();
+		wurst.put("salat", null);
+		var builder = Options.newOptions();
+		assertThatNoException().isThrownBy(() -> builder.withParameterValues(wurst));
 	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementCatalog.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementCatalog.java
@@ -20,6 +20,7 @@ package org.neo4j.cypherdsl.core;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
@@ -433,7 +434,7 @@ public sealed interface StatementCatalog permits StatementCatalogBuildingVisitor
 		 */
 		public PropertyFilter {
 			parameterNames = Set.copyOf(parameterNames);
-			parameters = Map.copyOf(parameters);
+			parameters = Collections.unmodifiableMap(new HashMap<>(parameters));
 		}
 	}
 

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/StatementCatalogBuildingVisitorTest.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/StatementCatalogBuildingVisitorTest.java
@@ -251,4 +251,13 @@ class StatementCatalogBuildingVisitorTest {
 				}
 				RETURN n, r, m""");
 	}
+
+	@Test // GH-785
+	void nullParametersMustBeAllowed() {
+
+		var statement = Cypher.match(Cypher.anyNode("n")).where(Cypher.property("n", "whatever").isEqualTo(Cypher.parameter("foo", null))).returning(Cypher.asterisk()).build();
+		assertThat(statement.getCypher()).isEqualTo("MATCH (n) WHERE n.whatever = $foo RETURN *");
+		assertThat(statement.getCatalog().getParameters())
+			.containsEntry("foo", null);
+	}
 }


### PR DESCRIPTION
Fixes #785
