### PR TITLE
build: Remove explicit management of bytebuddy.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '17', '19' ]
+        java: [ '17', '21' ]
     needs: build
     steps:
       - name: Determine revision

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/FunctionsIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/FunctionsIT.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Locale;
-import java.util.Optional;
 import java.util.TimeZone;
 import java.util.stream.Stream;
 
@@ -34,7 +33,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mockito;
 import org.neo4j.cypherdsl.core.renderer.Configuration;
 import org.neo4j.cypherdsl.core.renderer.Dialect;
 import org.neo4j.cypherdsl.core.renderer.Renderer;
@@ -196,17 +194,6 @@ class FunctionsIT {
 	void neo5jSpecificFunctionsShouldWork(FunctionInvocation functionInvocation, String expected) {
 		Renderer renderer = Renderer.getRenderer(Configuration.newConfig().withDialect(Dialect.NEO4J_5).build());
 		assertThat(renderer.render(Cypher.returning(functionInvocation).build())).isEqualTo(expected);
-	}
-
-	@Test
-	void errorMessagesShouldWorkForNamedPath() {
-
-		var path = Mockito.spy(Cypher.path("x").definedBy(Cypher.node("Movie").relationshipTo(Cypher.node("Person"))));
-		Mockito.when(path.getSymbolicName()).thenReturn(Optional.empty());
-		var expectedMessages = "The path needs to be named!";
-		assertThatIllegalArgumentException().isThrownBy(() -> Functions.length(path)).withMessage(expectedMessages);
-		assertThatIllegalArgumentException().isThrownBy(() -> Functions.nodes(path)).withMessage(expectedMessages);
-		assertThatIllegalArgumentException().isThrownBy(() -> Functions.relationships(path)).withMessage(expectedMessages);
 	}
 
 	@Test

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,6 @@
 		<asm.version>9.6</asm.version>
 		<assertj.version>3.24.2</assertj.version>
 		<auto-common.version>0.11</auto-common.version>
-		<byte-buddy.version>1.14.9</byte-buddy.version>
 		<cglib.version>3.3.0</cglib.version>
 		<changelist>-SNAPSHOT</changelist>
 		<checker-qual.version>3.39.0</checker-qual.version>
@@ -336,13 +335,6 @@
 				<groupId>io.projectreactor</groupId>
 				<artifactId>reactor-bom</artifactId>
 				<version>${reactor.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>net.bytebuddy</groupId>
-				<artifactId>byte-buddy-parent</artifactId>
-				<version>${byte-buddy.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
The Maven Site plugin fails on that. But doing so, brings us back to a Non-JDK-21 compliant version which in turn then doesn't let us do inline mocks proper.
