### PR TITLE
feat: Add support for predicates inside pattern elements.

### DIFF
--- a/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/NodeAtom.java
+++ b/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/NodeAtom.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.cypherdsl.parser;
 
-import org.neo4j.cypherdsl.core.Expression;
 import org.neo4j.cypherdsl.core.Node;
 import org.neo4j.cypherdsl.core.PatternElement;
 
@@ -28,8 +27,7 @@ import org.neo4j.cypherdsl.core.PatternElement;
  *
  * @author Michael J. Simons
  * @param value The actual node
- * @param predicate An optional predicate to capture node pattern predicates.
  * @since 2023.0.0
  */
-record NodeAtom(Node value, Expression predicate) implements PatternAtom, PatternElement {
+record NodeAtom(Node value) implements PatternAtom, PatternElement {
 }

--- a/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/PathAtom.java
+++ b/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/PathAtom.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.cypherdsl.parser;
 
+import org.neo4j.cypherdsl.core.Expression;
 import org.neo4j.cypherdsl.core.MapExpression;
 import org.neo4j.cypherdsl.core.Relationship.Direction;
 import org.neo4j.cypherdsl.core.SymbolicName;
@@ -33,7 +34,7 @@ import org.neo4j.cypherdsl.core.SymbolicName;
 final class PathAtom implements PatternAtom {
 
 	static PathAtom of(SymbolicName name, PathLength length, boolean left, boolean right,
-		String[] relTypes, MapExpression properties, boolean negatedType) {
+		String[] relTypes, MapExpression properties, boolean negatedType, Expression predicate) {
 
 		if (left && right) {
 			throw new IllegalArgumentException("Only left-to-right, right-to-left or unidirectional path elements are supported.");
@@ -48,7 +49,7 @@ final class PathAtom implements PatternAtom {
 			direction = Direction.UNI;
 		}
 
-		return new PathAtom(name, length, direction, negatedType, relTypes, properties);
+		return new PathAtom(name, length, direction, negatedType, relTypes, properties, predicate);
 	}
 
 	private final SymbolicName name;
@@ -63,14 +64,17 @@ final class PathAtom implements PatternAtom {
 
 	private final MapExpression properties;
 
+	private final Expression predicate;
+
 	private PathAtom(SymbolicName name, PathLength length, Direction direction, boolean negatedType, String[] types,
-		MapExpression properties) {
+		MapExpression properties, Expression predicate) {
 		this.name = name;
 		this.length = length;
 		this.direction = direction;
 		this.negatedType = negatedType;
 		this.types = types;
 		this.properties = properties;
+		this.predicate = predicate;
 	}
 
 	public PathLength getLength() {
@@ -95,5 +99,9 @@ final class PathAtom implements PatternAtom {
 
 	public SymbolicName getName() {
 		return name;
+	}
+
+	public Expression getPredicate() {
+		return predicate;
 	}
 }

--- a/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/PathAtom.java
+++ b/neo4j-cypher-dsl-parser/src/main/java/org/neo4j/cypherdsl/parser/PathAtom.java
@@ -33,6 +33,7 @@ import org.neo4j.cypherdsl.core.SymbolicName;
  */
 final class PathAtom implements PatternAtom {
 
+	@SuppressWarnings("squid:S107") // Totally fine with that number of args for this internal API.
 	static PathAtom of(SymbolicName name, PathLength length, boolean left, boolean right,
 		String[] relTypes, MapExpression properties, boolean negatedType, Expression predicate) {
 

--- a/neo4j-cypher-dsl-parser/src/test/java/org/neo4j/cypherdsl/parser/CypherParserTest.java
+++ b/neo4j-cypher-dsl-parser/src/test/java/org/neo4j/cypherdsl/parser/CypherParserTest.java
@@ -462,10 +462,10 @@ class CypherParserTest {
 
 	@ParameterizedTest
 	@CsvSource(textBlock = """
-		MATCH (n:Person WHERE n.name = 'Tom Hanks') RETURN n,MATCH (n:Person) WHERE n.name = 'Tom Hanks' RETURN n
-		MATCH (n:Person WHERE n.name = 'Tom Hanks' OR n.name = 'Bud Spencer') RETURN n,MATCH (n:Person) WHERE (n.name = 'Tom Hanks' OR n.name = 'Bud Spencer') RETURN n
-		MATCH (n:Person WHERE n.name = 'Tom Hanks') WHERE n.born <= 2000 RETURN n,MATCH (n:Person) WHERE (n.born <= 2000 AND n.name = 'Tom Hanks') RETURN n
-		MATCH (n:Person WHERE n.name = 'Tom Hanks' OR n.name = 'Bud Spencer') WHERE n.born <= 2000 RETURN n,MATCH (n:Person) WHERE (n.born <= 2000 AND (n.name = 'Tom Hanks' OR n.name = 'Bud Spencer')) RETURN n
+		MATCH (n:Person WHERE n.name = 'Tom Hanks') RETURN n,MATCH (n:Person WHERE n.name = 'Tom Hanks') RETURN n
+		MATCH (n:Person WHERE n.name = 'Tom Hanks' OR n.name = 'Bud Spencer') RETURN n,MATCH (n:Person WHERE (n.name = 'Tom Hanks' OR n.name = 'Bud Spencer')) RETURN n
+		MATCH (n:Person WHERE n.name = 'Tom Hanks') WHERE n.born <= 2000 RETURN n,MATCH (n:Person WHERE n.name = 'Tom Hanks') WHERE n.born <= 2000 RETURN n
+		MATCH (n:Person WHERE n.name = 'Tom Hanks' OR n.name = 'Bud Spencer') WHERE n.born <= 2000 RETURN n,MATCH (n:Person WHERE (n.name = 'Tom Hanks' OR n.name = 'Bud Spencer')) WHERE n.born <= 2000 RETURN n
 		""")
 	void whereInMatch(String statement, String expected) {
 

--- a/neo4j-cypher-dsl-parser/src/test/java/org/neo4j/cypherdsl/parser/QPPTest.java
+++ b/neo4j-cypher-dsl-parser/src/test/java/org/neo4j/cypherdsl/parser/QPPTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypherdsl.parser;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class QPPTest {
+
+
+	@ParameterizedTest
+	@CsvSource(delimiterString = "%%", textBlock = """
+		MATCH (n:(TrainStation&BusStation)|StationGroup)      %% MATCH (n:`TrainStation`&`BusStation`|`StationGroup`)
+		MATCH (n:Station WHERE n.name STARTS WITH 'Preston')  %% MATCH (n:`Station` WHERE n.name STARTS WITH 'Preston')
+		MATCH (n)-[{ distance: 0.24, duration: 'PT4M' }]->(m) %% MATCH (n)-[ {distance: 0.24, duration: 'PT4M'}]->(m)
+		MATCH (n)-[r WHERE time() + duration(r.duration) < time('22:00') ]->(m) %% MATCH (n)-[r WHERE (time() + duration(r.duration)) < time('22:00')]->(m)
+		""")
+	void parsingAndRenderingOfQPPShouldWork(String input, String expected) {
+		System.out.println(CypherParser.parse(input).getCypher());
+		Assertions.assertThat(CypherParser.parse(input).getCypher()).isEqualTo(expected.trim());
+	}
+}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
@@ -138,7 +138,7 @@ public final class Cypher {
 	 */
 	@NotNull @Contract(pure = true)
 	public static Node node(LabelExpression labelExpression) {
-		return new InternalNodeImpl(Objects.requireNonNull(labelExpression));
+		return new InternalNodeImpl(Objects.requireNonNull(labelExpression), null);
 	}
 
 	/**

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesProperties.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesProperties.java
@@ -34,7 +34,7 @@ import org.jetbrains.annotations.NotNull;
 public interface ExposesProperties<T extends ExposesProperties<?> & PropertyContainer> {
 
 	/**
-	 * Creates a a copy of this property container with additional properties.
+	 * Creates a copy of this property container with additional properties.
 	 * Creates a property container without properties when no properties are passed to this method.
 	 *
 	 * @param newProperties the new properties (can be {@literal null} to remove exiting properties).
@@ -44,7 +44,7 @@ public interface ExposesProperties<T extends ExposesProperties<?> & PropertyCont
 	T withProperties(MapExpression newProperties);
 
 	/**
-	 * Creates a a copy of this property container with additional properties.
+	 * Creates a copy of this property container with additional properties.
 	 * Creates a property container without properties when no properties are passed to this method.
 	 *
 	 * @param keysAndValues A list of key and values. Must be an even number, with alternating {@link String} and {@link Expression}.
@@ -54,7 +54,7 @@ public interface ExposesProperties<T extends ExposesProperties<?> & PropertyCont
 	T withProperties(Object... keysAndValues);
 
 	/**
-	 * Creates a a copy of this property container with additional properties.
+	 * Creates a copy of this property container with additional properties.
 	 *
 	 * @param newProperties A map with the new properties
 	 * @return The new property container.

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/InternalNodeImpl.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/InternalNodeImpl.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.apiguardian.api.API;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.utils.Assertions;
 
 /**
@@ -40,16 +41,16 @@ final class InternalNodeImpl extends NodeBase<InternalNodeImpl> {
 	InternalNodeImpl() {
 	}
 
-	InternalNodeImpl(LabelExpression labelExpression) {
-		super(null, null, labelExpression, null);
+	InternalNodeImpl(LabelExpression labelExpression, Where innerPredicate) {
+		super(null, null, labelExpression, null, innerPredicate);
 	}
 
 	InternalNodeImpl(String primaryLabel, String... additionalLabels) {
 		super(primaryLabel, additionalLabels);
 	}
 
-	InternalNodeImpl(SymbolicName symbolicName, List<NodeLabel> labels, LabelExpression labelExpression, Properties properties) {
-		super(symbolicName, labels, labelExpression, properties);
+	InternalNodeImpl(SymbolicName symbolicName, List<NodeLabel> labels, LabelExpression labelExpression, Properties properties, Where innerPredicate) {
+		super(symbolicName, labels, labelExpression, properties, innerPredicate);
 	}
 
 	InternalNodeImpl(SymbolicName symbolicName, String primaryLabel,
@@ -62,7 +63,7 @@ final class InternalNodeImpl extends NodeBase<InternalNodeImpl> {
 	public InternalNodeImpl named(SymbolicName newSymbolicName) {
 
 		Assertions.notNull(newSymbolicName, "Symbolic name is required.");
-		return new InternalNodeImpl(newSymbolicName, labels, labelExpression, properties);
+		return new InternalNodeImpl(newSymbolicName, labels, labelExpression, properties, innerPredicate);
 
 	}
 
@@ -70,6 +71,17 @@ final class InternalNodeImpl extends NodeBase<InternalNodeImpl> {
 	@Override
 	public InternalNodeImpl withProperties(MapExpression newProperties) {
 
-		return new InternalNodeImpl(this.getSymbolicName().orElse(null), labels, labelExpression, Properties.create(newProperties));
+		return new InternalNodeImpl(this.getSymbolicName().orElse(null), labels, labelExpression, Properties.create(newProperties), innerPredicate);
+	}
+
+	@NotNull
+	@Override
+	public Node where(@Nullable Expression predicate) {
+		if (predicate == null) {
+			return this;
+		}
+
+		return new InternalNodeImpl(this.getSymbolicName().orElse(null), labels, labelExpression, properties,
+			Where.from(predicate));
 	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Node.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Node.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.apiguardian.api.API;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * See <a href="https://s3.amazonaws.com/artifacts.opencypher.org/M15/railroad/NodePattern.html">NodePattern</a>.
@@ -150,4 +151,16 @@ public interface Node extends PatternElement, PropertyContainer, ExposesProperti
 	 */
 	@NotNull @Contract(pure = true)
 	FunctionInvocation labels();
+
+	/**
+	 * Creates a new {@link Node node pattern} which including an additional filter. Returns {@code this} node when
+	 * {@code predicate} is literal {@code null}
+	 * @param predicate the predicate to filter on
+	 * @return a new node or this instance if the predicate to this method was literal {@code null}
+	 * @since 2023.9.0
+	 */
+	@NotNull @Contract(pure = true)
+	default Node where(@Nullable Expression predicate) {
+		throw new UnsupportedOperationException();
+	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NodeBase.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NodeBase.java
@@ -43,6 +43,7 @@ import org.neo4j.cypherdsl.core.utils.Assertions;
  * @since 2021.1.0
  */
 @API(status = STABLE, since = "2021.1.0")
+@SuppressWarnings("deprecation") // IDEA is stupid.
 public abstract class NodeBase<SELF extends Node> extends AbstractNode implements Node {
 
 	@SuppressWarnings("squid:S3077") // Symbolic name is unmodifiable
@@ -53,6 +54,8 @@ public abstract class NodeBase<SELF extends Node> extends AbstractNode implement
 	final LabelExpression labelExpression;
 
 	final Properties properties;
+
+	final Where innerPredicate;
 
 	// ------------------------------------------------------------------------
 	// Public API to be used by the static meta model.
@@ -79,7 +82,7 @@ public abstract class NodeBase<SELF extends Node> extends AbstractNode implement
 	 */
 	protected NodeBase(SymbolicName symbolicName, List<NodeLabel> labels, Properties properties) {
 
-		this(symbolicName, new ArrayList<>(labels), null, properties);
+		this(symbolicName, new ArrayList<>(labels), null, properties, null);
 	}
 
 	@Override
@@ -183,12 +186,13 @@ public abstract class NodeBase<SELF extends Node> extends AbstractNode implement
 		this(symbolicName, assertLabels(primaryLabel, additionalLabels), Properties.create(properties));
 	}
 
-	NodeBase(SymbolicName symbolicName, List<NodeLabel> labels, LabelExpression labelExpression, Properties properties) {
+	NodeBase(SymbolicName symbolicName, List<NodeLabel> labels, LabelExpression labelExpression, Properties properties, Where innerPredicate) {
 
 		this.symbolicName = symbolicName;
 		this.labels = labels;
 		this.labelExpression = labelExpression;
 		this.properties = properties;
+		this.innerPredicate = innerPredicate;
 	}
 
 	@Override
@@ -201,6 +205,7 @@ public abstract class NodeBase<SELF extends Node> extends AbstractNode implement
 		}
 		Visitable.visitIfNotNull(this.labelExpression, visitor);
 		Visitable.visitIfNotNull(this.properties, visitor);
+		Visitable.visitIfNotNull(this.innerPredicate, visitor);
 		visitor.leave(this);
 	}
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipBase.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipBase.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 
 import org.apiguardian.api.API;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.ast.Visitor;
 import org.neo4j.cypherdsl.core.internal.RelationshipPatternCondition;
 import org.neo4j.cypherdsl.core.utils.Assertions;
@@ -288,5 +289,10 @@ public abstract class RelationshipBase<S extends NodeBase<?>, E extends NodeBase
 	@Override
 	public String toString() {
 		return RendererBridge.render(this);
+	}
+
+	@Override
+	public @NotNull Relationship where(@Nullable Expression predicate) {
+		return new InternalRelationshipImpl(this.left, this.details.where(predicate), this.right);
 	}
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipChain.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/RelationshipChain.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.apiguardian.api.API;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.ast.Visitor;
 import org.neo4j.cypherdsl.core.internal.RelationshipPatternCondition;
@@ -122,6 +123,20 @@ public final class RelationshipChain implements RelationshipPattern, ExposesPatt
 
 		Relationship lastElement = this.relationships.getLast();
 		return this.replaceLast(lastElement.named(newSymbolicName));
+	}
+
+	/**
+	 * Replaces the last element of this chains with a copy of the relationship if {@code predicate} was not {@literal null}
+	 *
+	 * @param predicate the predicate to the last element of the chain
+	 * @return A new chain
+	 * @since 2023.9.0
+	 */
+	@NotNull @Contract(pure = true)
+	public RelationshipChain where(@Nullable Expression predicate) {
+
+		Relationship lastElement = this.relationships.getLast();
+		return this.replaceLast(lastElement.where(predicate));
 	}
 
 	/**

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/CypherIT.java
@@ -5029,4 +5029,26 @@ class CypherIT {
 					RETURN node""");
 		}
 	}
+
+	// GH-858
+	@Nested
+	class ConditionalPatterns {
+
+		@Test
+		void nodesWithWhere() {
+
+			var node = Cypher.node("Movie").withProperties(Map.of("title", "The Matrix")).named("n");
+			var cypher = Cypher.match(node.where(node.property("released").eq(Cypher.literalOf(1999)))).returning(node).build().getCypher();
+			assertThat(cypher).isEqualTo("MATCH (n:`Movie` {title: 'The Matrix'} WHERE n.released = 1999) RETURN n");
+		}
+
+		@Test
+		void relationshipsWithWhere() {
+
+			var node = Cypher.node("Movie").withProperties(Map.of("title", "The Matrix")).named("n");
+			var actor = Cypher.node("Actor");
+			var cypher = Cypher.match(node.relationshipFrom(actor, "ACTED_IN").named("r").where(Cypher.property("r", "role").eq(Cypher.literalOf("Neo4j")))).returning(Cypher.asterisk()).build().getCypher();
+			assertThat(cypher).isEqualTo("MATCH (n:`Movie` {title: 'The Matrix'})<-[r:`ACTED_IN` WHERE r.role = 'Neo4j']-(:`Actor`) RETURN *");
+		}
+	}
 }


### PR DESCRIPTION
This allows `where` to be used on `Node` and `Relationship`.
While it closes #858 it is merely the groundwork to support parsing QPP.
