### PR TITLE
fix: Driving symbolic names for list predicate function must not be scoped.

### DIFF
--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/BuiltInFunctions.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/BuiltInFunctions.java
@@ -23,7 +23,7 @@ import org.apiguardian.api.API.Status;
 import org.neo4j.cypherdsl.core.FunctionInvocation.FunctionDefinition;
 
 /**
- * A (non exhaustive) list of builtin functions.
+ * A (non-exhaustive) list of builtin functions.
  *
  * @author Michael J. Simons
  * @soundtrack Metallica - ReLoad

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
@@ -4009,7 +4009,7 @@ public final class Cypher {
 
 	/**
 	 * Starts building a new condition based on a function invocation for the {@code single()} function.
-	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/predicate/#functions-single">exists</a>.
+	 * See <a href="https://neo4j.com/docs/cypher-manual/current/functions/predicate/#functions-single">single</a>.
 	 *
 	 * @param variable The variable referring to elements of a list
 	 * @return A builder for the {@code single()} predicate function


### PR DESCRIPTION
Fixes #903.
