### PR TITLE
fix: Don’t introduce new names in pattern expressions.

### DIFF
--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/books/Book.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/books/Book.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2019-2024 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.examples.sdn6.books;
+
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+
+/**
+ * @author Michael J. Simons
+ */
+@Node
+public class Book {
+	@Id @GeneratedValue String id;
+
+	private String lang;
+}

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/books/BookGenre.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/books/BookGenre.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019-2024 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.examples.sdn6.books;
+
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+
+/**
+ * @author Michael J. Simons
+ */
+@Node
+public class BookGenre {
+	@Id @GeneratedValue String id;
+}

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/books/UserDetails.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/books/UserDetails.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019-2024 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.examples.sdn6.books;
+
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+
+/**
+ * @author Michael J. Simons
+ */
+@Node
+public class UserDetails {
+
+	@Id @GeneratedValue String id;
+}

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/books/UserPreferences.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/books/UserPreferences.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019-2024 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.examples.sdn6.books;
+
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+
+/**
+ * @author Michael J. Simons
+ */
+@Node
+public class UserPreferences {
+
+	@Id @GeneratedValue String id;
+
+	String userId;
+}

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/books/UserSuggestionActivity.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/books/UserSuggestionActivity.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019-2024 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.examples.sdn6.books;
+
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+
+/**
+ * @author Michael J. Simons
+ */
+@Node
+public class UserSuggestionActivity {
+
+	@Id @GeneratedValue String id;
+
+	String userId;
+}

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/books/package-info.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/main/java/org/neo4j/cypherdsl/examples/sdn6/books/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2019-2024 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * This package exists only to reproduce an issue, it is not a complete example.
+ */
+package org.neo4j.cypherdsl.examples.sdn6.books;

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/test/java/org/neo4j/cypherdsl/examples/sdn6/books/ScopingTest.java
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/src/test/java/org/neo4j/cypherdsl/examples/sdn6/books/ScopingTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2019-2024 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.examples.sdn6.books;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.neo4j.cypherdsl.core.Cypher;
+
+/**
+ * @author Michael J. Simons
+ */
+class ScopingTest {
+
+	@ParameterizedTest // GH-1014
+	@ValueSource(booleans = { true, false })
+	void patternExpressionMustNotIntroduceNames(boolean withIt) {
+
+		var userIdParam = Cypher.parameter("userId");
+		var limitParam = Cypher.parameter("limit");
+		var langParam = Cypher.parameter("lang");
+
+		var book = Book_.BOOK.withProperties(Book_.BOOK.LANG, langParam)
+			.named("book");
+
+		var userDetails =
+			UserDetails_.USER_DETAILS.withProperties(UserDetails_.USER_DETAILS.ID, userIdParam)
+				.named("user");
+		var userPreferences =
+			UserPreferences_.USER_PREFERENCES.withProperties(UserPreferences_.USER_PREFERENCES.USER_ID, userIdParam)
+				.named("preferences");
+		var genre = BookGenre_.BOOK_GENRE.named("genre");
+		var userActivity = UserSuggestionActivity_.USER_SUGGESTION_ACTIVITY.withProperties(
+			UserSuggestionActivity_.USER_SUGGESTION_ACTIVITY.USER_ID, userIdParam
+		).named("activity");
+
+		var relationBookGenre = book.relationshipTo(genre, "BELONGS_TO").named("rel");
+
+		var relationBookAvoidedGenre =
+			book.relationshipTo(BookGenre_.BOOK_GENRE, "BELONGS_TO").relationshipFrom(userPreferences, "AVOIDED");
+
+		var relationUserPreferencesGenreBook = userDetails
+			.relationshipTo(userPreferences, "HAS_PREFERENCES")
+			.relationshipTo(genre, "PREFERRED")
+			.relationshipFrom(book, "BELONGS_TO");
+
+		var returningBooks = Cypher.call("distinct").withArgs(Cypher.name("book")).asFunction();
+
+		// This is the correct variant, as shown in the latest code update on the issue, matching the activity first, then
+		// passing it on.
+		if (withIt) {
+			var statement = Cypher.match(
+					relationUserPreferencesGenreBook
+				).match(userDetails.relationshipTo(userActivity, "HAS_ACTIVITY"))
+				.where(Cypher.not(Cypher.exists(relationBookAvoidedGenre)))
+				.with(book, userActivity).limit(limitParam)
+				.match(relationBookGenre)
+				.where(Cypher.not(Cypher.exists(book.relationshipBetween(userActivity))))
+				.returning(
+					returningBooks, Cypher.collect(Cypher.name("rel")), Cypher.collect(genre)
+				)
+				.build();
+
+			assertThat(statement.getCypher())
+				.isEqualTo(
+					"MATCH (user:`UserDetails` {id: $userId})-[:`HAS_PREFERENCES`]->(preferences:`UserPreferences` {userId: $userId})-[:`PREFERRED`]->(genre:`BookGenre`)<-[:`BELONGS_TO`]-(book:`Book` {lang: $lang}) MATCH (user)-[:`HAS_ACTIVITY`]->(activity:`UserSuggestionActivity` {userId: $userId}) WHERE NOT (exists((book)-[:`BELONGS_TO`]->(:`BookGenre`)<-[:`AVOIDED`]-(preferences))) WITH book, activity LIMIT $limit MATCH (book)-[rel:`BELONGS_TO`]->(genre:`BookGenre`) WHERE NOT (exists((book)--(activity))) RETURN distinct(book), collect(rel), collect(genre)");
+
+		} else {
+			// Statement is identical, except the with clause. activity goes out of scope, hence in the existential subquery it will be rerendered.
+			// There however it must not include the name a new
+			var statement = Cypher.match(
+					relationUserPreferencesGenreBook
+				).match(userDetails.relationshipTo(userActivity, "HAS_ACTIVITY"))
+				.where(Cypher.not(Cypher.exists(relationBookAvoidedGenre)))
+				.with(book).limit(limitParam)
+				.match(relationBookGenre)
+				.where(Cypher.not(Cypher.exists(book.relationshipBetween(userActivity))))
+				.returning(
+					returningBooks, Cypher.collect(Cypher.name("rel")), Cypher.collect(genre)
+				)
+				.build();
+			assertThat(statement.getCypher())
+				.isEqualTo(
+					"MATCH (user:`UserDetails` {id: $userId})-[:`HAS_PREFERENCES`]->(preferences:`UserPreferences` {userId: $userId})-[:`PREFERRED`]->(genre:`BookGenre`)<-[:`BELONGS_TO`]-(book:`Book` {lang: $lang}) MATCH (user)-[:`HAS_ACTIVITY`]->(activity:`UserSuggestionActivity` {userId: $userId}) WHERE NOT (exists((book)-[:`BELONGS_TO`]->(:`BookGenre`)<-[:`AVOIDED`]-(preferences))) WITH book LIMIT $limit MATCH (book)-[rel:`BELONGS_TO`]->(genre:`BookGenre`) WHERE NOT (exists((book)--(:`UserSuggestionActivity` {userId: $userId}))) RETURN distinct(book), collect(rel), collect(genre)");
+		}
+	}
+}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NodeBase.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NodeBase.java
@@ -78,10 +78,9 @@ public abstract class NodeBase<SELF extends Node> extends AbstractNode implement
 	 *
 	 * @param symbolicName The symbolic name for this node object
 	 * @param labels The list of labels, no primary is given
-	 * @param properties A seto f properties
+	 * @param properties A set of properties
 	 */
 	protected NodeBase(SymbolicName symbolicName, List<NodeLabel> labels, Properties properties) {
-
 		this(symbolicName, new ArrayList<>(labels), null, properties, null);
 	}
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PatternExpression.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PatternExpression.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019-2024 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.core;
+
+/**
+ * A marker interface used for pattern appearing in {@code exists} or {@code size} statements.
+ * @author Michael J. Simons
+ * @since 2023.9.8
+ */
+public sealed interface PatternExpression permits PatternExpressionImpl {
+}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PatternExpressionImpl.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/PatternExpressionImpl.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019-2024 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.core;
+
+import java.util.List;
+
+import org.neo4j.cypherdsl.core.ast.Visitable;
+import org.neo4j.cypherdsl.core.ast.Visitor;
+
+final class PatternExpressionImpl implements PatternExpression, Visitable {
+
+	private final Pattern pattern;
+
+	PatternExpressionImpl(PatternElement patternElement) {
+
+		this.pattern = Pattern.of(List.of(patternElement));
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+		visitor.enter(this);
+		this.pattern.accept(visitor);
+		visitor.leave(this);
+	}
+}

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/FunctionsIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/FunctionsIT.java
@@ -260,7 +260,7 @@ class FunctionsIT {
 			Arguments.of(Cypher.trim(e1), "RETURN trim(e1)"),
 			Arguments.of(Cypher.split(e1, Cypher.literalOf(",")), "RETURN split(e1, ',')"),
 			Arguments.of(Cypher.size(e1), "RETURN size(e1)"),
-			Arguments.of(Cypher.size(r), "RETURN size((n:`Node`)-[r]->(m:`Node2`))"),
+			Arguments.of(Cypher.size(r), "RETURN size((:`Node`)-[]->(:`Node2`))"),
 			Arguments.of(Cypher.exists(e1), "RETURN exists(e1)"),
 			Arguments.of(Cypher.distance(p1, p2),
 				"RETURN distance(point({latitude: 1, longitude: 2}), point({latitude: 3, longitude: 4}))"),

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/IssueRelatedIT.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/IssueRelatedIT.java
@@ -1985,6 +1985,50 @@ class IssueRelatedIT {
 			RETURN v1""");
 	}
 
+	@Test // GH-1014
+	void patternExpressionMustNotIntroduceNames() {
+
+		var userIdParam = Cypher.parameter("userId");
+
+		var book = Cypher.node("Book").named("b");
+		var userActivity = Cypher.node("UserSuggestionActivity")
+			.named("ua")
+			.withProperties("userId", userIdParam);
+
+
+		// ua has not been used before
+		var rel = book.relationshipBetween(userActivity);
+		var cypher = Cypher.match(book)
+			.where(Cypher.not(Cypher.exists(rel)))
+			.returning(Cypher.asterisk())
+			.build().getCypher();
+
+		assertThat(cypher).isEqualTo("MATCH (b:`Book`) WHERE NOT (exists((b)--(:`UserSuggestionActivity` {userId: $userId}))) RETURN *");
+
+		// b has not been used before
+		cypher = Cypher.match(userActivity)
+			.where(Cypher.not(Cypher.exists(rel)))
+			.returning(Cypher.asterisk())
+			.build().getCypher();
+
+		assertThat(cypher).isEqualTo("MATCH (ua:`UserSuggestionActivity` {userId: $userId}) WHERE NOT (exists((:`Book`)--(ua))) RETURN *");
+
+		// Both have been used before, example does not make much sense, but still
+		cypher = Cypher.match(book.relationshipFrom(userActivity, "WROTE"))
+			.where(Cypher.not(Cypher.exists(rel)))
+			.returning(Cypher.asterisk())
+			.build().getCypher();
+
+		assertThat(cypher).isEqualTo("MATCH (b:`Book`)<-[:`WROTE`]-(ua:`UserSuggestionActivity` {userId: $userId}) WHERE NOT (exists((b)--(ua))) RETURN *");
+
+		// All expressions
+		cypher = Cypher.match(book)
+			.returning(Cypher.size(rel))
+			.build().getCypher();
+
+		assertThat(cypher).isEqualTo("MATCH (b:`Book`) RETURN size((b)--(:`UserSuggestionActivity` {userId: $userId}))");
+	}
+
 	@Nested
 	class Chaining {
 


### PR DESCRIPTION
A marker interface has been introduced to check for pattern expressions. When a symbolic names needs to be rendered, it its checked if it has been already resolved when inside a pattern expressions. If so, it will be rendered as normal, otherwise it will be skipped.

Closes #1014
