### PR TITLE
feat: Add support for vector literals and the `SEARCH` clause.

### DIFF
--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/pom.xml
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/pom.xml
@@ -43,6 +43,11 @@
 			<groupId>org.neo4j</groupId>
 			<artifactId>neo4j-cypher-dsl-codegen-core</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.neo4j</groupId>
+			<artifactId>neo4j-cypher-dsl-parser</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 
 		<!-- SDN 6 annotation proc -->
 		<dependency>

--- a/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/pom.xml
+++ b/neo4j-cypher-dsl-codegen/neo4j-cypher-dsl-codegen-sdn6/pom.xml
@@ -43,11 +43,6 @@
 			<groupId>org.neo4j</groupId>
 			<artifactId>neo4j-cypher-dsl-codegen-core</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.neo4j</groupId>
-			<artifactId>neo4j-cypher-dsl-parser</artifactId>
-			<scope>runtime</scope>
-		</dependency>
 
 		<!-- SDN 6 annotation proc -->
 		<dependency>
@@ -57,6 +52,11 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-neo4j</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.neo4j</groupId>
+			<artifactId>neo4j-cypher-dsl-parser</artifactId>
+			<scope>runtime</scope>
 		</dependency>
 
 		<dependency>

--- a/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/pom.xml
+++ b/neo4j-cypher-dsl-examples/neo4j-cypher-dsl-examples-sdn6/pom.xml
@@ -80,6 +80,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-neo4j</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-restclient</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Clauses.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Clauses.java
@@ -61,7 +61,24 @@ public final class Clauses {
 	public static Clause match(boolean optional, List<PatternElement> patternElements, Where optionalWhere,
 			List<Hint> optionalHints) {
 
-		return new Match(optional, Pattern.of(patternElements), optionalWhere, optionalHints);
+		return match(optional, patternElements, null, optionalWhere, optionalHints);
+	}
+
+	/**
+	 * Builds a {@code MATCH} clause. The result can be safely cast to a {@link Match} if
+	 * needed.
+	 * @param optional should this be an optional match?
+	 * @param patternElements the pattern elements to match
+	 * @param optionalSearch an optional search clause
+	 * @param optionalWhere an optional where sub-clause
+	 * @param optionalHints optional hints to be used
+	 * @return an immutable match clause
+	 * @since 2025.3.0
+	 */
+	static Clause match(boolean optional, List<PatternElement> patternElements, Search optionalSearch,
+			Where optionalWhere, List<Hint> optionalHints) {
+
+		return new Match(optional, Pattern.of(patternElements), optionalSearch, optionalWhere, optionalHints);
 	}
 
 	/**

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/CountExpression.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/CountExpression.java
@@ -53,11 +53,11 @@ public final class CountExpression implements SubqueryExpression, ExposesWhere<E
 		var imports = optionalWith.imports();
 
 		if (imports != null && patternOrUnion instanceof Pattern pattern) {
-			this.fragments = List.of(new Match(false, pattern, innerWhere, null));
+			this.fragments = List.of(new Match(false, pattern, null, innerWhere, null));
 			this.innerWhere = null;
 		}
 		else if (imports != null && patternOrUnion instanceof Match match) {
-			this.fragments = List.of(new Match(false, match.pattern, innerWhere, null));
+			this.fragments = List.of(new Match(false, match.pattern, null, innerWhere, null));
 			this.innerWhere = null;
 		}
 		else {

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
@@ -3617,6 +3617,12 @@ public final class Cypher {
 		return VectorLiteral.of(elements);
 	}
 
+	/**
+	 * Creates a builder for the {@code SEARCH} clause.
+	 * @param name the name of the node or relationship to search
+	 * @return the builder entry point
+	 * @since 2025.3.0
+	 */
 	public static Search.SpecifyIndexName search(SymbolicName name) {
 		return new Search.Builder(name);
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Cypher.java
@@ -3557,4 +3557,68 @@ public final class Cypher {
 		return Predicates.single(variable);
 	}
 
+	/**
+	 * Creates an INTEGER8 vector.
+	 * @param elements the elements for the new vector
+	 * @return a new {@link VectorLiteral}
+	 * @since 2025.3.0
+	 */
+	public static VectorLiteral vector(byte[] elements) {
+		return VectorLiteral.of(elements);
+	}
+
+	/**
+	 * Creates an INTEGER16 vector.
+	 * @param elements the elements for the new vector
+	 * @return a new {@link VectorLiteral}
+	 * @since 2025.3.0
+	 */
+	public static VectorLiteral vector(short[] elements) {
+		return VectorLiteral.of(elements);
+	}
+
+	/**
+	 * Creates an INTEGER32 vector.
+	 * @param elements the elements for the new vector
+	 * @return a new {@link VectorLiteral}
+	 * @since 2025.3.0
+	 */
+	public static VectorLiteral vector(int[] elements) {
+		return VectorLiteral.of(elements);
+	}
+
+	/**
+	 * Creates an INTEGER vector.
+	 * @param elements the elements for the new vector
+	 * @return a new {@link VectorLiteral}
+	 * @since 2025.3.0
+	 */
+	public static VectorLiteral vector(long[] elements) {
+		return VectorLiteral.of(elements);
+	}
+
+	/**
+	 * Creates an FLOAT32 vector.
+	 * @param elements the elements for the new vector
+	 * @return a new {@link VectorLiteral}
+	 * @since 2025.3.0
+	 */
+	public static VectorLiteral vector(float[] elements) {
+		return VectorLiteral.of(elements);
+	}
+
+	/**
+	 * Creates an FLOAT vector.
+	 * @param elements the elements for the new vector
+	 * @return a new {@link VectorLiteral}
+	 * @since 2025.3.0
+	 */
+	public static VectorLiteral vector(double[] elements) {
+		return VectorLiteral.of(elements);
+	}
+
+	public static Search.SpecifyIndexName search(SymbolicName name) {
+		return new Search.Builder(name);
+	}
+
 }

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DefaultStatementBuilder.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/DefaultStatementBuilder.java
@@ -36,6 +36,7 @@ import org.neo4j.cypherdsl.core.StatementBuilder.OngoingMatchAndUpdate;
 import org.neo4j.cypherdsl.core.StatementBuilder.OngoingMerge;
 import org.neo4j.cypherdsl.core.StatementBuilder.OngoingReadingWithWhere;
 import org.neo4j.cypherdsl.core.StatementBuilder.OngoingReadingWithoutWhere;
+import org.neo4j.cypherdsl.core.StatementBuilder.OngoingReadingWithoutWhereWithSearch;
 import org.neo4j.cypherdsl.core.StatementBuilder.OngoingUpdate;
 import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.internal.ProcedureName;
@@ -54,8 +55,9 @@ import static org.apiguardian.api.API.Status.INTERNAL;
  */
 @API(status = INTERNAL, since = "2021.2.1")
 class DefaultStatementBuilder implements StatementBuilder, OngoingUpdate, OngoingMerge, OngoingReadingWithWhere,
-		OngoingReadingWithoutWhere, OngoingMatchAndUpdate, BuildableMatchAndUpdate, BuildableOngoingMergeAction,
-		ExposesSubqueryCall.BuildableSubquery, StatementBuilder.VoidCall, StatementBuilder.Terminal {
+		OngoingReadingWithoutWhere, OngoingReadingWithoutWhereWithSearch, OngoingMatchAndUpdate,
+		BuildableMatchAndUpdate, BuildableOngoingMergeAction, ExposesSubqueryCall.BuildableSubquery,
+		StatementBuilder.VoidCall, StatementBuilder.Terminal {
 
 	private static final EnumSet<UpdateType> MERGE_OR_CREATE = EnumSet.of(UpdateType.CREATE, UpdateType.MERGE);
 
@@ -513,6 +515,15 @@ class DefaultStatementBuilder implements StatementBuilder, OngoingUpdate, Ongoin
 	}
 
 	@Override
+	public final OngoingReadingWithoutWhereWithSearch search(Search search) {
+		if (this.currentOngoingMatch == null) {
+			throw new IllegalStateException("No current match");
+		}
+		this.currentOngoingMatch.search = search;
+		return this;
+	}
+
+	@Override
 	public final OngoingReadingWithWhere and(Condition additionalCondition) {
 
 		this.currentOngoingMatch.conditionBuilder.and(additionalCondition);
@@ -823,6 +834,8 @@ class DefaultStatementBuilder implements StatementBuilder, OngoingUpdate, Ongoin
 
 		private final List<Hint> hints = new ArrayList<>();
 
+		private Search search;
+
 		private final ConditionBuilder conditionBuilder = new ConditionBuilder();
 
 		private final boolean optional;
@@ -832,7 +845,7 @@ class DefaultStatementBuilder implements StatementBuilder, OngoingUpdate, Ongoin
 		}
 
 		Match buildMatch() {
-			return (Match) Clauses.match(this.optional, this.patternList,
+			return (Match) Clauses.match(this.optional, this.patternList, this.search,
 					Where.from(this.conditionBuilder.buildCondition().orElse(null)), this.hints);
 		}
 

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesSearch.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/ExposesSearch.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2019-2026 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.core;
+
+import org.apiguardian.api.API;
+
+import static org.apiguardian.api.API.Status.STABLE;
+
+/**
+ * A step that allows to specify a {@code SEARCH} clause after a {@code MATCH} clause. See
+ * {@link Cypher#search(SymbolicName)} for defining such a clause.
+ *
+ * @author Michael J. Simons
+ * @since 2025.3.0
+ */
+@API(status = STABLE, since = "2025.3.0")
+public interface ExposesSearch {
+
+	/**
+	 * Adds a search clause to a match.
+	 * @param search the search clause
+	 * @return the ongoing reading
+	 */
+	StatementBuilder.OngoingReadingWithoutWhereWithSearch search(Search search);
+
+}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Match.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Match.java
@@ -49,11 +49,14 @@ public final class Match extends AbstractClause implements ReadingClause {
 	 */
 	private final List<Hint> hints;
 
+	private final Search optionalSearch;
+
 	private final Where optionalWhere;
 
-	Match(boolean optional, Pattern pattern, Where optionalWhere, List<Hint> optionalHints) {
+	Match(boolean optional, Pattern pattern, Search optionalSearch, Where optionalWhere, List<Hint> optionalHints) {
 		this.optional = optional;
 		this.pattern = pattern;
+		this.optionalSearch = optionalSearch;
 		this.optionalWhere = optionalWhere;
 		this.hints = (optionalHints != null) ? new ArrayList<>(optionalHints) : Collections.emptyList();
 	}
@@ -72,6 +75,7 @@ public final class Match extends AbstractClause implements ReadingClause {
 		visitor.enter(this);
 		this.pattern.accept(visitor);
 		this.hints.forEach(value -> value.accept(visitor));
+		Visitable.visitIfNotNull(this.optionalSearch, visitor);
 		Visitable.visitIfNotNull(this.optionalWhere, visitor);
 		visitor.leave(this);
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Search.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Search.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright (c) 2019-2026 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.core;
+
+import java.util.Objects;
+
+import org.apiguardian.api.API;
+import org.neo4j.cypherdsl.core.ast.Visitable;
+import org.neo4j.cypherdsl.core.ast.Visitor;
+
+import static org.apiguardian.api.API.Status.INTERNAL;
+import static org.apiguardian.api.API.Status.STABLE;
+
+/**
+ * See <a href= "https://neo4j.com/docs/cypher-manual/current/clauses/search/">SEARCH</a>.
+ *
+ * @author Michael J. Simons
+ * @since 2025.3.0
+ */
+@API(status = STABLE, since = "2025.3.0")
+public final class Search implements Visitable, Clause {
+
+	private final SymbolicName name;
+
+	private final VectorIndexClause vectorIndexClause;
+
+	private final ForClause forClause;
+
+	private final TopKClause topKClause;
+
+	private final Where where;
+
+	private final SymbolicName scoreAlias;
+
+	private Search(Builder builder) {
+		this.name = builder.name;
+		this.vectorIndexClause = new VectorIndexClause(builder.indexName);
+		this.forClause = new ForClause(builder.vector);
+		this.topKClause = new TopKClause(builder.topK);
+		if (builder.where != null) {
+			this.where = new Where(builder.where);
+		}
+		else {
+			this.where = null;
+		}
+		this.scoreAlias = builder.scoreAlias;
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+		visitor.enter(this);
+		this.vectorIndexClause.accept(visitor);
+		this.forClause.accept(visitor);
+		Visitable.visitIfNotNull(this.where, visitor);
+		this.topKClause.accept(visitor);
+		visitor.leave(this);
+	}
+
+	@Override
+	public String toString() {
+		return RendererBridge.render(this);
+	}
+
+	@API(status = INTERNAL)
+	public SymbolicName getName() {
+		return this.name;
+	}
+
+	@API(status = INTERNAL)
+	public SymbolicName getScoreAlias() {
+		return this.scoreAlias;
+	}
+
+	/**
+	 * Step specifying the index name.
+	 */
+	public interface SpecifyIndexName {
+
+		/**
+		 * Specifies the index name.
+		 * @param indexName required index name
+		 * @return the next step
+		 */
+		SpecifyVector in(String indexName);
+
+	}
+
+	public interface SpecifyVector {
+
+		/**
+		 * Specifies the vector a vector as literal.
+		 * @param vector the vector to search with
+		 * @return the next step
+		 */
+		SpecifyWhereOrLimit forVector(Expression vector);
+
+	}
+
+	/**
+	 * Final step building the {@link Search} clause.
+	 */
+	public interface Buildable {
+
+		/**
+		 * {@return the ready to use search clause}
+		 */
+		Search build();
+
+	}
+
+	/**
+	 * The optional WHERE subclause used to do vector search with filters is a restricted
+	 * version of the normal Cypher WHERE clause and only allows certain types of
+	 * predicates. The predicates must only be property predicates.
+	 */
+	public interface SpecifyWhere {
+
+		/**
+		 * Specify one or more property predicates. All predicates will be put together as
+		 * conjunction.
+		 * @param predicate a required predicate
+		 * @param more one or more optional more predicates
+		 * @return the next step
+		 */
+		SpecifyLimit where(Condition predicate, Condition... more);
+
+	}
+
+	/**
+	 * Required limit step.
+	 */
+	public interface SpecifyLimit {
+
+		/**
+		 * Specifies the limit.
+		 * @param topK the topK, required to be 0 &le; topK &le; 2147483647
+		 * @return the buildable search clause
+		 */
+		SpecifyScoreOrBuild limit(int topK);
+
+	}
+
+	/**
+	 * The union step of where and limit.
+	 */
+	public interface SpecifyWhereOrLimit extends SpecifyLimit, SpecifyWhere {
+
+	}
+
+	/**
+	 * The optional SCORE subclause makes the SEARCH clause return the similarity score
+	 * for each node or relationship in addition to the node or relationship itself. In
+	 * the result, the column for the similarity scores will be called score_alias.
+	 */
+	public interface SpecifyScoreOrBuild extends Buildable {
+
+		/**
+		 * Adds the score clause.
+		 * @param alias the alias to use
+		 * @return the buildable search clause
+		 */
+		Buildable score(SymbolicName alias);
+
+	}
+
+	@API(status = INTERNAL)
+	public static final class VectorIndexClause implements Visitable {
+
+		private final String name;
+
+		VectorIndexClause(String name) {
+			this.name = name;
+		}
+
+		@API(status = INTERNAL)
+		public String name() {
+			return this.name;
+		}
+
+	}
+
+	@API(status = INTERNAL)
+	public static final class ForClause implements Visitable {
+
+		private final Expression target;
+
+		private ForClause(Expression target) {
+			this.target = target;
+		}
+
+		@Override
+		public void accept(Visitor visitor) {
+			visitor.enter(this);
+			this.target.accept(visitor);
+			visitor.leave(this);
+		}
+
+	}
+
+	@API(status = INTERNAL)
+	public static final class TopKClause implements Visitable {
+
+		private final int value;
+
+		TopKClause(int value) {
+			this.value = value;
+		}
+
+		@API(status = INTERNAL)
+		public int value() {
+			return this.value;
+		}
+
+	}
+
+	static final class Builder implements SpecifyIndexName, SpecifyVector, SpecifyWhereOrLimit, SpecifyScoreOrBuild {
+
+		private final SymbolicName name;
+
+		private String indexName;
+
+		private Expression vector;
+
+		private Integer topK;
+
+		private Condition where;
+
+		private SymbolicName scoreAlias;
+
+		Builder(SymbolicName name) {
+			this.name = name;
+		}
+
+		static Condition assertCondition(Condition condition) {
+			if (!(Objects.requireNonNull(condition) instanceof Comparison)) {
+				throw new IllegalArgumentException("Only comparison conditions are supported");
+			}
+			return condition;
+		}
+
+		@Override
+		public SpecifyVector in(String indexName) {
+			this.indexName = indexName;
+			return this;
+		}
+
+		@Override
+		public SpecifyWhereOrLimit forVector(Expression vector) {
+			Objects.requireNonNull(vector);
+			if (!(vector instanceof VectorLiteral || vector instanceof ListLiteral || vector instanceof ListExpression
+					|| vector instanceof Parameter<?> || vector instanceof Property)) {
+				throw new IllegalArgumentException("Unsupported vector expression %s".formatted(vector.getClass()));
+			}
+			this.vector = vector;
+			return this;
+		}
+
+		@Override
+		public SpecifyScoreOrBuild limit(int topK) {
+			this.topK = topK;
+			return this;
+		}
+
+		@Override
+		public SpecifyLimit where(Condition predicate, Condition... more) {
+			var finalCondition = assertCondition(predicate);
+
+			if (more != null) {
+				for (var additional : more) {
+					finalCondition = finalCondition.and(assertCondition(additional));
+				}
+			}
+
+			this.where = finalCondition;
+			return this;
+		}
+
+		@Override
+		public Buildable score(SymbolicName alias) {
+			this.scoreAlias = alias;
+			return this;
+		}
+
+		@Override
+		public Search build() {
+			return new Search(this);
+		}
+
+	}
+
+}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Search.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Search.java
@@ -105,7 +105,7 @@ public final class Search implements Visitable, Clause {
 	public interface SpecifyVector {
 
 		/**
-		 * Specifies the vector a vector as literal.
+		 * Specifies the vector expression to search with.
 		 * @param vector the vector to search with
 		 * @return the next step
 		 */

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Search.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Search.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import org.apiguardian.api.API;
 import org.neo4j.cypherdsl.core.ast.Visitable;
 import org.neo4j.cypherdsl.core.ast.Visitor;
+import org.neo4j.cypherdsl.core.utils.Assertions;
 
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.apiguardian.api.API.Status.STABLE;
@@ -244,7 +245,7 @@ public final class Search implements Visitable, Clause {
 		private SymbolicName scoreAlias;
 
 		Builder(SymbolicName name) {
-			this.name = name;
+			this.name = Objects.requireNonNull(name, "Name is required");
 		}
 
 		static Condition assertCondition(Condition condition) {
@@ -256,6 +257,7 @@ public final class Search implements Visitable, Clause {
 
 		@Override
 		public SpecifyVector in(String indexName) {
+			Assertions.hasText(indexName, "The index name must not be null or empty");
 			this.indexName = indexName;
 			return this;
 		}
@@ -273,6 +275,9 @@ public final class Search implements Visitable, Clause {
 
 		@Override
 		public SpecifyScoreOrBuild limit(int topK) {
+			if (topK < 0) {
+				throw new IllegalArgumentException("topK must be greater than or equal to 0");
+			}
 			this.topK = topK;
 			return this;
 		}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementBuilder.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementBuilder.java
@@ -95,7 +95,7 @@ public interface StatementBuilder extends ExposesMatch, ExposesCreate, ExposesMe
 
 	/**
 	 * A match that exposes {@code returning} and {@code where} methods to add required
-	 * information. While the where clauses is optional, a returning clause needs to be
+	 * information. While the where clause is optional, a returning clause needs to be
 	 * specified before the statement can be built.
 	 *
 	 * @since 2025.3.0

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementBuilder.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/StatementBuilder.java
@@ -81,13 +81,26 @@ public interface StatementBuilder extends ExposesMatch, ExposesCreate, ExposesMe
 	}
 
 	/**
-	 * A match that exposes {@code returning} and {@code where} methods to add required
-	 * information. While the where clause is optional, a returning clause needs to be
-	 * specified before the statement can be built.
+	 * A match that exposes {@code returning}, {@code search} and {@code where} methods to
+	 * add required information. While the search and where clauses are optional, a
+	 * returning clause needs to be specified before the statement can be built.
 	 *
 	 * @since 1.0
 	 */
-	interface OngoingReadingWithoutWhere extends OngoingReading, ExposesHints,
+	interface OngoingReadingWithoutWhere
+			extends OngoingReading, ExposesHints, ExposesWhere<StatementBuilder.OngoingReadingWithWhere>, ExposesMatch,
+			ExposesExistentialSubqueryCall, ExposesSearch {
+
+	}
+
+	/**
+	 * A match that exposes {@code returning} and {@code where} methods to add required
+	 * information. While the where clauses is optional, a returning clause needs to be
+	 * specified before the statement can be built.
+	 *
+	 * @since 2025.3.0
+	 */
+	interface OngoingReadingWithoutWhereWithSearch extends OngoingReading, ExposesHints,
 			ExposesWhere<StatementBuilder.OngoingReadingWithWhere>, ExposesMatch, ExposesExistentialSubqueryCall {
 
 	}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/VectorLiteral.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/VectorLiteral.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2019-2026 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.core;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Vector;
+import java.util.stream.Collectors;
+
+/**
+ * See <a href=
+ * "https://neo4j.com/docs/cypher-manual/current/values-and-types/vector/">VECTOR</a>. The
+ * API is very much aligned with the Neo4j-JDBC driver.
+ *
+ * @author Michael J. Simons
+ * @since 2025.3.0
+ */
+public final class VectorLiteral implements Literal<List<? extends Number>> {
+
+	private static final String MSG_NULL_CHECK = "Vector elements must not be literal null";
+
+	/**
+	 * The maximum size of a vector property supported by Neo4j as of Neo4j 2026.05.
+	 */
+	private static final int MAX_VECTOR_SIZE = 4096;
+
+	private static void assertSize(int size) {
+
+		if (size <= 0 || (size > MAX_VECTOR_SIZE)) {
+			throw new IllegalArgumentException(
+					"'%d' is not a valid value. Must be a %s in the range %d to %d (GQL 42N31)".formatted(size,
+							"number", 1, MAX_VECTOR_SIZE));
+		}
+	}
+
+	/**
+	 * Creates a vector composed of {@link ElementType#INTEGER8}.
+	 * @param elements the elements for the new vector
+	 * @return a new {@link Vector}
+	 */
+	static VectorLiteral of(byte[] elements) {
+		assertSize(Objects.requireNonNull(elements, MSG_NULL_CHECK).length);
+		var content = new ArrayList<Byte>();
+		for (var element : elements) {
+			content.add(element);
+		}
+		return new VectorLiteral(ElementType.INTEGER8, content);
+	}
+
+	/**
+	 * Creates a vector composed of {@link ElementType#INTEGER16}.
+	 * @param elements the elements for the new vector
+	 * @return a new {@link Vector}
+	 */
+	static VectorLiteral of(short[] elements) {
+		assertSize(Objects.requireNonNull(elements, MSG_NULL_CHECK).length);
+		var content = new ArrayList<Short>();
+		for (var element : elements) {
+			content.add(element);
+		}
+		return new VectorLiteral(ElementType.INTEGER16, content);
+	}
+
+	/**
+	 * Creates a vector composed of {@link ElementType#INTEGER32}.
+	 * @param elements the elements for the new vector
+	 * @return a new {@link Vector}
+	 */
+	static VectorLiteral of(int[] elements) {
+		assertSize(Objects.requireNonNull(elements, MSG_NULL_CHECK).length);
+		return new VectorLiteral(ElementType.INTEGER32, Arrays.stream(elements).boxed().toList());
+	}
+
+	/**
+	 * Creates a vector composed of {@link ElementType#INTEGER}.
+	 * @param elements the elements for the new vector
+	 * @return a new {@link Vector}
+	 */
+	static VectorLiteral of(long[] elements) {
+		assertSize(Objects.requireNonNull(elements, MSG_NULL_CHECK).length);
+		return new VectorLiteral(ElementType.INTEGER, Arrays.stream(elements).boxed().toList());
+	}
+
+	/**
+	 * Creates a vector composed of {@link ElementType#FLOAT32}.
+	 * @param elements the elements for the new vector
+	 * @return a new {@link Vector}
+	 */
+	static VectorLiteral of(float[] elements) {
+		assertSize(Objects.requireNonNull(elements, MSG_NULL_CHECK).length);
+		var content = new ArrayList<Float>();
+		for (var element : elements) {
+			content.add(element);
+		}
+		return new VectorLiteral(ElementType.FLOAT32, content);
+	}
+
+	/**
+	 * Creates a vector composed of {@link ElementType#FLOAT}.
+	 * @param elements the elements for the new vector
+	 * @return a new {@link Vector}
+	 */
+	static VectorLiteral of(double[] elements) {
+		assertSize(Objects.requireNonNull(elements, MSG_NULL_CHECK).length);
+		return new VectorLiteral(ElementType.FLOAT, Arrays.stream(elements).boxed().toList());
+	}
+
+	private final ElementType type;
+
+	private final List<? extends Number> content;
+
+	private VectorLiteral(ElementType type, List<? extends Number> content) {
+		this.type = type;
+		this.content = content;
+	}
+
+	@Override
+	public String asString() {
+		var value = this.content.stream().map(Number::toString).collect(Collectors.joining(", ", "[", "]"));
+		return "vector(%s, %d, %s NOT NULL)".formatted(value, this.content.size(), this.type);
+	}
+
+	@Override
+	public List<? extends Number> getContent() {
+		return this.content;
+	}
+
+	private enum ElementType {
+
+		/**
+		 * Neo4j INTEGER8 type.
+		 */
+		INTEGER8,
+		/**
+		 * Neo4j INTEGER16 type.
+		 */
+		INTEGER16,
+		/**
+		 * Neo4j INTEGER32 type.
+		 */
+		INTEGER32,
+		/**
+		 * Neo4j INTEGER64 type (Cypher CIP-200 normalises INTEGER64 to INTEGER, and we
+		 * want the Cypher-DSL to be aligned here).
+		 */
+		INTEGER,
+		/**
+		 * Neo4j FLOAT32 type.
+		 */
+		FLOAT32,
+		/**
+		 * Neo4j FLOAT64 type (Cypher CIP-200 normalises FLOAT64 to FLOAT, and we want the
+		 * Cypher-DSL to be aligned here).
+		 */
+		FLOAT
+
+	}
+
+}

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/VectorLiteral.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/VectorLiteral.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.Vector;
 import java.util.stream.Collectors;
 
 /**
@@ -54,7 +53,7 @@ public final class VectorLiteral implements Literal<List<? extends Number>> {
 	/**
 	 * Creates a vector composed of {@link ElementType#INTEGER8}.
 	 * @param elements the elements for the new vector
-	 * @return a new {@link Vector}
+	 * @return a new {@link VectorLiteral}
 	 */
 	static VectorLiteral of(byte[] elements) {
 		assertSize(Objects.requireNonNull(elements, MSG_NULL_CHECK).length);
@@ -68,7 +67,7 @@ public final class VectorLiteral implements Literal<List<? extends Number>> {
 	/**
 	 * Creates a vector composed of {@link ElementType#INTEGER16}.
 	 * @param elements the elements for the new vector
-	 * @return a new {@link Vector}
+	 * @return a new {@link VectorLiteral}
 	 */
 	static VectorLiteral of(short[] elements) {
 		assertSize(Objects.requireNonNull(elements, MSG_NULL_CHECK).length);
@@ -82,7 +81,7 @@ public final class VectorLiteral implements Literal<List<? extends Number>> {
 	/**
 	 * Creates a vector composed of {@link ElementType#INTEGER32}.
 	 * @param elements the elements for the new vector
-	 * @return a new {@link Vector}
+	 * @return a new {@link VectorLiteral}
 	 */
 	static VectorLiteral of(int[] elements) {
 		assertSize(Objects.requireNonNull(elements, MSG_NULL_CHECK).length);
@@ -92,7 +91,7 @@ public final class VectorLiteral implements Literal<List<? extends Number>> {
 	/**
 	 * Creates a vector composed of {@link ElementType#INTEGER}.
 	 * @param elements the elements for the new vector
-	 * @return a new {@link Vector}
+	 * @return a new {@link VectorLiteral}
 	 */
 	static VectorLiteral of(long[] elements) {
 		assertSize(Objects.requireNonNull(elements, MSG_NULL_CHECK).length);
@@ -102,7 +101,7 @@ public final class VectorLiteral implements Literal<List<? extends Number>> {
 	/**
 	 * Creates a vector composed of {@link ElementType#FLOAT32}.
 	 * @param elements the elements for the new vector
-	 * @return a new {@link Vector}
+	 * @return a new {@link VectorLiteral}
 	 */
 	static VectorLiteral of(float[] elements) {
 		assertSize(Objects.requireNonNull(elements, MSG_NULL_CHECK).length);
@@ -116,7 +115,7 @@ public final class VectorLiteral implements Literal<List<? extends Number>> {
 	/**
 	 * Creates a vector composed of {@link ElementType#FLOAT}.
 	 * @param elements the elements for the new vector
-	 * @return a new {@link Vector}
+	 * @return a new {@link VectorLiteral}
 	 */
 	static VectorLiteral of(double[] elements) {
 		assertSize(Objects.requireNonNull(elements, MSG_NULL_CHECK).length);

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/DefaultVisitor.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/DefaultVisitor.java
@@ -72,6 +72,7 @@ import org.neo4j.cypherdsl.core.QuantifiedPathPattern;
 import org.neo4j.cypherdsl.core.Relationship;
 import org.neo4j.cypherdsl.core.Remove;
 import org.neo4j.cypherdsl.core.Return;
+import org.neo4j.cypherdsl.core.Search;
 import org.neo4j.cypherdsl.core.Set;
 import org.neo4j.cypherdsl.core.Skip;
 import org.neo4j.cypherdsl.core.SortItem;
@@ -1118,6 +1119,41 @@ class DefaultVisitor extends ReflectiveVisitor implements RenderingVisitor {
 	void enter(QuantifiedPathPattern.Quantifier quantifier) {
 
 		this.builder.append(quantifier.toString());
+	}
+
+	void enter(Search search) {
+		giveSpaceIfNeccessary();
+		this.builder.append("SEARCH ");
+		search.getName().accept(this);
+		this.builder.append(" IN (");
+	}
+
+	void enter(Search.VectorIndexClause vectorIndexClause) {
+		this.builder.append("VECTOR INDEX %s ".formatted(vectorIndexClause.name()));
+	}
+
+	void enter(Search.ForClause forClause) {
+		this.builder.append("FOR ");
+	}
+
+	void enter(Search.TopKClause topKClause) {
+		giveSpaceIfNeccessary();
+		this.builder.append("LIMIT %d".formatted(topKClause.value()));
+	}
+
+	private void giveSpaceIfNeccessary() {
+		var l = this.builder.length();
+		if (l != 0 && this.builder.charAt(l - 1) != ' ') {
+			this.builder.append(" ");
+		}
+	}
+
+	void leave(Search search) {
+		this.builder.append(")");
+		if (search.getScoreAlias() != null) {
+			this.builder.append(" SCORE AS ");
+			search.getScoreAlias().accept(this);
+		}
 	}
 
 	@Override

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/DefaultVisitor.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/DefaultVisitor.java
@@ -1122,14 +1122,14 @@ class DefaultVisitor extends ReflectiveVisitor implements RenderingVisitor {
 	}
 
 	void enter(Search search) {
-		giveSpaceIfNeccessary();
+		giveSpaceIfNecessary();
 		this.builder.append("SEARCH ");
 		search.getName().accept(this);
 		this.builder.append(" IN (");
 	}
 
 	void enter(Search.VectorIndexClause vectorIndexClause) {
-		this.builder.append("VECTOR INDEX %s ".formatted(vectorIndexClause.name()));
+		this.builder.append("VECTOR INDEX %s ".formatted(escapeIfNecessary(vectorIndexClause.name())));
 	}
 
 	void enter(Search.ForClause forClause) {
@@ -1137,11 +1137,11 @@ class DefaultVisitor extends ReflectiveVisitor implements RenderingVisitor {
 	}
 
 	void enter(Search.TopKClause topKClause) {
-		giveSpaceIfNeccessary();
+		giveSpaceIfNecessary();
 		this.builder.append("LIMIT %d".formatted(topKClause.value()));
 	}
 
-	private void giveSpaceIfNeccessary() {
+	private void giveSpaceIfNecessary() {
 		var l = this.builder.length();
 		if (l != 0 && this.builder.charAt(l - 1) != ' ') {
 			this.builder.append(" ");

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/PrettyPrintingVisitor.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/renderer/PrettyPrintingVisitor.java
@@ -32,6 +32,7 @@ import org.neo4j.cypherdsl.core.Operator;
 import org.neo4j.cypherdsl.core.Parameter;
 import org.neo4j.cypherdsl.core.PropertyLookup;
 import org.neo4j.cypherdsl.core.Return;
+import org.neo4j.cypherdsl.core.Search;
 import org.neo4j.cypherdsl.core.Set;
 import org.neo4j.cypherdsl.core.StatementContext;
 import org.neo4j.cypherdsl.core.Subquery;
@@ -66,6 +67,8 @@ class PrettyPrintingVisitor extends DefaultVisitor {
 
 	private boolean passedFirstReadingOrUpdatingClause;
 
+	private boolean inSearch;
+
 	PrettyPrintingVisitor(StatementContext statementContext, Configuration configuration) {
 		this(statementContext, false, configuration);
 	}
@@ -91,13 +94,22 @@ class PrettyPrintingVisitor extends DefaultVisitor {
 
 	@Override
 	void enter(Where where) {
-		if (this.currentVisitedElements.stream().noneMatch(Return.class::isInstance)) {
+		if (this.inSearch || this.currentVisitedElements.stream().noneMatch(Return.class::isInstance)) {
 			this.builder.append("\n");
+			if (this.inSearch) {
+				++this.indentationLevel;
+			}
 			indent(this.indentationLevel);
 			this.builder.append("WHERE ");
 		}
 		else {
 			super.enter(where);
+		}
+	}
+
+	void leave(Where where) {
+		if (this.inSearch) {
+			--this.indentationLevel;
 		}
 	}
 
@@ -313,6 +325,55 @@ class PrettyPrintingVisitor extends DefaultVisitor {
 		else {
 			super.enter(parameter);
 		}
+	}
+
+	@Override
+	void enter(Search search) {
+		this.inSearch = true;
+		trimNewline();
+		this.indent(++this.indentationLevel);
+		super.enter(search);
+	}
+
+	@Override
+	void enter(Search.VectorIndexClause vectorIndexClause) {
+		trimNewline();
+		this.indent(++this.indentationLevel);
+		super.enter(vectorIndexClause);
+	}
+
+	void leave(Search.VectorIndexClause vectorIndexClause) {
+		--this.indentationLevel;
+	}
+
+	@Override
+	void enter(Search.ForClause forClause) {
+		trimNewline();
+		this.indent(++this.indentationLevel);
+		super.enter(forClause);
+	}
+
+	void leave(Search.ForClause forClause) {
+		--this.indentationLevel;
+	}
+
+	@Override
+	void enter(Search.TopKClause topKClause) {
+		trimNewline();
+		this.indent(++this.indentationLevel);
+		super.enter(topKClause);
+	}
+
+	void leave(Search.TopKClause topKClause) {
+		--this.indentationLevel;
+	}
+
+	@Override
+	void leave(Search search) {
+		trimNewline();
+		this.indent(this.indentationLevel--);
+		super.leave(search);
+		this.inSearch = false;
 	}
 
 }

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/SearchTests.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/SearchTests.java
@@ -265,7 +265,7 @@ class SearchTests {
 		}
 
 		@Test
-		void vectorSearchWithFilterWithAnANDPredicateOnseparateProperties() {
+		void vectorSearchWithFilterWithAnAndPredicateOnSeparateProperties() {
 
 			var snowWhite = Cypher.node("Movie", Cypher.mapOf("title", Cypher.literalOf("Snow White")))
 				.named("snowWhite");

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/SearchTests.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/SearchTests.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright (c) 2019-2026 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.core;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.Parameter;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.neo4j.cypherdsl.core.renderer.Configuration;
+import org.neo4j.cypherdsl.core.renderer.Renderer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SearchTests {
+
+	static Stream<org.junit.jupiter.params.provider.Arguments> basicVectorSearchClause() {
+		return Stream.of(
+				org.junit.jupiter.params.provider.Arguments.of(Cypher.vector(new long[] { 1, 2, 3 }),
+						"vector([1, 2, 3], 3, INTEGER NOT NULL)"),
+				org.junit.jupiter.params.provider.Arguments.of(Cypher.literalOf(List.of(1, 2, 3)), "[1, 2, 3]"),
+				org.junit.jupiter.params.provider.Arguments
+					.of(Cypher.listOf(Cypher.literalOf(1), Cypher.literalOf(2), Cypher.literalOf(3)), "[1, 2, 3]"),
+				org.junit.jupiter.params.provider.Arguments.of(Cypher.parameter("snowWhiteEmbedding"),
+						"$snowWhiteEmbedding"),
+				org.junit.jupiter.params.provider.Arguments.of(Cypher.name("snowWhite").property("embedding"),
+						"snowWhite.embedding"),
+				Arguments.of(Cypher.node("Movie", Cypher.mapOf("title", Cypher.literalOf("Snow White")))
+					.named("snowWhite")
+					.property("embedding"), "snowWhite.embedding"));
+	}
+
+	@ParameterizedTest
+	@MethodSource
+	void basicVectorSearchClause(Expression vector, String vectorAsString) {
+
+		var movie = Cypher.name("movie");
+		var topK = 4;
+		var search = Cypher.search(movie).in("moviePlots").forVector(vector).limit(topK).build();
+		assertThat(search).hasToString("Search{cypher=SEARCH movie IN (VECTOR INDEX moviePlots FOR %s LIMIT 4)}",
+				vectorAsString);
+	}
+
+	@Test
+	void basicVectorSearchClauseWithScore() {
+
+		var movie = Cypher.name("movie");
+		var vector = Cypher.vector(new long[] { 1, 2, 3 });
+		var topK = 4;
+		var search = Cypher.search(movie)
+			.in("moviePlots")
+			.forVector(vector)
+			.limit(topK)
+			.score(Cypher.name("similarityScore"))
+			.build();
+		assertThat(search).hasToString(
+				"Search{cypher=SEARCH movie IN (VECTOR INDEX moviePlots FOR vector([1, 2, 3], 3, INTEGER NOT NULL) LIMIT 4) SCORE AS similarityScore}");
+	}
+
+	@Test
+	void vectorSearchWithFilters1() {
+		var movie = Cypher.name("movie");
+		var vector = Cypher.vector(new long[] { 1, 2, 3 });
+		var topK = 4;
+		var search = Cypher.search(movie)
+			.in("moviePlots")
+			.forVector(vector)
+			.where(movie.property("releaseDate").gt(Cypher.date("1990")))
+			.limit(topK)
+			.score(Cypher.name("similarityScore"))
+			.build();
+		assertThat(search).hasToString(
+				"Search{cypher=SEARCH movie IN (VECTOR INDEX moviePlots FOR vector([1, 2, 3], 3, INTEGER NOT NULL) WHERE movie.releaseDate > date('1990') LIMIT 4) SCORE AS similarityScore}");
+	}
+
+	@Test
+	void vectorSearchWithFilters2() {
+		var movie = Cypher.name("movie");
+		var vector = Cypher.vector(new long[] { 1, 2, 3 });
+		var topK = 4;
+		var search = Cypher.search(movie)
+			.in("moviePlots")
+			.forVector(vector)
+			.where(movie.property("releaseDate").gt(Cypher.date("1990")),
+					movie.property("title").startsWith(Cypher.literalOf("A")))
+			.limit(topK)
+			.score(Cypher.name("similarityScore"))
+			.build();
+		assertThat(search).hasToString(
+				"Search{cypher=SEARCH movie IN (VECTOR INDEX moviePlots FOR vector([1, 2, 3], 3, INTEGER NOT NULL) WHERE (movie.releaseDate > date('1990') AND movie.title STARTS WITH 'A') LIMIT 4) SCORE AS similarityScore}");
+	}
+
+	@Nested
+	@ParameterizedClass
+	@ValueSource(booleans = { true, false })
+	class FullExamples {
+
+		@Parameter
+		boolean prettyPrint;
+
+		@Test
+		void findTheMostSimilarNodesWithScore() {
+			var movie = Cypher.name("movie");
+			var similarityScore = Cypher.name("similarityScore");
+
+			var search = Cypher.search(movie)
+				.in("moviePlots")
+				.forVector(Cypher.vector(new long[] { 1, 2, 3 }))
+				.limit(4)
+				.score(similarityScore)
+				.build();
+
+			var stmt = Cypher.match(Cypher.node("Movie").named(movie))
+				.search(search)
+				.returning(movie.property("title").as("title"), similarityScore)
+				.build();
+
+			if (!this.prettyPrint) {
+				assertThat(stmt.getCypher()).isEqualTo(
+						"MATCH (movie:`Movie`) SEARCH movie IN (VECTOR INDEX moviePlots FOR vector([1, 2, 3], 3, INTEGER NOT NULL) LIMIT 4) SCORE AS similarityScore RETURN movie.title AS title, similarityScore");
+			}
+			else {
+				var expected = """
+						MATCH (movie:Movie)
+						  SEARCH movie IN (
+						    VECTOR INDEX moviePlots
+						    FOR vector([1, 2, 3], 3, INTEGER NOT NULL)
+						    LIMIT 4
+						  ) SCORE AS similarityScore
+						RETURN movie.title AS title, similarityScore""";
+				assertThat(Renderer.getRenderer(Configuration.prettyPrinting()).render(stmt)).isEqualTo(expected);
+			}
+		}
+
+		@Test
+		void vectorSearchWithFilters() {
+			var movie = Cypher.name("movie");
+
+			var search = Cypher.search(movie)
+				.in("moviePlots")
+				.forVector(Cypher.vector(new long[] { 1, 2, 3 }))
+				.where(movie.property("releaseDate").gt(Cypher.date("1990")))
+				.limit(4)
+				.build();
+
+			var stmt = Cypher.match(Cypher.node("Movie").named(movie))
+				.search(search)
+
+				.returning(movie.property("title").as("title"),
+						movie.property("releaseDate").property("year").as("year"))
+				.build();
+
+			if (this.prettyPrint) {
+				assertThat(stmt.getCypher()).isEqualTo(
+						"MATCH (movie:`Movie`) SEARCH movie IN (VECTOR INDEX moviePlots FOR vector([1, 2, 3], 3, INTEGER NOT NULL) WHERE movie.releaseDate > date('1990') LIMIT 4) RETURN movie.title AS title, movie.releaseDate.year AS year");
+			}
+			else {
+				var expected = """
+						MATCH (movie:Movie)
+						  SEARCH movie IN (
+						    VECTOR INDEX moviePlots
+						    FOR vector([1, 2, 3], 3, INTEGER NOT NULL)
+						    WHERE movie.releaseDate > date('1990')
+						    LIMIT 4
+						  )
+						RETURN movie.title AS title, movie.releaseDate.year AS year""";
+				assertThat(Renderer.getRenderer(Configuration.prettyPrinting()).render(stmt)).isEqualTo(expected);
+			}
+
+		}
+
+		@Test
+		void vectorSearchWithOuterFilters() {
+			var movie = Cypher.name("movie");
+
+			var search = Cypher.search(movie)
+				.in("moviePlots")
+				.forVector(Cypher.vector(new long[] { 1, 2, 3 }))
+				.limit(4)
+				.build();
+
+			var stmt = Cypher.match(Cypher.node("Movie").named(movie))
+				.search(search)
+				.where(movie.property("releaseDate").gt(Cypher.date("1990")))
+				.returning(movie.property("title").as("title"),
+						movie.property("releaseDate").property("year").as("year"))
+				.build();
+
+			if (this.prettyPrint) {
+				assertThat(stmt.getCypher()).isEqualTo(
+						"MATCH (movie:`Movie`) SEARCH movie IN (VECTOR INDEX moviePlots FOR vector([1, 2, 3], 3, INTEGER NOT NULL) LIMIT 4) WHERE movie.releaseDate > date('1990') RETURN movie.title AS title, movie.releaseDate.year AS year");
+			}
+			else {
+				var expected = """
+						MATCH (movie:Movie)
+						  SEARCH movie IN (
+						    VECTOR INDEX moviePlots
+						    FOR vector([1, 2, 3], 3, INTEGER NOT NULL)
+						    LIMIT 4
+						  )
+						WHERE movie.releaseDate > date('1990')
+						RETURN movie.title AS title, movie.releaseDate.year AS year""";
+				assertThat(Renderer.getRenderer(Configuration.prettyPrinting()).render(stmt)).isEqualTo(expected);
+			}
+
+		}
+
+		@Test
+		void vectorSearchWithFiltersAndWhereClause() {
+			var movie = Cypher.name("movie");
+
+			var search = Cypher.search(movie)
+				.in("moviePlots")
+				.forVector(Cypher.vector(new long[] { 1, 2, 3 }))
+				.where(movie.property("releaseDate").gt(Cypher.date("1990")))
+				.limit(4)
+				.build();
+
+			var stmt = Cypher.match(Cypher.node("Movie").named(movie))
+				.search(search)
+				.where(movie.property("rating").gt(Cypher.literalOf(7.5)))
+				.returning(movie.property("title").as("title"),
+						movie.property("releaseDate").property("year").as("year"))
+				.build();
+
+			if (this.prettyPrint) {
+				assertThat(stmt.getCypher()).isEqualTo(
+						"MATCH (movie:`Movie`) SEARCH movie IN (VECTOR INDEX moviePlots FOR vector([1, 2, 3], 3, INTEGER NOT NULL) WHERE movie.releaseDate > date('1990') LIMIT 4) WHERE movie.rating > 7.5 RETURN movie.title AS title, movie.releaseDate.year AS year");
+			}
+			else {
+				var expected = """
+						MATCH (movie:Movie)
+						  SEARCH movie IN (
+						    VECTOR INDEX moviePlots
+						    FOR vector([1, 2, 3], 3, INTEGER NOT NULL)
+						    WHERE movie.releaseDate > date('1990')
+						    LIMIT 4
+						  )
+						WHERE movie.rating > 7.5
+						RETURN movie.title AS title, movie.releaseDate.year AS year""";
+				assertThat(Renderer.getRenderer(Configuration.prettyPrinting()).render(stmt)).isEqualTo(expected);
+			}
+		}
+
+		@Test
+		void vectorSearchWithFilterWithAnANDPredicateOnseparateProperties() {
+
+			var snowWhite = Cypher.node("Movie", Cypher.mapOf("title", Cypher.literalOf("Snow White")))
+				.named("snowWhite");
+			var movie = Cypher.name("movie");
+
+			var search = Cypher.search(movie)
+				.in("moviePlots")
+				.forVector(snowWhite.property("embedding"))
+				.where(movie.property("releaseDate").lt(Cypher.date("2000")),
+						movie.property("rating").gte(snowWhite.property("rating")))
+				.limit(4)
+				.build();
+
+			var stmt = Cypher.match(snowWhite)
+				.match(Cypher.node("Movie").named(movie))
+				.search(search)
+				.returning(movie.property("title").as("title"),
+						movie.property("releaseDate").property("year").as("year"))
+				.build();
+
+			if (this.prettyPrint) {
+				assertThat(stmt.getCypher()).isEqualTo(
+						"MATCH (snowWhite:`Movie` {title: 'Snow White'}) MATCH (movie:`Movie`) SEARCH movie IN (VECTOR INDEX moviePlots FOR snowWhite.embedding WHERE (movie.releaseDate < date('2000') AND movie.rating >= snowWhite.rating) LIMIT 4) RETURN movie.title AS title, movie.releaseDate.year AS year");
+			}
+			else {
+				var expected = """
+						MATCH (snowWhite:Movie {
+						  title: 'Snow White'
+						})
+						MATCH (movie:Movie)
+						  SEARCH movie IN (
+						    VECTOR INDEX moviePlots
+						    FOR snowWhite.embedding
+						    WHERE (movie.releaseDate < date('2000')
+						      AND movie.rating >= snowWhite.rating)
+						    LIMIT 4
+						  )
+						RETURN movie.title AS title, movie.releaseDate.year AS year""";
+				assertThat(Renderer.getRenderer(Configuration.prettyPrinting()).render(stmt)).isEqualTo(expected);
+			}
+		}
+
+	}
+
+}

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/SearchTests.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/SearchTests.java
@@ -172,7 +172,7 @@ class SearchTests {
 						movie.property("releaseDate").property("year").as("year"))
 				.build();
 
-			if (this.prettyPrint) {
+			if (!this.prettyPrint) {
 				assertThat(stmt.getCypher()).isEqualTo(
 						"MATCH (movie:`Movie`) SEARCH movie IN (VECTOR INDEX moviePlots FOR vector([1, 2, 3], 3, INTEGER NOT NULL) WHERE movie.releaseDate > date('1990') LIMIT 4) RETURN movie.title AS title, movie.releaseDate.year AS year");
 			}
@@ -208,7 +208,7 @@ class SearchTests {
 						movie.property("releaseDate").property("year").as("year"))
 				.build();
 
-			if (this.prettyPrint) {
+			if (!this.prettyPrint) {
 				assertThat(stmt.getCypher()).isEqualTo(
 						"MATCH (movie:`Movie`) SEARCH movie IN (VECTOR INDEX moviePlots FOR vector([1, 2, 3], 3, INTEGER NOT NULL) LIMIT 4) WHERE movie.releaseDate > date('1990') RETURN movie.title AS title, movie.releaseDate.year AS year");
 			}
@@ -245,7 +245,7 @@ class SearchTests {
 						movie.property("releaseDate").property("year").as("year"))
 				.build();
 
-			if (this.prettyPrint) {
+			if (!this.prettyPrint) {
 				assertThat(stmt.getCypher()).isEqualTo(
 						"MATCH (movie:`Movie`) SEARCH movie IN (VECTOR INDEX moviePlots FOR vector([1, 2, 3], 3, INTEGER NOT NULL) WHERE movie.releaseDate > date('1990') LIMIT 4) WHERE movie.rating > 7.5 RETURN movie.title AS title, movie.releaseDate.year AS year");
 			}
@@ -286,7 +286,7 @@ class SearchTests {
 						movie.property("releaseDate").property("year").as("year"))
 				.build();
 
-			if (this.prettyPrint) {
+			if (!this.prettyPrint) {
 				assertThat(stmt.getCypher()).isEqualTo(
 						"MATCH (snowWhite:`Movie` {title: 'Snow White'}) MATCH (movie:`Movie`) SEARCH movie IN (VECTOR INDEX moviePlots FOR snowWhite.embedding WHERE (movie.releaseDate < date('2000') AND movie.rating >= snowWhite.rating) LIMIT 4) RETURN movie.title AS title, movie.releaseDate.year AS year");
 			}

--- a/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/VectorTests.java
+++ b/neo4j-cypher-dsl/src/test/java/org/neo4j/cypherdsl/core/VectorTests.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2019-2026 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypherdsl.core;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class VectorTests {
+
+	@Test
+	void integer8ShouldCheckNull() {
+		assertThatNullPointerException().isThrownBy(() -> VectorLiteral.of((byte[]) null))
+			.withMessage("Vector elements must not be literal null");
+	}
+
+	@Test
+	void integer8ShouldCheckMinSize() {
+		var elements = new byte[0];
+		assertThatIllegalArgumentException().isThrownBy(() -> VectorLiteral.of(elements))
+			.withMessage("'0' is not a valid value. Must be a number in the range 1 to 4096 (GQL 42N31)");
+	}
+
+	@Test
+	void integer8ShouldCheckMaxSize() {
+		var elements = new byte[5000];
+		assertThatIllegalArgumentException().isThrownBy(() -> VectorLiteral.of(elements))
+			.withMessage("'5000' is not a valid value. Must be a number in the range 1 to 4096 (GQL 42N31)");
+	}
+
+	@Test
+	void integer8ShouldWork() {
+		assertThat(VectorLiteral.of(new byte[] { 1, 2, 3 }).asString())
+			.isEqualTo("vector([1, 2, 3], 3, INTEGER8 NOT NULL)");
+	}
+
+	@Test
+	void integer16ShouldCheckNull() {
+		assertThatNullPointerException().isThrownBy(() -> VectorLiteral.of((short[]) null))
+			.withMessage("Vector elements must not be literal null");
+	}
+
+	@Test
+	void integer16ShouldCheckMinSize() {
+		var elements = new short[0];
+		assertThatIllegalArgumentException().isThrownBy(() -> VectorLiteral.of(elements))
+			.withMessage("'0' is not a valid value. Must be a number in the range 1 to 4096 (GQL 42N31)");
+	}
+
+	@Test
+	void integer16ShouldCheckMaxSize() {
+		var elements = new short[5000];
+		assertThatIllegalArgumentException().isThrownBy(() -> VectorLiteral.of(elements))
+			.withMessage("'5000' is not a valid value. Must be a number in the range 1 to 4096 (GQL 42N31)");
+	}
+
+	@Test
+	void integer16ShouldWork() {
+		assertThat(VectorLiteral.of(new short[] { 1, 2, 3 }).asString())
+			.isEqualTo("vector([1, 2, 3], 3, INTEGER16 NOT NULL)");
+	}
+
+	@Test
+	void integer32ShouldCheckNull() {
+		assertThatNullPointerException().isThrownBy(() -> VectorLiteral.of((int[]) null))
+			.withMessage("Vector elements must not be literal null");
+	}
+
+	@Test
+	void integer32ShouldCheckMinSize() {
+		var elements = new int[0];
+		assertThatIllegalArgumentException().isThrownBy(() -> VectorLiteral.of(elements))
+			.withMessage("'0' is not a valid value. Must be a number in the range 1 to 4096 (GQL 42N31)");
+	}
+
+	@Test
+	void integer32ShouldCheckMaxSize() {
+		var elements = new int[5000];
+		assertThatIllegalArgumentException().isThrownBy(() -> VectorLiteral.of(elements))
+			.withMessage("'5000' is not a valid value. Must be a number in the range 1 to 4096 (GQL 42N31)");
+	}
+
+	@Test
+	void integer32ShouldWork() {
+		assertThat(VectorLiteral.of(new int[] { 1, 2, 3 }).asString())
+			.isEqualTo("vector([1, 2, 3], 3, INTEGER32 NOT NULL)");
+	}
+
+	@Test
+	void integerShouldCheckNull() {
+		assertThatNullPointerException().isThrownBy(() -> VectorLiteral.of((long[]) null))
+			.withMessage("Vector elements must not be literal null");
+	}
+
+	@Test
+	void integerShouldCheckMinSize() {
+		var elements = new long[0];
+		assertThatIllegalArgumentException().isThrownBy(() -> VectorLiteral.of(elements))
+			.withMessage("'0' is not a valid value. Must be a number in the range 1 to 4096 (GQL 42N31)");
+	}
+
+	@Test
+	void integerShouldCheckMaxSize() {
+		var elements = new long[5000];
+		assertThatIllegalArgumentException().isThrownBy(() -> VectorLiteral.of(elements))
+			.withMessage("'5000' is not a valid value. Must be a number in the range 1 to 4096 (GQL 42N31)");
+	}
+
+	@Test
+	void integerShouldWork() {
+		assertThat(VectorLiteral.of(new long[] { 1, 2, 3 }).asString())
+			.isEqualTo("vector([1, 2, 3], 3, INTEGER NOT NULL)");
+	}
+
+	@Test
+	void float32ShouldCheckNull() {
+		assertThatNullPointerException().isThrownBy(() -> VectorLiteral.of((float[]) null))
+			.withMessage("Vector elements must not be literal null");
+	}
+
+	@Test
+	void float32ShouldCheckMinSize() {
+		var elements = new float[0];
+		assertThatIllegalArgumentException().isThrownBy(() -> VectorLiteral.of(elements))
+			.withMessage("'0' is not a valid value. Must be a number in the range 1 to 4096 (GQL 42N31)");
+	}
+
+	@Test
+	void float32ShouldCheckMaxSize() {
+		var elements = new float[5000];
+		assertThatIllegalArgumentException().isThrownBy(() -> VectorLiteral.of(elements))
+			.withMessage("'5000' is not a valid value. Must be a number in the range 1 to 4096 (GQL 42N31)");
+	}
+
+	@Test
+	void float32ShouldWork() {
+		assertThat(VectorLiteral.of(new float[] { 1, 2, 3 }).asString())
+			.isEqualTo("vector([1.0, 2.0, 3.0], 3, FLOAT32 NOT NULL)");
+	}
+
+	@Test
+	void floatShouldCheckNull() {
+		assertThatNullPointerException().isThrownBy(() -> VectorLiteral.of((double[]) null))
+			.withMessage("Vector elements must not be literal null");
+	}
+
+	@Test
+	void floatShouldCheckMinSize() {
+		var elements = new double[0];
+		assertThatIllegalArgumentException().isThrownBy(() -> VectorLiteral.of(elements))
+			.withMessage("'0' is not a valid value. Must be a number in the range 1 to 4096 (GQL 42N31)");
+	}
+
+	@Test
+	void floatShouldCheckMaxSize() {
+		var elements = new double[5000];
+		assertThatIllegalArgumentException().isThrownBy(() -> VectorLiteral.of(elements))
+			.withMessage("'5000' is not a valid value. Must be a number in the range 1 to 4096 (GQL 42N31)");
+	}
+
+	@Test
+	void floatShouldWork() {
+		assertThat(VectorLiteral.of(new double[] { 1, 2, 3 }).asString())
+			.isEqualTo("vector([1.0, 2.0, 3.0], 3, FLOAT NOT NULL)");
+	}
+
+}


### PR DESCRIPTION
`Cypher#search` provides the entry to a builder for the `SEARCH` clause. This has been done outside the "normal"
building flow to prevent the existing statement builder from getting even bigger. That means a `SEARCH` clause must be
build individually and than added to a `MATCH` with the new `search` step. Whereas Cypher itself does not care about the
order of `WHERE` and `SEARCH` in a `MATCH` clause, Cyher-DSL will only allow `SEARCH` before `WHERE`, so that the actual
Cypher semantics (`WHERE` being a post-filter on-top of the `SEARCH` clause) become visible.

The literals for vectors are provided for convenience and testing mostly. We do strongly recommend passing vectors via
paramters or use existing embeddings on other entities.

Closes #1543.

Signed-off-by: Michael Simons <michael.simons@neo4j.com>
