### PR TITLE
chore: Use JDK 26 for building all relevant modules.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 25
+          java-version: 26
       - name: Enable Sonar for local PRs not from Dependabot
         if:  ${{ github.event.sender.login != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         run: echo "USE_SONAR=sonar" >> $GITHUB_ENV
@@ -53,7 +53,6 @@ jobs:
         run: >
           ./mvnw --no-transfer-progress clean deploy -DSCHEMA_NAMES_TEST_ALL_VERSIONS=false -P$USE_SONAR -Drevision=$REVISION -Dsha1=-$GITHUB_SHA -Dchangelist= -Dcypher-dsl.version.old=$OLD_VERSION
           -DaltDeploymentRepository=releases::default::file://$GITHUB_WORKSPACE/target/repository
-          -pl !org.neo4j:neo4j-cypher-dsl-native-tests
           -pl !org.neo4j:neo4j-cypher-dsl-examples-core
           -pl !org.neo4j:neo4j-cypher-dsl-examples-parser
           -pl !org.neo4j:neo4j-cypher-dsl-examples-ogm-quarkus
@@ -87,14 +86,14 @@ jobs:
       - name: Run Maven build
         run: >
           ./mvnw --no-transfer-progress clean verify -Djqassistant.skip=true -Drevision=$REVISION -Dsha1=-$GITHUB_SHA -Dchangelist=
-          -pl org.neo4j:neo4j-cypher-dsl-native-tests
+          -DenableNativeTests -pl org.neo4j:neo4j-cypher-dsl-native-tests
 
   build_examples:
     name: Verify examples with ${{ matrix.java }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '17', '21', '25' ]
+        java: [ '17', '21', '25', '26' ]
     needs: build
     steps:
       - name: Determine revision

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 25
+          java-version: 26
       - name: Run docs generation
         run: >
           ./mvnw --no-transfer-progress install -pl neo4j-cypher-dsl-bom &&

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 25
+          java-version: 26
 
       - name: 'Prepare git'
         run: git config --global core.autocrlf false

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,4 +1,4 @@
 wrapperVersion=3.3.4
 distributionType=bin
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -25,9 +25,9 @@ For the full project, including examples and native tests:
 
 For the project, including examples but skipping native tests:
 
-* JDK 17+ (Can be https://openjdk.java.net[OpenJDK] or https://www.oracle.com/technetwork/java/index.html[Oracle JDK])
+* JDK 26+ (Can be https://openjdk.java.net[OpenJDK] or https://www.oracle.com/technetwork/java/index.html[Oracle JDK])
 
-Maven 3.8.4 is our build tool of choice. We provide the Maven wrapper, see `mvnw` respectively `mvnw.cmd` in the project root;
+Maven 3.9.16 is our build tool of choice. We provide the Maven wrapper, see `mvnw` respectively `mvnw.cmd` in the project root;
 the wrapper downloads the appropriate Maven version automatically.
 
 The build requires a local copy of the project:
@@ -70,9 +70,9 @@ The output should be similar:
 .Verify your JDK
 ----
 $ java -version
-openjdk version "24" 2025-03-18
-OpenJDK Runtime Environment GraalVM CE 24+36.1 (build 24+36-jvmci-b01)
-OpenJDK 64-Bit Server VM GraalVM CE 24+36.1 (build 24+36-jvmci-b01, mixed mode, sharing)
+openjdk version "25.0.2" 2026-01-20
+OpenJDK Runtime Environment GraalVM CE 25.0.2+10.1 (build 25.0.2+10-jvmci-b01)
+OpenJDK 64-Bit Server VM GraalVM CE 25.0.2+10.1 (build 25.0.2+10-jvmci-b01, mixed mode, sharing)
 ----
 
 Check whether GraalVM `native-image` is present with:
@@ -82,7 +82,12 @@ Check whether GraalVM `native-image` is present with:
 .Check for the present of `native-image`
 ----
 $ which native-image
-/Users/msimons/.sdkman/candidates/java/24-graalce/bin/native-image
+/Users/msimons/.sdkman/candidates/java/25.0.2-graalce/bin/native-image
+
+$ native-image --version
+native-image 25.0.2 2026-01-20
+GraalVM Runtime Environment GraalVM CE 25.0.2+10.1 (build 25.0.2+10-jvmci-b01)
+Substrate VM GraalVM CE 25.0.2+10.1 (build 25.0.2+10, serial gc)
 ----
 
 You should see `native-image` in the list. If not, you are most likely on a GraalVM version we don't support with this project.
@@ -93,7 +98,7 @@ After that, use `./mvnw` on a Unix-like operating system to build the Cypher-DSL
 [[build-default-bash]]
 .Build with default settings on Linux / macOS
 ----
-$ ./mvnw clean verify
+$ ./mvnw clean verify -DenableNativeTests
 ----
 
 On a Windows machine, use
@@ -107,13 +112,13 @@ $ mvnw.cmd clean verify
 
 === Skipping native tests
 
-On a plain JDK 17 or higher, run the following to skip the native tests:
+On a plain JDK 26 or higher, run the following without running the native tests:
 
 [source,console,subs="verbatim,attributes"]
 [[build-skip-native-bash]]
 .Skipping native tests
 ----
-$ ./mvnw clean verify -pl \!org.neo4j:neo4j-cypher-dsl-native-tests
+$ ./mvnw clean verify
 ----
 
 === Build only the core module
@@ -124,7 +129,7 @@ The core module can be built on plain JDK 17 with:
 [[build-only-core-bash]]
 .Build only the core module
 ----
-$ ./mvnw clean verify -am -pl org.neo4j:neo4j-cypher-dsl
+$ ./mvnw clean verify -am -pl neo4j-cypher-dsl-build/processor -pl org.neo4j:neo4j-cypher-dsl
 ----
 
 === CI-friendly version numbers

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractNode.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/AbstractNode.java
@@ -32,8 +32,8 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 @API(status = INTERNAL, since = "2021.1.0")
 abstract class AbstractNode extends AbstractPropertyContainer implements Node {
 
-	@Deprecated(forRemoval = true)
 	@Override
+	@Deprecated(forRemoval = true)
 	@SuppressWarnings("removal")
 	public final Condition hasLabels(LabelExpression labels) {
 		return hasLabels(Labels.of(labels));

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Node.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/Node.java
@@ -68,8 +68,8 @@ public interface Node
 	 * @since 2024.3.0
 	 * @deprecated use {@link #hasLabels(Labels)}
 	 */
-	@SuppressWarnings("removal")
 	@Deprecated(forRemoval = true)
+	@SuppressWarnings("removal")
 	Condition hasLabels(LabelExpression labels);
 
 	/**

--- a/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NodeBase.java
+++ b/neo4j-cypher-dsl/src/main/java/org/neo4j/cypherdsl/core/NodeBase.java
@@ -41,7 +41,7 @@ import static org.apiguardian.api.API.Status.STABLE;
  * @since 2021.1.0
  */
 @API(status = STABLE, since = "2021.1.0")
-@SuppressWarnings("deprecation") // IDEA is stupid.
+@SuppressWarnings({ "deprecation", "removal" })
 public abstract class NodeBase<SELF extends Node> extends AbstractNode implements Node {
 
 	final List<NodeLabel> staticLabels;

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,6 @@
 		<module>neo4j-cypher-dsl</module>
 		<module>neo4j-cypher-dsl-codegen</module>
 		<module>neo4j-cypher-dsl-parser</module>
-		<module>neo4j-cypher-dsl-native-tests</module>
 		<module>neo4j-cypher-dsl-examples</module>
 		<module>neo4j-cypher-dsl-test-results</module>
 	</modules>
@@ -157,7 +156,7 @@
 		<jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
 		<japicmp-maven-plugin.version>0.26.1</japicmp-maven-plugin.version>
 		<java-module-name/>
-		<java.version>25</java.version>
+		<java.version>26</java.version>
 		<javapoet.version>1.13.0</javapoet.version>
 		<javax.annotation-api.version>1.3.2</javax.annotation-api.version>
 		<jaxb.version>2.3.1</jaxb.version>
@@ -183,7 +182,7 @@
 		<maven.compiler.debug>true</maven.compiler.debug>
 		<maven.compiler.parameters>true</maven.compiler.parameters>
 		<maven.compiler.release>17</maven.compiler.release>
-		<maven.version>3.9.12</maven.version>
+		<maven.version>3.9.16</maven.version>
 		<mockito.version>5.23.0</mockito.version>
 		<moditect-maven-plugin.version>1.3.0.Final</moditect-maven-plugin.version>
 		<neo4j-java-driver.version>6.2.0</neo4j-java-driver.version>
@@ -1085,6 +1084,22 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+
+		<profile>
+			<id>nativeTestsEnabled</id>
+			<activation>
+				<property>
+					<name>enableNativeTests</name>
+				</property>
+			</activation>
+			<modules>
+				<module>neo4j-cypher-dsl-native-tests</module>
+			</modules>
+			<properties>
+				<!-- Latest GraalVM Community version available -->
+				<java.version>25</java.version>
+			</properties>
 		</profile>
 
 		<profile>


### PR DESCRIPTION
**We are still releasing for JDK 17, no worries**

- Requires JDK 26 by default
- Exclude the module containing native tests (since there is no GraalVM 26 yet)
- Introduces a new profile `nativeTestsEnabled` that downgrades the required Java build version to 25 and includes above
  module again
- Bumps the GitHub flows

Signed-off-by: Michael Simons <michael.simons@neo4j.com>
